### PR TITLE
fix undefined variable error

### DIFF
--- a/includes/rules/color_contrast_failure.php
+++ b/includes/rules/color_contrast_failure.php
@@ -729,7 +729,7 @@ function edac_replace_css_variables($value, $css_array){
 			}
 		}
 
-		if($found_value){
+		if( ! empty( $found_value )){
 			return $found_value;
 		}else{
 			return $value;


### PR DESCRIPTION
Uses `! is_empty()` to test the `$found_value` variable. Empty includes `isset()` functionality so it will not throw an error if the variable is undefined.

fixes https://github.com/equalizedigital/accessibility-checker/issues/82
