### PR TITLE
Increase max characters in alt

### DIFF
--- a/includes/rules/img_alt_long.php
+++ b/includes/rules/img_alt_long.php
@@ -21,7 +21,7 @@ function edac_rule_img_alt_long( $content, $post ) {
 	foreach ( $images as $image ) {
 		if ( isset( $image ) && $image->hasAttribute( 'alt' ) && $image->getAttribute( 'alt' ) != '' ) {
 			$alt = $image->getAttribute( 'alt' );
-			if ( strlen( $alt ) > 100 ) {
+			if ( strlen( $alt ) > 300 ) {
 				$image_code = $image;
 				$errors[] = $image_code;
 			}


### PR DESCRIPTION
100 characters doesn't feel long enough for quality image alt on many photos or graphics. Increasing this to 300 characters or only about a small bit longer than a tweet.

This feels like an improvement to this rule after seeing some longer alt on client sites that I still think is good alt.