### PR TITLE
fixed - a video is present duplicated warning issue

### DIFF
--- a/includes/rules/video_present.php
+++ b/includes/rules/video_present.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Accessibility Checker pluign file.
+ * Accessibility Checker plugin file.
  *
  * @package Accessibility_Checker
  */
@@ -18,12 +18,19 @@ function edac_rule_video_present( $content, $post ) {
 	$file_extensions = array( '.3gp', '.asf', '.asx', '.avi', '.flv', '.m4p', '.mov', '.mp4', '.mpeg', '.mpeg2', '.mpg', '.mpv', '.ogg', '.ogv', '.qtl', '.smi', '.smil', '.wax', '.webm', '.wmv', '.wmp', '.wmx' );
 	$keywords = array( 'youtube', 'youtu.be', 'vimeo' );
 	$errors = array();
+	$videos_found = array();
 
 	// check for video blocks.
 	$elements = $dom->find( '.is-type-video' );
 	if ( $elements ) {
 		foreach ( $elements as $element ) {
 			$errors[] = $element->outertext;
+
+			// Check for just one iframe.
+			$iframe = $element->find( 'iframe', 0 );
+			if ( $iframe ) {
+				$videos_found[ $iframe->getAttribute( 'src' ) ] = true;
+			}
 		}
 	}
 
@@ -33,6 +40,12 @@ function edac_rule_video_present( $content, $post ) {
 		$file_extensions = array_merge( $file_extensions, $keywords );
 		foreach ( $elements as $element ) {
 			$src_text = $element->getAttribute( 'src' );
+
+			// Skip if iframe src is already found in the video blocks.
+			if ( isset( $videos_found[ $src_text ] ) ) {
+				continue;
+			}
+
 			foreach ( $file_extensions as $file_extension ) {
 				if ( strpos( strtolower( $src_text ), $file_extension ) ) {
 					$errors[] = $element->outertext;
@@ -46,6 +59,12 @@ function edac_rule_video_present( $content, $post ) {
 	if ( $elements ) {
 		foreach ( $elements as $element ) {
 			$src_text = $element->getAttribute( 'src' );
+
+			// Skip if iframe src is already found in the video blocks.
+			if ( isset( $videos_found[ $src_text ] ) ) {
+				continue;
+			}
+
 			foreach ( $file_extensions as $file_extension ) {
 				if ( strpos( strtolower( $src_text ), $file_extension ) ) {
 					$errors[] = $element->outertext;


### PR DESCRIPTION
There were a few additional approaches to this problem that I considered. However, I ultimately chose the most readable solution that maintained the current algorithm's complexity. Implementing other approaches would have required significant refactoring, which I believe was not the main intent of this task.

Please note that there are a couple of minor edge cases not addressed in the current implementation:

1. The first one is having the same video embedded twice with different YouTube URLs (e.g., `youtube.com/foo` and `youtu.be/foo`). While this issue may not arise with Gutenberg, it could potentially occur with other builders. For now, I don't recommend complicating the code with URL normalization, but it's something to keep in mind for future improvements.
2. Another minor edge case is when multiple `<iframe>` elements are found within a single `<figure>` element. Although this is not a recommended practice, it could still happen in certain situations. The current implementation treats each iframe separately, and it does not attempt to consolidate them or handle them differently when they are contained within the same `<figure>`. While this is likely not a significant concern, it's worth considering if you encounter such scenarios or if you decide to further refine the code in the future.