### PR TITLE
feature - missing subheadings check requirements

### DIFF
--- a/includes/rules/missing_headings.php
+++ b/includes/rules/missing_headings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Accessibility Checker pluign file.
+ * Accessibility Checker plugin file.
  *
  * @package Accessibility_Checker
  */
@@ -13,12 +13,13 @@
  * @return array
  */
 function edac_rule_missing_headings( $content, $post ) {
+	$word_count = str_word_count( strip_tags( $post->post_content ) );
 
-	$dom = str_get_html( $post->post_content );
-	if ( empty( $dom ) ) {
-		goto error;
+	if ( $word_count < 400 ) {
+		return;
 	}
 
+	$dom = str_get_html( $post->post_content );
 	$h2 = count( $dom->find( 'h2,[role=heading][aria-level=2]' ) );
 	$h3 = count( $dom->find( 'h3,[role=heading][aria-level=3]' ) );
 	$h4 = count( $dom->find( 'h4,[role=heading][aria-level=4]' ) );
@@ -27,7 +28,6 @@ function edac_rule_missing_headings( $content, $post ) {
 	$headings = ( $h2 + $h3 + $h4 + $h5 + $h6 );
 
 	if ( 0 === $headings ) {
-		error:
 		$errorcode = __( 'Missing headings - Post ID: ', 'edac' ) . $post->ID;
 		return array( $errorcode );
 	}


### PR DESCRIPTION
I have added the minimum word count and professional version requirements.

**Some stuff worth considering:**

- If we might have similar word-limiting occasions this should be pulled out to a helper function. 

- I did not have access to a valid key at the time of testing, so I wasn't able to conduct a thorough test. This pro check should properly work though. Also regarding the check for professional plugin version rules, I suggest that it be implemented separately from the rule-checking functions. One possible solution would include the key with a boolean value for each rule within an individual rule array, in the `edac_register_rules()` function. However, this might make it easy to crack/null the plugin but that is for a different discussion. 

My general suggestion is to deal with the pro check in a different ticket. 