### PR TITLE
Fixes #275

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 .sass-cache/
 #.codekit-config.json
 #config.codekit
-#config.codekit3
+config.codekit3
 edac_log.txt
- 
+
 # Hidden system files
 *.DS_Store
 *[Tt]humbs.db

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility, section 508, aoda, a11y, audit, readability, content analysis
 Requires at least: 5.0.0
 Tested up to: 6.3
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,6 +170,9 @@ No, Accessibility Checker runs completely on your server and does not require yo
 8. Accessibility Checker Summary tab on a page with no accessibility error or warnings and an included simplified summary.
 
 == Changelog ==
+
+= 1.5.1 =
+Updated: button screen reader text
 
 = 1.5.0 =
 Added: site wide summary

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility, section 508, aoda, a11y, audit, readability, content analysis
 Requires at least: 5.0.0
 Tested up to: 6.3
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,6 +170,10 @@ No, Accessibility Checker runs completely on your server and does not require yo
 8. Accessibility Checker Summary tab on a page with no accessibility error or warnings and an included simplified summary.
 
 == Changelog ==
+
+= 1.5.2 =
+Fixed: missing class
+Removed: Freemius
 
 = 1.5.1 =
 Updated: button screen reader text

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility, section 508, aoda, a11y, audit, readability, content analysis
 Requires at least: 5.0.0
 Tested up to: 6.3
-Stable tag: 1.4.5
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.5.0
+ * Version:           1.5.1
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -89,7 +89,7 @@ if ( ! function_exists( 'edac_fs' ) ) {
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.5.0' );
+	define( 'EDAC_VERSION', '1.5.1' );
 }
 
 // Current database version.

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -15,7 +15,7 @@
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:       edac
+ * Text Domain:       accessibility-checker
  * Domain Path:       /languages
  */
 
@@ -314,7 +314,7 @@ function edac_register_rules() {
 			'info_url'  => 'https://a11ychecker.com/help4991',
 			'slug'      => 'img_alt_empty',
 			'rule_type' => 'warning',
-			'summary'   => esc_html( 'An Image Empty Alternative Text warning appears if you have an image with an alt attribute (alt="") that is empty. Alternative text tells people who cannot see what the images is and adds additional context to the post or page. It is only correct for alternative text to be empty if the image is purely decorative, like a border or decorative icon. To fix an Image Empty Alternative Text warning, you need to determine if the image is decorative or if adds something meaningful to the page. If it is not decorative, you need to add appropriate alternative text to describe the image’s purpose. If the image is decorative, then you would leave the alternative text blank and “Ignore” the warning.' ),
+			'summary'   => esc_html( 'An Image Empty Alternative Text warning appears if you have an image with an alt attribute (alt="") that is empty. Alternative text tells people who cannot see what the images is and adds additional context to the post or page. It is only correct for alternative text to be empty if the image is purely decorative, like a border or decorative icon. To fix an Image Empty Alternative Text warning, you need to determine if the image is decorative or if adds something meaningful to the page. If it is not decorative, you need to add appropriate alternative text to describe the image\'s purpose. If the image is decorative, then you would leave the alternative text blank and “Ignore” the warning.' ),
 		)
 	);
 
@@ -556,7 +556,7 @@ function edac_register_rules() {
 			'info_url'  => 'https://a11ychecker.com/help4109',
 			'slug'      => 'empty_form_label',
 			'rule_type' => 'error',
-			'summary'   => esc_html( 'An Empty Form Label error is triggered when a <label> tag is present in your form and associated with an input (form field), but does not contain any text. To fix empty form label errors, you’ll need to determine how the field and form were created and then add text to the label for the field that is currently blank.' ),
+			'summary'   => esc_html( 'An Empty Form Label error is triggered when a <label> tag is present in your form and associated with an input (form field), but does not contain any text. To fix empty form label errors, you\'ll need to determine how the field and form were created and then add text to the label for the field that is currently blank.' ),
 		)
 	);
 
@@ -567,7 +567,7 @@ function edac_register_rules() {
 			'info_url'  => 'https://a11ychecker.com/help1949',
 			'slug'      => 'missing_form_label',
 			'rule_type' => 'error',
-			'summary'   => esc_html( 'A Missing Form Label error is triggered when an <input> (form field) is present in your form and but is not associated with a <label> element. This could mean the label is present but is missing a for="" attribute to connect it to the applicable field or there could be no label present at all and only an <input> tag. To fix missing form label errors, you’ll need to determine how the field and form were created and then add field labels or a correct for="" attribute to exisiting labels that are not connected to a field.' ),
+			'summary'   => esc_html( 'A Missing Form Label error is triggered when an <input> (form field) is present in your form and but is not associated with a <label> element. This could mean the label is present but is missing a for="" attribute to connect it to the applicable field or there could be no label present at all and only an <input> tag. To fix missing form label errors, you\'ll need to determine how the field and form were created and then add field labels or a correct for="" attribute to exisiting labels that are not connected to a field.' ),
 		)
 	);
 
@@ -1363,7 +1363,7 @@ function edac_details_ajax() {
 							get_the_permalink( $postid )
 						);
 
-						$html .= '<a href="' . $url . '" class="edac-details-rule-records-record-actions-highlight-front" target="_blank" aria-label="' . __( 'View, opens a new window', 'edac' ) . '" ><span class="dashicons dashicons-welcome-view-site"></span>View on page</a>';
+						$html .= '<a href="' . $url . '" class="edac-details-rule-records-record-actions-highlight-front" target="_blank" aria-label="' . __( 'View, opens a new window', 'accessibility-checker' ) . '" ><span class="dashicons dashicons-welcome-view-site"></span>View on page</a>';
 					}
 
 						$html .= '</div>';
@@ -1385,7 +1385,7 @@ function edac_details_ajax() {
 						$html .= ( true === $ignore_permission ) ? '<button class="edac-details-rule-records-record-ignore-submit" data-id=' . $id . ' data-action=' . $ignore_action . ' data-type=' . $ignore_type . '>' . EDAC_SVG_IGNORE_ICON . ' <span class="edac-details-rule-records-record-ignore-submit-label">' . $ignore_submit_label . '<span></button>' : '';
 					}
 
-							$html .= ( false === $ignore_permission && false === $ignore ) ? __( 'Your user account doesn\'t have permission to ignore this issue.', 'edac' ) : '';
+							$html .= ( false === $ignore_permission && false === $ignore ) ? __( 'Your user account doesn\'t have permission to ignore this issue.', 'accessibility-checker' ) : '';
 
 						$html .= '</div>';
 
@@ -1678,11 +1678,11 @@ function edac_get_accessibility_statement() {
 	$policy_page            = is_numeric( $policy_page ) ? get_page_link( $policy_page ) : $policy_page;
 
 	if ( $add_footer_statement ) {
-		$statement .= get_bloginfo( 'name' ) . ' ' . esc_html__( 'uses', 'edac' ) . ' <a href="https://equalizedigital.com/accessibility-checker" target="_blank" aria-label="' . esc_attr__( 'Accessibility Checker', 'edac' ) . ', opens a new window">' . esc_html__( 'Accessibility Checker', 'edac' ) . '</a> ' . esc_html__( 'to monitor our website\'s accessibility. ', 'edac' );
+		$statement .= get_bloginfo( 'name' ) . ' ' . esc_html__( 'uses', 'accessibility-checker' ) . ' <a href="https://equalizedigital.com/accessibility-checker" target="_blank" aria-label="' . esc_attr__( 'Accessibility Checker', 'accessibility-checker' ) . ', opens a new window">' . esc_html__( 'Accessibility Checker', 'accessibility-checker' ) . '</a> ' . esc_html__( 'to monitor our website\'s accessibility. ', 'accessibility-checker' );
 	}
 
 	if ( $include_statement_link && $policy_page ) {
-		$statement .= esc_html__( 'Read our ', 'edac' ) . '<a href="' . $policy_page . '">' . esc_html__( 'Accessibility Policy', 'edac' ) . '</a>.';
+		$statement .= esc_html__( 'Read our ', 'accessibility-checker' ) . '<a href="' . $policy_page . '">' . esc_html__( 'Accessibility Policy', 'accessibility-checker' ) . '</a>.';
 	}
 
 	return $statement;
@@ -1744,12 +1744,12 @@ function edac_review_notice() {
 	?>
 	<div class="notice notice-info edac-review-notice">
 		<p>
-			<?php esc_html_e( "Hello! Thank you for using Accessibility Checker as part of your accessibility toolkit. Since you've been using it for a while, would you please write a 5-star review of Accessibility Checker in the WordPress plugin directory? This will help increase our visibility so more people can learn about the importance of web accessibility. Thanks so much!", 'edac' ); ?>
+			<?php esc_html_e( "Hello! Thank you for using Accessibility Checker as part of your accessibility toolkit. Since you've been using it for a while, would you please write a 5-star review of Accessibility Checker in the WordPress plugin directory? This will help increase our visibility so more people can learn about the importance of web accessibility. Thanks so much!", 'accessibility-checker' ); ?>
 		</p>
 		<p>
-			<button class="edac-review-notice-review"><?php esc_html_e( 'Write A Review', 'edac' ); ?></button>
-			<button class="edac-review-notice-remind"><?php esc_html_e( 'Remind Me In Two Weeks', 'edac' ); ?></button>
-			<button class="edac-review-notice-dismiss"><?php esc_html_e( 'Never Ask Again', 'edac' ); ?></button>
+			<button class="edac-review-notice-review"><?php esc_html_e( 'Write A Review', 'accessibility-checker' ); ?></button>
+			<button class="edac-review-notice-remind"><?php esc_html_e( 'Remind Me In Two Weeks', 'accessibility-checker' ); ?></button>
+			<button class="edac-review-notice-dismiss"><?php esc_html_e( 'Never Ask Again', 'accessibility-checker' ); ?></button>
 		</p>
 	</div>
 	<?php
@@ -1953,10 +1953,10 @@ function edac_get_gaad_promo_message() {
 
 	// Construct the promotional message.
 	$message  = '<div class="edac_gaad_notice notice notice-info is-dismissible">';
-	$message .= '<p><strong>' . esc_html__( '🎉 Get 30% off Accessibility Checker Pro in honor of Global Accessibility Awareness Day! 🎉', 'edac' ) . '</strong><br />';
-	$message .= esc_html__( 'Use coupon code GAAD23 from May 18th-May 25th to get access to full-site scanning and other pro features at a special discount. Not sure if upgrading is right for you?', 'edac' ) . '<br />';
-	$message .= '<a class="button button-primary" href="' . esc_url( 'https://my.equalizedigital.com/support/pre-sale-questions/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23' ) . '">' . esc_html__( 'Ask a Pre-Sale Question', 'edac' ) . '</a> ';
-	$message .= '<a class="button button-primary" href="' . esc_url( 'https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23' ) . '">' . esc_html__( 'Upgrade Now', 'edac' ) . '</a></p>';
+	$message .= '<p><strong>' . esc_html__( '🎉 Get 30% off Accessibility Checker Pro in honor of Global Accessibility Awareness Day! 🎉', 'accessibility-checker' ) . '</strong><br />';
+	$message .= esc_html__( 'Use coupon code GAAD23 from May 18th-May 25th to get access to full-site scanning and other pro features at a special discount. Not sure if upgrading is right for you?', 'accessibility-checker' ) . '<br />';
+	$message .= '<a class="button button-primary" href="' . esc_url( 'https://my.equalizedigital.com/support/pre-sale-questions/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23' ) . '">' . esc_html__( 'Ask a Pre-Sale Question', 'accessibility-checker' ) . '</a> ';
+	$message .= '<a class="button button-primary" href="' . esc_url( 'https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23' ) . '">' . esc_html__( 'Upgrade Now', 'accessibility-checker' ) . '</a></p>';
 	$message .= '</div>';
 
 	return $message;

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -24,64 +24,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-/**
- * Freemius
- */
-if ( ! function_exists( 'edac_fs' ) ) {
-	/**
-	 * Create a helper function for easy SDK access.
-	 *
-	 * @return mixed
-	 */
-	function edac_fs() {
-		global $edac_fs;
-
-		if ( ! isset( $edac_fs ) ) {
-			// Include Freemius SDK.
-			require_once dirname( __FILE__ ) . '/vendor/freemius/wordpress-sdk/start.php';
-
-			$edac_fs = fs_dynamic_init(
-				array(
-					'id'             => '7322',
-					'slug'           => 'accessibility-checker',
-					'type'           => 'plugin',
-					'public_key'     => 'pk_5146b841819550deb8874ca70bc89',
-					'is_premium'     => false,
-					'has_addons'     => false,
-					'has_paid_plans' => false,
-					'menu'           => array(
-						'slug'       => 'accessibility_checker',
-						'first-path' => 'admin.php?page=accessibility_checker',
-						'account'    => false,
-						'contact'    => false,
-						'support'    => false,
-					),
-				)
-			);
-		}
-
-		return $edac_fs;
-	}
-
-	// Init Freemius.
-	edac_fs();
-
-	/**
-	 * Setup Freemius opt-in screen icon
-	 *
-	 * @return void
-	 */
-	function edac_fs_custom_icon() {
-		return dirname( __FILE__ ) . '/assets/images/edac-emblem.png';
-	}
-	 
-	edac_fs()->add_filter( 'plugin_icon' , 'edac_fs_custom_icon' );
-	
-
-	// Signal that SDK was initiated.
-	do_action( 'edac_fs_loaded' );
-}
-
+// Include plugin dependency.
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 /**
  * Setup constants.

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.5.1
+ * Version:           1.5.2
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -89,7 +89,7 @@ if ( ! function_exists( 'edac_fs' ) ) {
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.5.1' );
+	define( 'EDAC_VERSION', '1.5.2' );
 }
 
 // Current database version.

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,6 @@
             "email": "dev@equalizedigital.com"
         }
     ],
-    "require": {
-        "freemius/wordpress-sdk": "*"
-    },
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,77 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88caa99be502796383abac4aeccfe1d4",
-    "packages": [
-        {
-            "name": "freemius/wordpress-sdk",
-            "version": "2.5.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Freemius/wordpress-sdk.git",
-                "reference": "05bac841008b705bff9636f782c96fb0a73e615b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/05bac841008b705bff9636f782c96fb0a73e615b",
-                "reference": "05bac841008b705bff9636f782c96fb0a73e615b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "wp-coding-standards/wpcs": "^2.3"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-only"
-            ],
-            "description": "Freemius WordPress SDK",
-            "homepage": "https://freemius.com",
-            "keywords": [
-                "freemius",
-                "plugin",
-                "sdk",
-                "theme",
-                "wordpress",
-                "wordpress-plugin",
-                "wordpress-theme"
-            ],
-            "support": {
-                "issues": "https://github.com/Freemius/wordpress-sdk/issues",
-                "source": "https://github.com/Freemius/wordpress-sdk/tree/2.5.10"
-            },
-            "time": "2023-07-18T06:35:08+00:00"
-        }
-    ],
+    "content-hash": "42c9f5acd35c4ceb6b7b13c8bc82f8f9",
+    "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.1",
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
@@ -94,6 +50,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -101,7 +58,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2023-08-24T15:11:13+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -242,16 +199,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.16",
+            "version": "v2.11.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
                 "shasum": ""
             },
             "require": {
@@ -296,7 +253,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-03-31T16:46:32+00:00"
+            "time": "2023-08-05T23:46:11+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -45,30 +45,41 @@ function edac_add_accessibility_statement_page() {
 		$current_user = wp_get_current_user();
 		$author_id    = $current_user->ID;
 		$slug         = 'accessibility-statement';
-		$title        = __( 'Our Commitment to Web Accessibility', 'edacp' );
-		$content      = '[YOUR COMPANY NAME] is committed to providing a fully accessible website experience for all users of all abilities, including those who rely on assistive technologies like screen readers, screen enlargement software, and alternative keyboard input devices to navigate the web.<br /><br />
-<h2><strong>Ongoing Efforts to Ensure Accessibility</strong></h2>
- 
-We follow the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) version 2.1</a> as our guiding principle for determining accessibility. These are internationally agreed-upon standards that cover a wide range of recommendations and best practices for making content useable. As we add new pages and functionality to our website, all designs, code, and content entry practices are checked against these standards.<br /><br />
-Website accessibility is an ongoing process. We continually test content and features for WCAG 2.1 Level AA compliance and remediate any issues to ensure we meet or exceed the standards. Testing of our website is performed by our team members using industry-standard tools such as the <a href="https://a11ychecker.com/">Accessibility Checker WordPress Plugin</a>, color contrast analyzers, keyboard-only navigation techniques, and Flesch-Kincaid readability tests.<br /><br />
-<h2>Accessibility Features On Our Website</h2>
- 
-The following is a list of items we have included in our website to improve its accessibility:<br /><br />
-<ul>
-<li>[LIST ACCESSIBILITY FEATURES HERE]</li>
-</ul>
- 
-<h2>Where We’re Improving</h2>
- 
-In our efforts to bring our website up to standard, we are targeting the following areas:<br /><br />
-<ul>
-<li>[LIST ITEMS YOU\'RE WORKING TO FIX HERE]</li>
-<li>[IT MAY HELP TO REVIEW THE OPEN ISSUES TAB TO SEE THE MOST COMMON PROBLEMS]</li>
-</ul>
-This is part of our broader effort to make everyone’s experience at [COMPANY NAME] a welcoming and enjoyable one. Please note that while we make every effort to provide information accessible for all users, we cannot guarantee the accessibility of third party websites to which we may link.<br /><br />
-<h2>Accessibility Support Contact</h2>
- 
-We welcome comments, questions, and feedback on our website. If you are using assistive technologies and are having difficulty using our website, please email [YOUR ACCESSIBILITY EMAIL ADDRESS]  or give us a call at [YOUR PHONE NUMBER]. We will do our best to assist you and resolve issues.';
+		$title        = __( 'Our Commitment to Web Accessibility', 'accessibility-checker' );
+		$content      = sprintf(
+			'%1$s<br /><br />
+			<h2><strong>%2$s</strong></h2>
+			%3$s<br /><br />
+			%4$s<br /><br />
+			<h2>%5$s</h2>
+			%6$s<br /><br />
+			<ul>
+			<li>%7$s</li>
+			</ul>
+			<h2>%8$s</h2>
+			%9$s<br /><br />
+			<ul>
+			<li>%10$s</li>
+			<li>%11$s</li>
+			</ul>
+			%12$s<br /><br />
+			<h2>%13$s</h2>
+			%14$s',
+			sprintf( __( '[YOUR COMPANY NAME] is committed to providing a fully accessible website experience for all users of all abilities, including those who rely on assistive technologies like screen readers, screen enlargement software, and alternative keyboard input devices to navigate the web.', 'accessibility-checker' ) ),
+			__( 'Ongoing Efforts to Ensure Accessibility', 'accessibility-checker' ),
+			sprintf( __( 'We follow the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) version 2.1</a> as our guiding principle for determining accessibility. These are internationally agreed-upon standards that cover a wide range of recommendations and best practices for making content useable. As we add new pages and functionality to our website, all designs, code, and content entry practices are checked against these standards.', 'accessibility-checker' ) ),
+			sprintf( __( 'Website accessibility is an ongoing process. We continually test content and features for WCAG 2.1 Level AA compliance and remediate any issues to ensure we meet or exceed the standards. Testing of our website is performed by our team members using industry-standard tools such as the <a href="https://a11ychecker.com/">Accessibility Checker WordPress Plugin</a>, color contrast analyzers, keyboard-only navigation techniques, and Flesch-Kincaid readability tests.', 'accessibility-checker' ) ),
+			__( 'Accessibility Features On Our Website', 'accessibility-checker' ),
+			__( 'The following is a list of items we have included in our website to improve its accessibility:', 'accessibility-checker' ),
+			__( '[LIST ACCESSIBILITY FEATURES HERE]', 'accessibility-checker' ),
+			__( 'Where We\'re Improving', 'accessibility-checker' ),
+			__( 'In our efforts to bring our website up to standard, we are targeting the following areas:', 'accessibility-checker' ),
+			__( '[LIST ITEMS YOU\'RE WORKING TO FIX HERE]', 'accessibility-checker' ),
+			__( '[IT MAY HELP TO REVIEW THE OPEN ISSUES TAB TO SEE THE MOST COMMON PROBLEMS]', 'accessibility-checker' ),
+			sprintf( __( 'This is part of our broader effort to make everyone\'s experience at [COMPANY NAME] a welcoming and enjoyable one. Please note that while we make every effort to provide information accessible for all users, we cannot guarantee the accessibility of third party websites to which we may link.', 'accessibility-checker' ) ),
+			__( 'Accessibility Support Contact', 'accessibility-checker' ),
+			sprintf( __( 'We welcome comments, questions, and feedback on our website. If you are using assistive technologies and are having difficulty using our website, please email [YOUR ACCESSIBILITY EMAIL ADDRESS] or give us a call at [YOUR PHONE NUMBER]. We will do our best to assist you and resolve issues.', 'accessibility-checker' ) )
+		);
 
 		// create post object.
 		$page = array(

--- a/includes/classes/Welcome_Page.php
+++ b/includes/classes/Welcome_Page.php
@@ -36,18 +36,17 @@ class Welcome_Page {
 			$html .= '
 			<section>
 				<div class="edac-cols edac-cols-header">
-				<h2 class="edac-cols-left">
-					Most Recent Test Summary
-				</h2>
+					<h2 class="edac-cols-left">
+						' . __( 'Most Recent Test Summary', 'accessibility-checker' ) . '
+					</h2>
 
-				<p class="edac-cols-right"> 
-					<a class="button" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=scan' ) ) . '">Start New Scan</a>
-					<a class="edac-ml-1 button button-primary" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_issues' ) ) . '">View All Open Issues</a>
-				</p>
+					<p class="edac-cols-right"> 
+						<a class="button" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=scan' ) ) . '">' . __( 'Start New Scan', 'accessibility-checker' ) . '</a>
+						<a class="edac-ml-1 button button-primary" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_issues' ) ) . '">' . __( 'View All Open Issues', 'accessibility-checker' ) . '</a>
+					</p>
 				</div>
 				<div class="edac-welcome-grid-container">';
-			
-		
+
 			$html .= '
 				<div class="edac-welcome-grid-c1 edac-welcome-grid-item edac-background-light" style="grid-area: 1 / 1 / span 2;">
 					<div class="edac-circle-progress" role="progressbar" aria-valuenow="' . $summary['passed_percentage'] . '" 
@@ -56,114 +55,101 @@ class Welcome_Page {
 						background: radial-gradient(closest-side, white 90%, transparent 80% 100%), 
 						conic-gradient(#006600 ' . $summary['passed_percentage'] . '%, #e2e4e7 0);">
 						<div class="edac-progress-percentage edac-xxx-large-text">' . $summary['passed_percentage'] . '%</div>
-						<div class="edac-progress-label edac-large-text">Passed Tests</div>
-						
+						<div class="edac-progress-label edac-large-text">' . __( 'Passed Tests', 'accessibility-checker' ) . '</div>
 					</div>
 				</div>';
 
+			$html .= '
+				<div class="edac-welcome-grid-c2 edac-welcome-grid-item' . ( ( $summary['distinct_errors_without_contrast'] > 0 ) ? ' has-errors' : ' has-no-errors' ) . '">
+					<div class="edac-inner-row">
+						<div class="edac-stat-number">' . $summary['distinct_errors_without_contrast'] . '</div>
+					</div>
+					<div class="edac-inner-row">
+						<div class="edac-stat-label">' . sprintf( _n( 'Unique Error', 'Unique Errors', $summary['distinct_errors_without_contrast'], 'accessibility-checker' ), $summary['distinct_errors_without_contrast'] ) . '</div>
+					</div>
+				</div>
+			
+				<div class="edac-welcome-grid-c3 edac-welcome-grid-item' . ( ( $summary['distinct_contrast_errors'] > 0 ) ? ' has-contrast-errors' : ' has-no-contrast-errors' ) . '">
+					<div class="edac-inner-row">
+						<div class="edac-stat-number">' . $summary['distinct_contrast_errors'] . '</div>
+					</div>
+					<div class="edac-inner-row">
+						<div class="edac-stat-label">' . sprintf( _n( 'Unique Color Contrast Error', 'Unique Color Contrast Errors', $summary['distinct_contrast_errors'], 'accessibility-checker' ), $summary['distinct_contrast_errors'] ) . '</div>
+					</div>
+				</div>
+			
+				<div class="edac-welcome-grid-c4 edac-welcome-grid-item' . ( ( $summary['distinct_warnings'] > 0 ) ? ' has-warning' : ' has-no-warning' ) . '">
+					<div class="edac-inner-row">
+						<div class="edac-stat-number">' . $summary['distinct_warnings'] . '</div>
+					</div>
+					<div class="edac-inner-row">
+						<div class="edac-stat-label">' . sprintf( _n( 'Unique Warning', 'Unique Warnings', $summary['distinct_warnings'], 'accessibility-checker' ), $summary['distinct_warnings'] ) . '</div>
+					</div>
+				</div>
+			
+				<div class="edac-welcome-grid-c5 edac-welcome-grid-item' . ( ( $summary['distinct_ignored'] > 0 ) ? ' has-ignored' : ' has-no-ignored' ) . '">
+					<div class="edac-inner-row">
+						<div class="edac-stat-number">' . $summary['distinct_ignored'] . '</div>
+					</div>
+					<div class="edac-inner-row">
+						<div class="edac-stat-label">' . sprintf( _n( 'Ignored Item', 'Ignored Items', $summary['distinct_ignored'], 'accessibility-checker' ), $summary['distinct_ignored'] ) . '</div>
+					</div>
+				</div>';
+			
 
 			$html .= '
-					<div class="edac-welcome-grid-c2 edac-welcome-grid-item' . ( ( $summary['distinct_errors_without_contrast'] > 0 ) ? ' has-errors' : ' has-no-errors' ) . '">
-						<div class="edac-inner-row">
-							<div class="edac-stat-number">' . $summary['distinct_errors_without_contrast'] . '</div>
-						</div>
-						<div class="edac-inner-row">
-							<div class="edac-stat-label">Unique Error' . ( ( 1 == $summary['distinct_errors_without_contrast'] ) ? '' : 's' ) . '</div>
-						</div>
-					</div>
-	
-					<div class="edac-welcome-grid-c3 edac-welcome-grid-item' . ( ( $summary['distinct_contrast_errors'] > 0 ) ? ' has-contrast-errors' : ' has-no-contrast-errors' ) . '">
-						<div class="edac-inner-row">
-							<div class="edac-stat-number">' . $summary['distinct_contrast_errors'] . '</div>
-						</div>
-						<div class="edac-inner-row">
-							<div class="edac-stat-label">Unique Color Contrast Error' . ( ( 1 == $summary['distinct_errors_without_contrast'] ) ? '' : 's' ) . '</div>
-						</div>
-					</div>
-
-			
-					<div class="edac-welcome-grid-c4 edac-welcome-grid-item' . ( ( $summary['distinct_warnings'] > 0 ) ? ' has-warning' : ' has-no-warning' ) . '">
-						<div class="edac-inner-row">
-							<div class="edac-stat-number">' . $summary['distinct_warnings'] . '</div>
-						</div>
-						<div class="edac-inner-row">
-							<div class="edac-stat-label">Unique Warning' . ( ( 1 == $summary['distinct_warnings'] ) ? '' : 's' ) . '</div>
-						</div>
-					</div>
-		
-
-					
-			
-					<div class="edac-welcome-grid-c5 edac-welcome-grid-item' . ( ( $summary['distinct_ignored'] > 0 ) ? ' has-ignored' : ' has-no-ignored' ) . '">
-						<div class="edac-inner-row">
-							<div class="edac-stat-number">' . $summary['distinct_ignored'] . '</div>
-						</div>
-						<div class="edac-inner-row">
-							<div class="edac-stat-label">Ignored Item' . ( ( 1 == $summary['distinct_ignored'] ) ? '' : 's' ) . '</div>
-						</div>
-					</div>';
-
-			$html .= '
-					
 				<div class="edac-welcome-grid-c6 edac-welcome-grid-item edac-background-light">
 					<div class="edac-inner-row">
-						<div class="edac-stat-label">Average Issues Per Page</div>
+						<div class="edac-stat-label">' . esc_html__( 'Average Issues Per Page', 'accessibility-checker' ) . '</div>
 					</div>
-
 					<div class="edac-inner-row">
 						<div class="edac-stat-number">' . $summary['avg_issues_per_post'] . '</div>
 					</div>
 				</div>
-
-		
+			
 				<div class="edac-welcome-grid-c7 edac-welcome-grid-item edac-background-light">
 					<div class="edac-inner-row">
-						<div class="edac-stat-label">Average Issue Density</div>
+						<div class="edac-stat-label">' . esc_html__( 'Average Issue Density', 'accessibility-checker' ) . '</div>
 					</div>
 					<div class="edac-inner-row">
 						<div class="edac-stat-number">' . $summary['avg_issue_density_percentage'] . '%</div>
 					</div>
 				</div>
-
-		
+			
 				<div class="edac-welcome-grid-c8 edac-welcome-grid-item edac-background-light">
 					<div class="edac-inner-row">
-						<div class="edac-stat-label">Last Full-Site Scan: </div>
+						<div class="edac-stat-label">' . esc_html__( 'Last Full-Site Scan:', 'accessibility-checker' ) . '</div>
 					</div>
 					<div class="edac-inner-row">
+						';
 				
-					';
-				
-				if($summary['fullscan_completed_at'] > 0){
-					$html .= '
-						<div class="edac-stat-number edac-timestamp-to-local">' . $summary['fullscan_completed_at'] . '</div>';
-				} else {
-					$html .= '
-						<div class="edac-stat-number">Never</div>';
-				}
+					if ($summary['fullscan_completed_at'] > 0) {
+						$html .= '
+							<div class="edac-stat-number edac-timestamp-to-local">' . $summary['fullscan_completed_at'] . '</div>';
+					} else {
+						$html .= '
+							<div class="edac-stat-number">' . esc_html__( 'Never', 'accessibility-checker' ) . '</div>';
+					}
 
 				$html .= '
 					</div>
 				</div>
-
-
 
 				<div class="edac-welcome-grid-c9 edac-welcome-grid-item edac-background-light">
 					<div class="edac-inner-row">
 						<div class="edac-stat-number">' . $summary['posts_scanned'] . '</div>
 					</div>
 					<div class="edac-inner-row">
-						<div class="edac-stat-label">URLs Scanned</div>
+						<div class="edac-stat-label">' . esc_html__( 'URLs Scanned', 'accessibility-checker' ) . '</div>
 					</div>
 				</div>
 
-	
 				<div class="edac-welcome-grid-c10 edac-welcome-grid-item edac-background-light">
 					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . $summary['scannable_post_types_count'] . ' of ' . $summary['public_post_types_count'] . '</div>
+						<div class="edac-stat-number">' . $summary['scannable_post_types_count'] . ' ' . esc_html__( 'of', 'accessibility-checker' ) . ' ' . $summary['public_post_types_count'] . '</div>
 					</div>
 					<div class="edac-inner-row">
-						<div class="edac-stat-label">Post Types Checked</div>
+						<div class="edac-stat-label">' . esc_html__( 'Post Types Checked', 'accessibility-checker' ) . '</div>
 					</div>
 				</div>
 
@@ -172,53 +158,42 @@ class Welcome_Page {
 						<div class="edac-stat-number">' . $summary['posts_without_issues'] . '</div>
 					</div>
 					<div class="edac-inner-row">
-						<div class="edac-stat-label">URLs with 100% score</div>
+						<div class="edac-stat-label">' . esc_html__( 'URLs with 100% score', 'accessibility-checker' ) . '</div>
 					</div>
 				</div>
 
 			</div>
 			</section>';
-
 			
 		} else {
 
-		
 			if ( true !== boolval( get_user_meta( get_current_user_id(), 'edac_welcome_cta_dismissed', true )) ) {
 	
-				$html .='
-					<section>
+				$html .= '
+				<section>
 					<div class="edac-cols edac-cols-header">
-						<h3 class="edac-cols-left">
-							Site-Wide Accessibility Reports
-						</h3>
+						<h3 class="edac-cols-left">' . esc_html__( 'Site-Wide Accessibility Reports', 'accessibility-checker' ) . '</h3>
 
 						<p class="edac-cols-right"> 
-							<button id="dismiss_welcome_cta" class="button">Hide banner</button>
+							<button id="dismiss_welcome_cta" class="button">' . esc_html__( 'Hide banner', 'accessibility-checker' ) . '</button>
 						</p>
 					</div>
- 
+
 					<div class="edac-modal-container"> 
-						
-					
 						<div class="edac-modal">
-
 							<div class="edac-modal-content">
-
-								<h3 class="edac-align-center">Unlock Detailed Accessibility Reports</h3>
-								<p class="edac-align-center">Start scanning your entire website for accessibility issues, get full-site reports,
-								and become compliant with accessibility guidelines faster.</p>
+								<h3 class="edac-align-center">' . esc_html__( 'Unlock Detailed Accessibility Reports', 'accessibility-checker' ) . '</h3>
+								<p class="edac-align-center">' . esc_html__( 'Start scanning your entire website for accessibility issues, get full-site reports, and become compliant with accessibility guidelines faster.', 'accessibility-checker' ) . '</p>
 								<p class="edac-align-center">
 									<a class="button button-primary" href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">
-									Upgrade Accessibility Checker
-								</a>
+										' . esc_html__( 'Upgrade Accessibility Checker', 'accessibility-checker' ) . '
+									</a>
 								</p>
 							</div>	
-							
 						</div>					
-					
 					</div>
+				</section>';
 
-					</section>';
 			}
 
 		}
@@ -227,10 +202,6 @@ class Welcome_Page {
 		</div>';
 
 		echo $html;
-		
 
 	}
-
-
-
 }

--- a/includes/classes/Widgets.php
+++ b/includes/classes/Widgets.php
@@ -25,15 +25,11 @@ class Widgets {
 		$html = '';
 		$scan_data = new Scan_Report_Data( 5 );
 		$summary = $scan_data->scan_summary();
-	
+
 		$html .= '
 	
-		
 		<div class="edac-widget">';
 		
-		
-	
-			
 		$pro_modal_html = '';
 		if ( ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || 
 			false == EDAC_KEY_VALID ) &&
@@ -42,18 +38,14 @@ class Widgets {
 			$pro_modal_html = '
 			<div class="edac-modal">
 				<div class="edac-modal-content">
-					<button class="edac-modal-content-close edac-widget-modal-content-close" aria-label="close ad">&times;</button>
-					<h3>Get Detailed Accessibility Reports</h3>
-					<p class="edac-align-center">Start scanning your entire website for accessibility issues, get full-site reports,
-					and become compliant with accessibility guidelines faster.</p>
+					<button class="edac-modal-content-close edac-widget-modal-content-close" aria-label="' . esc_attr__( 'close ad', 'accessibility-checker' ) . '">&times;</button>
+					<h3>' . __( 'Get Detailed Accessibility Reports', 'accessibility-checker' ) . '</h3>
+					<p class="edac-align-center">' . __( 'Start scanning your entire website for accessibility issues, get full-site reports, and become compliant with accessibility guidelines faster.', 'accessibility-checker' ) . '</p>
 					<p class="edac-align-center">
-					<a class="button button-primary" href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">
-					Upgrade Accessibility Checker
-					</a>
+					<a class="button button-primary" href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">' . __( 'Upgrade Accessibility Checker', 'accessibility-checker' ) . '</a>
 					</p>
 				</div>
 			</div>';
-
 		}
 	
 		if ( ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' != $pro_modal_html ) {
@@ -64,23 +56,25 @@ class Widgets {
 			$html .= $pro_modal_html;
 		
 			$html .= '
-			<h3 class="edac-summary-header">
-			Full Site Accessibility Status
-			</h3>
+			<h3 class="edac-summary-header">' . 
+				__( 'Full Site Accessibility Status', 'accessibility-checker' ) . 
+			'</h3>
 			<div class="edac-summary-passed">
-				<div class="edac-circle-progress" role="progressbar" aria-valuenow="' . $summary['passed_percentage'] . '" 
+				<div class="edac-circle-progress" role="progressbar" aria-valuenow="' . esc_attr( $summary['passed_percentage'] ) . '" 
 					aria-valuemin="0" aria-valuemax="100"
 					style="text-align: center; 
 					background: radial-gradient(closest-side, white 85%, transparent 80% 100%), 
-					conic-gradient(#006600 ' . $summary['passed_percentage'] . '%, #e2e4e7 0);">
-					<div class="edac-progress-percentage">' . $summary['passed_percentage'] . '%</div>
-					<div class="edac-progress-label">Passed Tests</div>
+					conic-gradient(#006600 ' . esc_attr( $summary['passed_percentage'] ) . '%, #e2e4e7 0);">
+					<div class="edac-progress-percentage">' . esc_html( $summary['passed_percentage'] ) . '%</div>
+					<div class="edac-progress-label">' . 
+					__( 'Passed Tests', 'accessibility-checker' ) . 
+					'</div>
 				</div>
 			</div>
 		
 			<div class="edac-summary-info">
 				<div class="edac-summary-info-date">
-					<div class="edac-summary-info-date-label">Last Full-Site Scan: </div>
+					<div class="edac-summary-info-date-label">' . __( 'Last Full-Site Scan:', 'accessibility-checker' ) . '</div>
 				';
 			
 			if ( $summary['fullscan_completed_at'] > 0 ) {
@@ -96,55 +90,47 @@ class Widgets {
 
 				<div class="edac-summary-info-count">
 					<div class="edac-summary-scan-count-label">
-						URLs Scanned:
+						' . __( 'URLs Scanned:', 'accessibility-checker' ) . '
 					</div>
 					<div class="edac-summary-info-count-number">' . $summary['posts_scanned'] . '</div>
 				</div>';
 
-				
-
 			$html .= '
-			<div class="edac-summary-info-stats">
-				<div class="edac-summary-info-stats-box edac-summary-info-stats-box-error ' . ( ( $summary['distinct_errors_without_contrast'] > 0 ) ? ' has-errors' : '' ) . '">
-					<div class="edac-summary-info-stats-box-label">Errors: </div>
-					<div class="edac-summary-info-stats-box-number">
-						' . $summary['distinct_errors_without_contrast'] . '
+				<div class="edac-summary-info-stats">
+					<div class="edac-summary-info-stats-box edac-summary-info-stats-box-error ' . ( ( $summary['distinct_errors_without_contrast'] > 0 ) ? ' has-errors' : '' ) . '">
+						<div class="edac-summary-info-stats-box-label">' . __( 'Errors:', 'accessibility-checker' ) . ' </div>
+						<div class="edac-summary-info-stats-box-number">
+							' . $summary['distinct_errors_without_contrast'] . '
+						</div>
 					</div>
-				</div>
-				<div class="edac-summary-info-stats-box edac-summary-info-stats-box-contrast ' . ( ( $summary['distinct_contrast_errors'] > 0 ) ? ' has-errors' : '' ) . '">
-					<div class="edac-summary-info-stats-box-label">Color Contrast Errors: </div>
-					<div class="edac-summary-info-stats-box-number">
-						' . $summary['distinct_contrast_errors'] . '
+					<div class="edac-summary-info-stats-box edac-summary-info-stats-box-contrast ' . ( ( $summary['distinct_contrast_errors'] > 0 ) ? ' has-errors' : '' ) . '">
+						<div class="edac-summary-info-stats-box-label">' . __( 'Color Contrast Errors:', 'accessibility-checker' ) . ' </div>
+						<div class="edac-summary-info-stats-box-number">
+							' . $summary['distinct_contrast_errors'] . '
+						</div>
 					</div>
-				</div>
-				<div class="edac-summary-info-stats-box edac-summary-info-stats-box-warning ' . ( ( $summary['distinct_warnings'] > 0 ) ? ' has-warning' : '' ) . '">
-					<div class="edac-summary-info-stats-box-label">Warnings: </div>
-					<div class="edac-summary-info-stats-box-number">
-						' . $summary['distinct_warnings'] . '
+					<div class="edac-summary-info-stats-box edac-summary-info-stats-box-warning ' . ( ( $summary['distinct_warnings'] > 0 ) ? ' has-warning' : '' ) . '">
+						<div class="edac-summary-info-stats-box-label">' . __( 'Warnings:', 'accessibility-checker' ) . ' </div>
+						<div class="edac-summary-info-stats-box-number">
+							' . $summary['distinct_warnings'] . '
+						</div>
 					</div>
 				</div>
 			</div>
-
-			</div>
-			
-		';
+			';
 			
 			if ( (int) ( $summary['distinct_errors'] + $summary['distinct_warnings'] ) > 0 ) {
 				$html .= '
-			
-		<div class="edac-summary-notice">
-			Your site has accessibility issues that should be addressed as soon as possible 
-			to ensure compliance with accessibility guidelines.
-		</div>';
+				<div class="edac-summary-notice">
+					' . __( 'Your site has accessibility issues that should be addressed as soon as possible to ensure compliance with accessibility guidelines.', 'accessibility-checker' ) . '
+				</div>';
 
 			} else {
 				$html .= '
-		<div class="edac-summary-notice">
-			Way to go! Accessibility Checker cannot find any accessibility problems in the content it tested. 
-			Some problems cannot be found by automated tools so don\'t forget to <a href="https://equalizedigital.com/accessibility-checker/how-to-manually-check-your-website-for-accessibility/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">manually test your site</a>.
-		</div>';
-
-			}      
+				<div class="edac-summary-notice">
+					' . __( 'Way to go! Accessibility Checker cannot find any accessibility problems in the content it tested. Some problems cannot be found by automated tools so don\'t forget to', 'accessibility-checker' ) . ' <a href="https://equalizedigital.com/accessibility-checker/how-to-manually-check-your-website-for-accessibility/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">' . __( 'manually test your site', 'accessibility-checker' ) . '</a>.
+				</div>';
+			}     
 			
 			$html .= '
 		</div>
@@ -152,37 +138,33 @@ class Widgets {
 		
 		}
 
-
-
 		$html .= '
 		
 		<div class="edac-issues-summary">
 
 			<h3 class="edac-issues-summary-header">
-				Issues By Post Type
+				' . __( 'Issues By Post Type', 'accessibility-checker' ) . '
 			</h3> 
 
 			<table class="widefat striped">
 				<thead>
 				<tr>
 					<th scope="col">
-						Post Type
+						' . __( 'Post Type', 'accessibility-checker' ) . '
 					</th>
 					<th scope="col" >
-						Errors
+						' . __( 'Errors', 'accessibility-checker' ) . '
 					</th>
 					<th scope="col" >
-						Contrast
+						' . __( 'Contrast', 'accessibility-checker' ) . '
 					</th>
 					<th scope="col" >
-						Warnings
+						' . __( 'Warnings', 'accessibility-checker' ) . '
 					</th>
 				</tr>
 				</thead>
 
 				<tbody>';
-		
-
 			
 				$scannable_post_types = Settings::get_scannable_post_types();
 			
@@ -241,7 +223,7 @@ class Widgets {
 								<td colspan="3">
 									<div class="edac-issues-summary-notice-upgrade-to-edacp">
 										<a href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">
-											Upgrade to Scan
+											' . __( 'Upgrade to Scan', 'accessibility-checker' ) . '
 										</a>
 									</div>
 								</td>
@@ -258,45 +240,31 @@ class Widgets {
 		<div class="edac-buttons-container edac-mt-3 edac-mb-3">
 		';
 
-
 		if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
 			$html .= '
-			<a class="button edac-mr-1" href="/wp-admin/admin.php?page=accessibility_checker">See More Reports</a>';
+			<a class="button edac-mr-1" href="/wp-admin/admin.php?page=accessibility_checker">' . __( 'See More Reports', 'accessibility-checker' ) . '</a>';
 		}
-			
-
+		
 		$html .= '
-		<a href="/wp-admin/admin.php?page=accessibility_checker_settings">Edit Accessibility Checker Settings</a>
+		<a href="/wp-admin/admin.php?page=accessibility_checker_settings">' . __( 'Edit Accessibility Checker Settings', 'accessibility-checker' ) . '</a>
 		</div>
 		<hr class="edac-hr" />
 		<h3 class="edac-summary-header">
-			Learn Accessibility
+			' . __( 'Learn Accessibility', 'accessibility-checker' ) . '
 		</h3>';
 
 		$html .= edac_get_upcoming_meetups_html( 'wordpress-accessibility-meetup-group', 2 );
-
 
 		$html .= '
 		<hr class="edac-hr" />
 		<div class="edac-widget-footer-link-list">';
 
-		$html .= '<h3 class="screen-reader-text">Additional Resources</h3>';
-		$html .= '<a target="_blank" class="edac-widget-footer-link-list-item edac-mr-1" href="https://equalizedigital.com/resources/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">Blog</a>';
-		$html .= '<span class="edac-widget-footer-link-list-spacer" /><a target="_blank" class="edac-widget-footer-link-list-item edac-ml-1" href="https://equalizedigital.com/accessibility-checker/documentation/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">Documentation</a>
-		</div></div>';
-
-
-	
+		$html .= '<h3 class="screen-reader-text">' . __( 'Additional Resources', 'accessibility-checker' ) . '</h3>';
+		$html .= '<a target="_blank" aria-label="' . __( 'Blog (opens in a new window)', 'accessibility-checker' ) . '" class="edac-widget-footer-link-list-item edac-mr-1" href="https://equalizedigital.com/resources/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">' . __( 'Blog', 'accessibility-checker' ) . '</a>';
+		$html .= '<span class="edac-widget-footer-link-list-spacer"></span><a target="_blank" aria-label="' . __( 'Documentation (opens in a new window)', 'accessibility-checker' ) . '" class="edac-widget-footer-link-list-item edac-ml-1" href="https://equalizedigital.com/accessibility-checker/documentation/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">' . __( 'Documentation', 'accessibility-checker' ) . '</a></div></div>';
 
 		echo $html;
 
 	}
 
 }
-
-
-
-
-
-
-

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -15,9 +15,9 @@
 function edac_compare_strings( $string1, $string2 ) {
 	// text to remove.
 	$remove_text   = array();
-	$remove_text[] = __( 'permalink of ', 'edac' );
-	$remove_text[] = __( 'permalink to ', 'edac' );
-	$remove_text[] = __( '&nbsp;', 'edac' );
+	$remove_text[] = __( 'permalink of ', 'accessibility-checker' );
+	$remove_text[] = __( 'permalink to ', 'accessibility-checker' );
+	$remove_text[] = __( '&nbsp;', 'accessibility-checker' );
 
 	$string1 = strtolower( $string1 );
 	$string1 = str_ireplace( $remove_text, '', $string1 );

--- a/includes/meta-boxes.php
+++ b/includes/meta-boxes.php
@@ -16,7 +16,7 @@ function edac_register_meta_boxes() {
 		foreach ( $post_types as $post_type ) {
 			add_meta_box(
 				'edac-meta-box',
-				__( 'Accessibility Checker', 'edac' ),
+				__( 'Accessibility Checker', 'accessibility-checker' ),
 				'edac_custom_meta_box_cb',
 				$post_type,
 				'normal',

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -350,7 +350,7 @@ function edac_post_types_cb() {
 		<?php } else { ?>
 			<p class="edac-description">
 				<?php 
-				esc_html_e( 'Choose which post types should be checked during a scan. <em>Please note</em>, removing a previously selected post type will remove its scanned information and any custom ignored warnings that have been setup.', 'accessibility-checker' );
+				esc_html_e( 'Choose which post types should be checked during a scan. Please note, removing a previously selected post type will remove its scanned information and any custom ignored warnings that have been setup.', 'accessibility-checker' );
 				?>
 			</p>
 		<?php }

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -39,7 +39,7 @@ function edac_add_options_page() {
 		'read',
 		'accessibility_checker',
 		'edac_display_welcome_page',
-		'dashicons-universal-access-alt	'
+		'dashicons-universal-access-alt'
 	);
 
 	if ( ! edac_user_can_ignore() ) {
@@ -58,9 +58,8 @@ function edac_add_options_page() {
 		__( 'Settings', 'accessibility-checker' ),
 		$settings_capability,
 		'accessibility_checker_settings',
-		'edac_display_options_page',
-		1,
-		'dashicons-universal-access-alt	'
+		'edac_display_options_page'
+		// The submenu doesn't typically require a separate icon.
 	);
 }
 
@@ -210,11 +209,22 @@ function edac_register_setting() {
  */
 function edac_general_cb() {
 	echo '<p>';
-	echo esc_html__( 'Use the settings below to configure Accessibility Checker. Additional information about each setting can be found in the ', 'accessibility-checker' ) . '<a href="https://a11ychecker.com/" target="_blank">' . esc_html__( 'plugin documentation', 'accessibility-checker' ) . '</a>.';
+	
+	
+	printf(
+		/* translators: %1$s: link to the plugin documentation website. */
+		esc_html__( 'Use the settings below to configure Accessibility Checker. Additional information about each setting can be found in the %1$s.', 'accessibility-checker' ),
+		'<a href="https://a11ychecker.com/" target="_blank" aria-label="' . esc_attr__( 'plugin documentation (opens in a new window)', 'accessibility-checker' ) . '">' . esc_html__( 'plugin documentation', 'accessibility-checker' ) . '</a>'
+	);
 
 	if ( EDAC_KEY_VALID === false ) {
-		echo esc_html__( ' More features and email support is available with ', 'accessibility-checker' ) . '<a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank">' . esc_html__( 'Accessibility Checker Pro', 'accessibility-checker' ) . '</a>.';
+		printf(
+			/* translators: %1$s: link to the "Accessibility Checker Pro" website. */
+			' ' . esc_html__( 'More features and email support is available with %1$s.', 'accessibility-checker' ),
+			'<a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank" aria-label="' . esc_attr__( 'Accessibility Checker Pro (opens in a new window)', 'accessibility-checker' ) . '">' . esc_html__( 'Accessibility Checker Pro', 'accessibility-checker' ) . '</a>'
+		);
 	}
+
 	echo '</p>';
 }
 
@@ -222,14 +232,20 @@ function edac_general_cb() {
  * Render the text for the simplified summary section
  */
 function edac_simplified_summary_cb() {
-	echo '<p>' . esc_html__( 'Web Content Accessibility Guidelines (WCAG) at the AAA level require any content with a reading level above 9th grade to have an alternative that is easier to read. Simplified summary text is added on the readability tab in the Accessibility Checker meta box on each post\'s or page\'s edit screen. ', 'accessibility-checker' ) . '<a href="https://a11ychecker.com/help3265" target="_blank">' . esc_html__( 'Learn more about simplified summaries and readability requirements.', 'accessibility-checker' ) . '</a></p>';
+	printf(
+		'<p>%1$s %2$s</p>',
+		esc_html__( 'Web Content Accessibility Guidelines (WCAG) at the AAA level require any content with a reading level above 9th grade to have an alternative that is easier to read. Simplified summary text is added on the readability tab in the Accessibility Checker meta box on each post\'s or page\'s edit screen.', 'accessibility-checker' ),
+		'<a href="https://a11ychecker.com/help3265" target="_blank" aria-label="' . esc_attr__( 'Learn more about simplified summaries and readability requirements (opens in a new window)', 'accessibility-checker' ) . '">' . esc_html__( 'Learn more about simplified summaries and readability requirements.', 'accessibility-checker' ) . '</a>'
+	);
 }
 
 /**
  * Render the text for the footer accessiblity statement section
  */
 function edac_footer_accessibility_statement_cb() {
-	echo '<p>' . esc_html__( 'Are you thinking "Wow, this plugin is amazing" and is it helping you make your website more accessible? Share your efforts to make your website more accessible with your customers and let them know you\'re using Accessibility Checker to ensure all people can use your website. Add a small text-only link and statement in the footer of your website.', 'accessibility-checker' ) . '</p>';
+	echo '<p>';
+	echo esc_html__( 'Are you thinking "Wow, this plugin is amazing" and is it helping you make your website more accessible? Share your efforts to make your website more accessible with your customers and let them know you\'re using Accessibility Checker to ensure all people can use your website. Add a small text-only link and statement in the footer of your website.', 'accessibility-checker' );
+	echo '</p>';
 }
 
 /**
@@ -255,9 +271,9 @@ function edac_simplified_summary_position_cb() {
 			</label>
 		</fieldset>
 		<div id="ac-simplified-summary-option-code">
-			<p>Use this function to manually add the simplified summary to your theme within the loop.</p>
+			<p><?php esc_html_e( 'Use this function to manually add the simplified summary to your theme within the loop.', 'accessibility-checker' ); ?></p>
 			<kbd>edac_get_simplified_summary();</kbd>
-			<p>The function optionally accepts the post ID as a parameter.<p>
+			<p><?php esc_html_e( 'The function optionally accepts the post ID as a parameter.', 'accessibility-checker' ); ?><p>
 			<kbd>edac_get_simplified_summary($post);</kbd>
 		</div>
 		<p class="edac-description"><?php echo esc_html__( 'Set where you would like simplified summaries to appear in relation to your content if filled in.', 'accessibility-checker' ); ?></p>
@@ -346,15 +362,22 @@ function edac_post_types_cb() {
 			?>
 		</fieldset>
 		<?php if ( EDAC_KEY_VALID === false ) { ?>
-			<p class="edac-description"><?php echo esc_html__( 'To check content other than posts and pages, please ', 'accessibility-checker' ); ?><a href="https://my.equalizedigital.com/" target="_blank"><?php echo esc_html__( 'upgrade to pro', 'accessibility-checker' ); ?></a>.</p>
+			<p class="edac-description">
+				<?php 
+				echo esc_html__( 'To check content other than posts and pages, please ', 'accessibility-checker' );
+				?>
+				<a href="https://my.equalizedigital.com/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'upgrade to pro', 'accessibility-checker' ); ?></a>
+				<?php esc_html_e( ' (opens in a new window)', 'accessibility-checker' ); ?>
+			</p>
 		<?php } else { ?>
 			<p class="edac-description">
 				<?php 
 				esc_html_e( 'Choose which post types should be checked during a scan. Please note, removing a previously selected post type will remove its scanned information and any custom ignored warnings that have been setup.', 'accessibility-checker' );
 				?>
 			</p>
-		<?php }
-	
+			<?php 
+		}
+
 }
 
 /**
@@ -402,7 +425,7 @@ function edac_add_footer_accessibility_statement_cb() {
 	?>
 	<fieldset>
 		<label>
-			<input type="checkbox" name="<?php echo 'edac_add_footer_accessibility_statement'; ?>" value="<?php echo '1'; ?>" <?php checked( $option, 1 ); ?>>
+			<input type="checkbox" name="edac_add_footer_accessibility_statement" value="1" <?php checked( $option, 1 ); ?>>
 			<?php esc_html_e( 'Add Footer Accessibility Statement', 'accessibility-checker' ); ?>
 		</label>
 	</fieldset>
@@ -489,7 +512,7 @@ function edac_sanitize_accessibility_policy_page( $page ) {
  */
 function edac_accessibility_statement_preview_cb() {
 
-	echo edac_get_accessibility_statement();
+	echo wp_kses_post( edac_get_accessibility_statement() );
 
 }
 
@@ -503,12 +526,11 @@ function edac_delete_data_cb() {
 	?>
 	<fieldset>
 		<label>
-			<input type="checkbox" name="<?php echo 'edac_delete_data'; ?>" value="<?php echo '1'; ?>" <?php checked( $option, 1 ); ?>>
+			<input type="checkbox" name="edac_delete_data" value="1" <?php checked( $option, 1 ); ?>>
 			<?php esc_html_e( 'Delete all Accessibility Checker data when the plugin is uninstalled.', 'accessibility-checker' ); ?>
 		</label>
 	</fieldset>
 	<?php
-
 }
 
 /**

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -34,8 +34,8 @@ function edac_user_can_ignore() {
 function edac_add_options_page() {
 
 	add_menu_page(
-		__( 'Welcome to Accessibility Checker', 'edac' ),
-		__( 'Accessibility Checker', 'edac' ),
+		__( 'Welcome to Accessibility Checker', 'accessibility-checker' ),
+		__( 'Accessibility Checker', 'accessibility-checker' ),
 		'read',
 		'accessibility_checker',
 		'edac_display_welcome_page',
@@ -54,8 +54,8 @@ function edac_add_options_page() {
 
 	add_submenu_page(
 		'accessibility_checker',
-		__( 'Accessibility Checker Settings', 'edac' ),
-		__( 'Settings', 'edac' ),
+		__( 'Accessibility Checker Settings', 'accessibility-checker' ),
+		__( 'Settings', 'accessibility-checker' ),
 		$settings_capability,
 		'accessibility_checker_settings',
 		'edac_display_options_page',
@@ -86,21 +86,21 @@ function edac_register_setting() {
 	// Add sections.
 	add_settings_section(
 		'edac_general',
-		__( 'General Settings', 'edac' ),
+		__( 'General Settings', 'accessibility-checker' ),
 		'edac_general_cb',
 		'edac_settings'
 	);
 
 	add_settings_section(
 		'edac_simplified_summary',
-		__( 'Simplified Summary Settings', 'edac' ),
+		__( 'Simplified Summary Settings', 'accessibility-checker' ),
 		'edac_simplified_summary_cb',
 		'edac_settings'
 	);
 
 	add_settings_section(
 		'edac_footer_accessibility_statement',
-		__( 'Footer Accessibility Statement', 'edac' ),
+		__( 'Footer Accessibility Statement', 'accessibility-checker' ),
 		'edac_footer_accessibility_statement_cb',
 		'edac_settings'
 	);
@@ -108,7 +108,7 @@ function edac_register_setting() {
 	// Add fields.
 	add_settings_field(
 		'edac_post_types',
-		__( 'Post Types To Be Checked', 'edac' ),
+		__( 'Post Types To Be Checked', 'accessibility-checker' ),
 		'edac_post_types_cb',
 		'edac_settings',
 		'edac_general',
@@ -117,7 +117,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_delete_data',
-		__( 'Delete Data', 'edac' ),
+		__( 'Delete Data', 'accessibility-checker' ),
 		'edac_delete_data_cb',
 		'edac_settings',
 		'edac_general',
@@ -126,7 +126,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_simplified_summary_prompt',
-		__( 'Prompt for Simplified Summary', 'edac' ),
+		__( 'Prompt for Simplified Summary', 'accessibility-checker' ),
 		'edac_simplified_summary_prompt_cb',
 		'edac_settings',
 		'edac_simplified_summary',
@@ -135,7 +135,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_simplified_summary_position',
-		__( 'Simplified Summary Position', 'edac' ),
+		__( 'Simplified Summary Position', 'accessibility-checker' ),
 		'edac_simplified_summary_position_cb',
 		'edac_settings',
 		'edac_simplified_summary',
@@ -144,7 +144,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_add_footer_accessibility_statement',
-		__( 'Add Footer Accessibility Statement', 'edac' ),
+		__( 'Add Footer Accessibility Statement', 'accessibility-checker' ),
 		'edac_add_footer_accessibility_statement_cb',
 		'edac_settings',
 		'edac_footer_accessibility_statement',
@@ -153,7 +153,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_include_accessibility_statement_link',
-		__( 'Include Link to Accessibility Policy', 'edac' ),
+		__( 'Include Link to Accessibility Policy', 'accessibility-checker' ),
 		'edac_include_accessibility_statement_link_cb',
 		'edac_settings',
 		'edac_footer_accessibility_statement',
@@ -162,7 +162,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_accessibility_policy_page',
-		__( 'Accessibility Policy page', 'edac' ),
+		__( 'Accessibility Policy page', 'accessibility-checker' ),
 		'edac_accessibility_policy_page_cb',
 		'edac_settings',
 		'edac_footer_accessibility_statement',
@@ -171,7 +171,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edac_accessibility_statement_preview',
-		__( 'Accessibility Statement Preview', 'edac' ),
+		__( 'Accessibility Statement Preview', 'accessibility-checker' ),
 		'edac_accessibility_statement_preview_cb',
 		'edac_settings',
 		'edac_footer_accessibility_statement',
@@ -210,10 +210,10 @@ function edac_register_setting() {
  */
 function edac_general_cb() {
 	echo '<p>';
-	echo esc_html__( 'Use the settings below to configure Accessibility Checker. Additional information about each setting can be found in the ', 'edac' ) . '<a href="https://a11ychecker.com/" target="_blank">' . esc_html__( 'plugin documentation', 'edac' ) . '</a>.';
+	echo esc_html__( 'Use the settings below to configure Accessibility Checker. Additional information about each setting can be found in the ', 'accessibility-checker' ) . '<a href="https://a11ychecker.com/" target="_blank">' . esc_html__( 'plugin documentation', 'accessibility-checker' ) . '</a>.';
 
 	if ( EDAC_KEY_VALID === false ) {
-		echo esc_html__( ' More features and email support is available with ', 'edac' ) . '<a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank">' . esc_html__( 'Accessibility Checker Pro', 'edac' ) . '</a>.';
+		echo esc_html__( ' More features and email support is available with ', 'accessibility-checker' ) . '<a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank">' . esc_html__( 'Accessibility Checker Pro', 'accessibility-checker' ) . '</a>.';
 	}
 	echo '</p>';
 }
@@ -222,14 +222,14 @@ function edac_general_cb() {
  * Render the text for the simplified summary section
  */
 function edac_simplified_summary_cb() {
-	echo '<p>' . esc_html__( 'Web Content Accessibility Guidelines (WCAG) at the AAA level require any content with a reading level above 9th grade to have an alternative that is easier to read. Simplified summary text is added on the readability tab in the Accessibility Checker meta box on each post\'s or page\'s edit screen. ', 'edac' ) . '<a href="https://a11ychecker.com/help3265" target="_blank">' . esc_html__( 'Learn more about simplified summaries and readability requirements.', 'edac' ) . '</a></p>';
+	echo '<p>' . esc_html__( 'Web Content Accessibility Guidelines (WCAG) at the AAA level require any content with a reading level above 9th grade to have an alternative that is easier to read. Simplified summary text is added on the readability tab in the Accessibility Checker meta box on each post\'s or page\'s edit screen. ', 'accessibility-checker' ) . '<a href="https://a11ychecker.com/help3265" target="_blank">' . esc_html__( 'Learn more about simplified summaries and readability requirements.', 'accessibility-checker' ) . '</a></p>';
 }
 
 /**
  * Render the text for the footer accessiblity statement section
  */
 function edac_footer_accessibility_statement_cb() {
-	echo '<p>' . esc_html__( 'Are you thinking "Wow, this plugin is amazing" and is it helping you make your website more accessible? Share your efforts to make your website more accessible with your customers and let them know you\'re using Accessibility Checker to ensure all people can use your website. Add a small text-only link and statement in the footer of your website.', 'edac' ) . '</p>';
+	echo '<p>' . esc_html__( 'Are you thinking "Wow, this plugin is amazing" and is it helping you make your website more accessible? Share your efforts to make your website more accessible with your customers and let them know you\'re using Accessibility Checker to ensure all people can use your website. Add a small text-only link and statement in the footer of your website.', 'accessibility-checker' ) . '</p>';
 }
 
 /**
@@ -241,17 +241,17 @@ function edac_simplified_summary_position_cb() {
 		<fieldset>
 			<label>
 				<input type="radio" name="<?php echo 'edac_simplified_summary_position'; ?>" id="<?php echo 'edac_simplified_summary_position'; ?>" value="before" <?php checked( $position, 'before' ); ?>>
-				<?php esc_html_e( 'Before the content', 'edac' ); ?>
+				<?php esc_html_e( 'Before the content', 'accessibility-checker' ); ?>
 			</label>
 			<br>
 			<label>
 				<input type="radio" name="<?php echo 'edac_simplified_summary_position'; ?>" value="after" <?php checked( $position, 'after' ); ?>>
-				<?php esc_html_e( 'After the content', 'edac' ); ?>
+				<?php esc_html_e( 'After the content', 'accessibility-checker' ); ?>
 			</label>
 			<br>
 			<label>
 				<input type="radio" name="<?php echo 'edac_simplified_summary_position'; ?>" value="none" <?php checked( $position, 'none' ); ?>>
-				<?php esc_html_e( 'Insert manually', 'edac' ); ?>
+				<?php esc_html_e( 'Insert manually', 'accessibility-checker' ); ?>
 			</label>
 		</fieldset>
 		<div id="ac-simplified-summary-option-code">
@@ -260,7 +260,7 @@ function edac_simplified_summary_position_cb() {
 			<p>The function optionally accepts the post ID as a parameter.<p>
 			<kbd>edac_get_simplified_summary($post);</kbd>
 		</div>
-		<p class="edac-description"><?php echo esc_html__( 'Set where you would like simplified summaries to appear in relation to your content if filled in.', 'edac' ); ?></p>
+		<p class="edac-description"><?php echo esc_html__( 'Set where you would like simplified summaries to appear in relation to your content if filled in.', 'accessibility-checker' ); ?></p>
 	<?php
 }
 
@@ -285,20 +285,20 @@ function edac_simplified_summary_prompt_cb() {
 		<fieldset>
 			<label>
 				<input type="radio" name="<?php echo 'edac_simplified_summary_prompt'; ?>" id="<?php echo 'edac_simplified_summary_prompt'; ?>" value="when required" <?php checked( $prompt, 'when required' ); ?>>
-				<?php esc_html_e( 'When Required', 'edac' ); ?>
+				<?php esc_html_e( 'When Required', 'accessibility-checker' ); ?>
 			</label>
 			<br>
 			<label>
 				<input type="radio" name="<?php echo 'edac_simplified_summary_prompt'; ?>" value="always" <?php checked( $prompt, 'always' ); ?>>
-				<?php esc_html_e( 'Always', 'edac' ); ?>
+				<?php esc_html_e( 'Always', 'accessibility-checker' ); ?>
 			</label>
 			<br>
 			<label>
 				<input type="radio" name="<?php echo 'edac_simplified_summary_prompt'; ?>" value="none" <?php checked( $prompt, 'none' ); ?>>
-				<?php esc_html_e( 'Never', 'edac' ); ?>
+				<?php esc_html_e( 'Never', 'accessibility-checker' ); ?>
 			</label>
 		</fieldset>
-		<p class="edac-description"><?php echo esc_html__( 'Should Accessibility Checker only ask for a simplified summary when the reading level of your post or page is above 9th grade, always ask for it regardless of reading level, or never ask for it regardless of reading level?', 'edac' ); ?></p>
+		<p class="edac-description"><?php echo esc_html__( 'Should Accessibility Checker only ask for a simplified summary when the reading level of your post or page is above 9th grade, always ask for it regardless of reading level, or never ask for it regardless of reading level?', 'accessibility-checker' ); ?></p>
 	<?php
 }
 
@@ -346,13 +346,11 @@ function edac_post_types_cb() {
 			?>
 		</fieldset>
 		<?php if ( EDAC_KEY_VALID === false ) { ?>
-			<p class="edac-description"><?php echo esc_html__( 'To check content other than posts and pages, please ', 'edac' ); ?><a href="https://my.equalizedigital.com/" target="_blank"><?php echo esc_html__( 'upgrade to pro', 'edac' ); ?></a>.</p>
+			<p class="edac-description"><?php echo esc_html__( 'To check content other than posts and pages, please ', 'accessibility-checker' ); ?><a href="https://my.equalizedigital.com/" target="_blank"><?php echo esc_html__( 'upgrade to pro', 'accessibility-checker' ); ?></a>.</p>
 		<?php } else { ?>
 			<p class="edac-description">
 				<?php 
-				echo __('Choose which post types should be checked during a scan. <em>Please note</em>, 
-				removing a previously selected post type will remove its
-				scanned information and any custom ignored warnings that have been setup.', 'edac');
+				esc_html_e( 'Choose which post types should be checked during a scan. <em>Please note</em>, removing a previously selected post type will remove its scanned information and any custom ignored warnings that have been setup.', 'accessibility-checker' );
 				?>
 			</p>
 		<?php }
@@ -405,7 +403,7 @@ function edac_add_footer_accessibility_statement_cb() {
 	<fieldset>
 		<label>
 			<input type="checkbox" name="<?php echo 'edac_add_footer_accessibility_statement'; ?>" value="<?php echo '1'; ?>" <?php checked( $option, 1 ); ?>>
-			<?php esc_html_e( 'Add Footer Accessibility Statement', 'edac' ); ?>
+			<?php esc_html_e( 'Add Footer Accessibility Statement', 'accessibility-checker' ); ?>
 		</label>
 	</fieldset>
 	<?php
@@ -441,7 +439,7 @@ function edac_include_accessibility_statement_link_cb() {
 													disabled( $disabled, false );
 													?>
 			>
-			<?php esc_html_e( 'Include Link to Accessibility Policy', 'edac' ); ?>
+			<?php esc_html_e( 'Include Link to Accessibility Policy', 'accessibility-checker' ); ?>
 		</label>
 	</fieldset>
 	<?php
@@ -506,7 +504,7 @@ function edac_delete_data_cb() {
 	<fieldset>
 		<label>
 			<input type="checkbox" name="<?php echo 'edac_delete_data'; ?>" value="<?php echo '1'; ?>" <?php checked( $option, 1 ); ?>>
-			<?php esc_html_e( 'Delete all Accessibility Checker data when the plugin is uninstalled.', 'edac' ); ?>
+			<?php esc_html_e( 'Delete all Accessibility Checker data when the plugin is uninstalled.', 'accessibility-checker' ); ?>
 		</label>
 	</fieldset>
 	<?php

--- a/includes/system-info.php
+++ b/includes/system-info.php
@@ -42,12 +42,15 @@ function edac_tools_sysinfo_get() {
 	$browser = new Browser();
 
 	// Get theme info.
-	$theme_data   = wp_get_theme();
-	$theme        = $theme_data->Name . ' ' . $theme_data->Version;
+	$theme_data = wp_get_theme();
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$theme = $theme_data->Name . ' ' . $theme_data->Version;
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$parent_theme = $theme_data->Template;
 	if ( ! empty( $parent_theme ) ) {
 		$parent_theme_data = wp_get_theme( $parent_theme );
-		$parent_theme      = $parent_theme_data->Name . ' ' . $parent_theme_data->Version;
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$parent_theme = $parent_theme_data->Name . ' ' . $parent_theme_data->Version;
 	}
 
 	// Try to identify the hosting provider.
@@ -68,14 +71,14 @@ function edac_tools_sysinfo_get() {
 		$return .= "\n" . '-- Hosting Provider' . "\n\n";
 		$return .= 'Host:                     ' . $host . "\n";
 
-		$return  = apply_filters( 'edac_sysinfo_after_host_info', $return );
+		$return = apply_filters( 'edac_sysinfo_after_host_info', $return );
 	}
 
 	// The local users' browser information, handled by the Browser class.
 	$return .= "\n" . '-- User Browser' . "\n\n";
 	$return .= $browser;
 
-	$return  = apply_filters( 'edac_sysinfo_after_user_browser', $return );
+	$return = apply_filters( 'edac_sysinfo_after_user_browser', $return );
 
 	$locale = get_locale();
 
@@ -93,7 +96,7 @@ function edac_tools_sysinfo_get() {
 	// Only show page specs if frontpage is set to 'page'.
 	if ( get_option( 'show_on_front' ) == 'page' ) {
 		$front_page_id = get_option( 'page_on_front' );
-		$blog_page_id = get_option( 'page_for_posts' );
+		$blog_page_id  = get_option( 'page_for_posts' );
 
 		$return .= 'Page On Front:            ' . ( 0 !== $front_page_id ? get_the_title( $front_page_id ) . ' (#' . $front_page_id . ')' : 'Unset' ) . "\n";
 		$return .= 'Page For Posts:           ' . ( 0 !== $blog_page_id ? get_the_title( $blog_page_id ) . ' (#' . $blog_page_id . ')' : 'Unset' ) . "\n";
@@ -105,28 +108,27 @@ function edac_tools_sysinfo_get() {
 	$request['cmd'] = '_notify-validate';
 
 	$params = array(
-		'sslverify'     => false,
-		'timeout'       => 60,
-		'user-agent'    => 'EDAC/' . EDAC_VERSION,
-		'body'          => $request,
+		'sslverify'  => false,
+		'timeout'    => 3,
+		'user-agent' => 'EDAC/' . EDAC_VERSION,
+		'body'       => $request,
 	);
 
 	$response = wp_remote_post( 'https://www.paypal.com/cgi-bin/webscr', $params );
 
 	if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
-		$WP_REMOTE_POST = 'wp_remote_post() works';
+		$wp_remote_post = 'wp_remote_post() works';
 	} else {
-		$WP_REMOTE_POST = 'wp_remote_post() does not work';
+		$wp_remote_post = 'wp_remote_post() does not work';
 	}
 
-	$return .= 'Remote Post:              ' . $WP_REMOTE_POST . "\n";
-	$return .= 'Table Prefix:             ' . 'Length: ' . strlen( $wpdb->prefix ) . '   Status: ' . ( strlen( $wpdb->prefix ) > 16 ? 'ERROR: Too long' : 'Acceptable' ) . "\n";
-	// $return .= 'Admin AJAX:               ' . ( edac_test_ajax_works() ? 'Accessible' : 'Inaccessible' ) . "\n";
+	$return .= 'Remote Post:              ' . $wp_remote_post . "\n";
+	$return .= 'Table Prefix:             Length: ' . strlen( $wpdb->prefix ) . '   Status: ' . ( strlen( $wpdb->prefix ) > 16 ? 'ERROR: Too long' : 'Acceptable' ) . "\n";
 	$return .= 'WP_DEBUG:                 ' . ( defined( 'WP_DEBUG' ) ? WP_DEBUG ? 'Enabled' : 'Disabled' : 'Unset' ) . "\n";
 	$return .= 'Memory Limit:             ' . WP_MEMORY_LIMIT . "\n";
 	$return .= 'Registered Post Stati:    ' . implode( ', ', get_post_stati() ) . "\n";
 
-	$return  = apply_filters( 'edac_sysinfo_after_wordpress_config', $return );
+	$return = apply_filters( 'edac_sysinfo_after_wordpress_config', $return );
 
 	// EDAC configuration.
 	$return .= "\n" . '-- Accessibility Checker Configuration' . "\n\n";
@@ -139,7 +141,7 @@ function edac_tools_sysinfo_get() {
 	$return .= 'Authorization Password:   ' . ( get_option( 'edac_authorization_password' ) ? get_option( 'edac_authorization_password' ) . "\n" : "Unset\n" );
 	$return .= 'Delete Data:              ' . ( get_option( 'edac_delete_data' ) ? "Enabled\n" : "Disabled\n" );
 	$return .= 'Include Statement Link:   ' . ( get_option( 'edac_include_accessibility_statement_link' ) ? "Enabled\n" : "Disabled\n" );
-	$return .= 'Post Types:               ' . ( get_option( 'edac_post_types' ) ? implode( ", ", get_option( 'edac_post_types' ) ) . "\n" : "Unset\n" );
+	$return .= 'Post Types:               ' . ( get_option( 'edac_post_types' ) ? implode( ', ', get_option( 'edac_post_types' ) ) . "\n" : "Unset\n" );
 	$return .= 'Simplified Sum Position:  ' . get_option( 'edac_simplified_summary_position' ) . "\n";
 	$return .= 'Simplified Sum Prompt:    ' . get_option( 'edac_simplified_summary_prompt' ) . "\n";
 	$return .= 'Post Count:               ' . edac_get_posts_count() . "\n";
@@ -149,14 +151,14 @@ function edac_tools_sysinfo_get() {
 
 	if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) {
 
-		$return .= "\n" . '-- Accessibility Checker Pro Configuration' . "\n\n";
-		$return .= 'Version:                  ' . EDACP_VERSION . "\n";
-		$return .= 'Database Version:         ' . get_option( 'edacp_db_version' ) . "\n";
-		$return .= 'License Status:           ' . get_option( 'edacp_license_status' ) . "\n";
-		$return .= 'Scan ID:                  ' . get_transient( 'edacp_scan_id' ) . "\n";
-		$return .= 'Scan Total:               ' . get_transient( 'edacp_scan_total' ) . "\n";
-		$return .= 'Simplified Sum Heading:   ' . get_option( 'edacp_simplified_summary_heading' ) . "\n";
-		$return .= 'Background Scan Schedule: ' . get_option( 'edacp_background_scan_schedule' ) . "\n";
+		$return   .= "\n" . '-- Accessibility Checker Pro Configuration' . "\n\n";
+		$return   .= 'Version:                  ' . EDACP_VERSION . "\n";
+		$return   .= 'Database Version:         ' . get_option( 'edacp_db_version' ) . "\n";
+		$return   .= 'License Status:           ' . get_option( 'edacp_license_status' ) . "\n";
+		$return   .= 'Scan ID:                  ' . get_transient( 'edacp_scan_id' ) . "\n";
+		$return   .= 'Scan Total:               ' . get_transient( 'edacp_scan_total' ) . "\n";
+		$return   .= 'Simplified Sum Heading:   ' . get_option( 'edacp_simplified_summary_heading' ) . "\n";
+		$return   .= 'Background Scan Schedule: ' . get_option( 'edacp_background_scan_schedule' ) . "\n";
 		$next_scan = as_next_scheduled_action( 'edacp_schedule_scan_hook' );
 		if ( $next_scan ) {
 			$return .= 'Next Background Scan: ' . gmdate( 'F j, Y g:i a', $next_scan ) . "\n";
@@ -166,7 +168,7 @@ function edac_tools_sysinfo_get() {
 		$return .= 'Logs DB Table Count:      ' . edac_database_table_count( 'accessibility_checker_logs' ) . "\n";
 	}
 
-	$return  = apply_filters( 'edac_sysinfo_after_edac_config', $return );
+	$return = apply_filters( 'edac_sysinfo_after_edac_config', $return );
 
 	// Templates.
 	$dir = get_stylesheet_directory() . '/edac_templates/*';
@@ -177,7 +179,7 @@ function edac_tools_sysinfo_get() {
 			$return .= 'Filename:                 ' . basename( $file ) . "\n";
 		}
 
-		$return  = apply_filters( 'edac_sysinfo_after_edac_templates', $return );
+		$return = apply_filters( 'edac_sysinfo_after_edac_templates', $return );
 	}
 
 	// Get plugins that have an update.
@@ -199,7 +201,7 @@ function edac_tools_sysinfo_get() {
 	// WordPress active plugins.
 	$return .= "\n" . '-- WordPress Active Plugins' . "\n\n";
 
-	$plugins = get_plugins();
+	$plugins        = get_plugins();
 	$active_plugins = get_option( 'active_plugins', array() );
 
 	foreach ( $plugins as $plugin_path => $plugin ) {
@@ -207,11 +209,11 @@ function edac_tools_sysinfo_get() {
 			continue;
 		}
 
-		$update = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[ $plugin_path ]->update->new_version . ')' : '';
+		$update  = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[ $plugin_path ]->update->new_version . ')' : '';
 		$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . "\n";
 	}
 
-	$return  = apply_filters( 'edac_sysinfo_after_wordpress_plugins', $return );
+	$return = apply_filters( 'edac_sysinfo_after_wordpress_plugins', $return );
 
 	// WordPress inactive plugins.
 	$return .= "\n" . '-- WordPress Inactive Plugins' . "\n\n";
@@ -221,17 +223,17 @@ function edac_tools_sysinfo_get() {
 			continue;
 		}
 
-		$update = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[ $plugin_path ]->update->new_version . ')' : '';
+		$update  = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[ $plugin_path ]->update->new_version . ')' : '';
 		$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . "\n";
 	}
 
-	$return  = apply_filters( 'edac_sysinfo_after_wordpress_plugins_inactive', $return );
+	$return = apply_filters( 'edac_sysinfo_after_wordpress_plugins_inactive', $return );
 
 	if ( is_multisite() ) {
 		// WordPress Multisite active plugins.
 		$return .= "\n" . '-- Network Active Plugins' . "\n\n";
 
-		$plugins = wp_get_active_network_plugins();
+		$plugins        = wp_get_active_network_plugins();
 		$active_plugins = get_site_option( 'active_sitewide_plugins', array() );
 
 		foreach ( $plugins as $plugin_path ) {
@@ -241,21 +243,23 @@ function edac_tools_sysinfo_get() {
 				continue;
 			}
 
-			$update = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[ $plugin_path ]->update->new_version . ')' : '';
+			$update  = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[ $plugin_path ]->update->new_version . ')' : '';
 			$plugin  = get_plugin_data( $plugin_path );
 			$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . "\n";
 		}
 
-		$return  = apply_filters( 'edac_sysinfo_after_wordpress_ms_plugins', $return );
+		$return = apply_filters( 'edac_sysinfo_after_wordpress_ms_plugins', $return );
 	}
 
 	// Server configuration.
+	$server_software = isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( $_SERVER['SERVER_SOFTWARE'] ) : 'Unknown';
+
 	$return .= "\n" . '-- Webserver Configuration' . "\n\n";
 	$return .= 'PHP Version:              ' . PHP_VERSION . "\n";
 	$return .= 'MySQL Version:            ' . $wpdb->db_version() . "\n";
-	$return .= 'Webserver Info:           ' . $_SERVER['SERVER_SOFTWARE'] . "\n";
+	$return .= 'Webserver Info:           ' . $server_software . "\n";
 
-	$return  = apply_filters( 'edac_sysinfo_after_webserver_config', $return );
+	$return = apply_filters( 'edac_sysinfo_after_webserver_config', $return );
 
 	// PHP configs.
 	$return .= "\n" . '-- PHP Configuration' . "\n\n";
@@ -268,7 +272,7 @@ function edac_tools_sysinfo_get() {
 	$return .= 'Display Errors:           ' . ( ini_get( 'display_errors' ) ? 'On (' . ini_get( 'display_errors' ) . ')' : 'N/A' ) . "\n";
 	$return .= 'PHP Arg Separator:        ' . edac_get_php_arg_separator_output() . "\n";
 
-	$return  = apply_filters( 'edac_sysinfo_after_php_config', $return );
+	$return = apply_filters( 'edac_sysinfo_after_php_config', $return );
 
 	// PHP extensions and such.
 	$return .= "\n" . '-- PHP Extensions' . "\n\n";
@@ -277,11 +281,10 @@ function edac_tools_sysinfo_get() {
 	$return .= 'SOAP Client:              ' . ( class_exists( 'SoapClient' ) ? 'Installed' : 'Not Installed' ) . "\n";
 	$return .= 'Suhosin:                  ' . ( extension_loaded( 'suhosin' ) ? 'Installed' : 'Not Installed' ) . "\n";
 
-	$return  = apply_filters( 'edac_sysinfo_after_php_ext', $return );
+	$return = apply_filters( 'edac_sysinfo_after_php_ext', $return );
 
 	// Session stuff.
 	$return .= "\n" . '-- Session Configuration' . "\n\n";
-	// $return .= 'EDAC Use Sessions:         ' . ( defined( 'edac_USE_PHP_SESSIONS' ) && edac_USE_PHP_SESSIONS ? 'Enforced' : ( EDAC()->session->use_php_sessions() ? 'Enabled' : 'Disabled' ) ) . "\n";
 	$return .= 'Session:                  ' . ( isset( $_SESSION ) ? 'Enabled' : 'Disabled' ) . "\n";
 
 	// The rest of this is only relevant is session is enabled.
@@ -293,7 +296,7 @@ function edac_tools_sysinfo_get() {
 		$return .= 'Use Only Cookies:         ' . ( ini_get( 'session.use_only_cookies' ) ? 'On' : 'Off' ) . "\n";
 	}
 
-	$return  = apply_filters( 'edac_sysinfo_after_session_config', $return );
+	$return = apply_filters( 'edac_sysinfo_after_session_config', $return );
 
 	$return .= "\n" . '### End System Info ###';
 
@@ -374,7 +377,9 @@ function edac_tools_sysinfo_download() {
 		header( 'Content-Type: text/plain' );
 		header( 'Content-Disposition: attachment; filename="edac-system-info.txt"' );
 
-		echo esc_html( wp_strip_all_tags( $_POST['edac-sysinfo'] ) );
+		if ( isset( $_POST['edac-sysinfo'] ) ) {
+			echo esc_html( wp_strip_all_tags( $_POST['edac-sysinfo'] ) );
+		}
 
 		die();
 
@@ -432,10 +437,25 @@ function edac_get_posts_count() {
 function edac_get_error_count() {
 	global $wpdb;
 
-	$query = 'SELECT count(*) FROM ' . $wpdb->prefix . 'accessibility_checker where siteid = %d and ruletype = %s';
-	$summary['errors'] = intval( $wpdb->get_var( $wpdb->prepare( $query, get_current_blog_id(), 'error' ) ) );
+	// Define a unique cache key for our data.
+	$cache_key     = 'edac_errors_' . get_current_blog_id();
+	$stored_errors = wp_cache_get( $cache_key );
 
-	return $summary['errors'];
+	// Check if the result exists in the cache.
+	if ( false === $stored_errors ) {
+		// If not, perform the database query.
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$query = $wpdb->prepare( 'SELECT count(*) FROM ' . $table_name . ' WHERE siteid = %d AND ruletype = %s', get_current_blog_id(), 'error' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$stored_errors = intval( $wpdb->get_var( $query ) );
+
+		// Save the result in the cache for future use.
+		wp_cache_set( $cache_key, $stored_errors );
+	}
+
+	return $stored_errors;
 }
 
 /**
@@ -446,11 +466,27 @@ function edac_get_error_count() {
 function edac_get_warning_count() {
 	global $wpdb;
 
-	$query             = 'SELECT count(*) FROM ' . $wpdb->prefix . 'accessibility_checker where siteid = %d and ruletype = %s';
-	$summary['errors'] = intval( $wpdb->get_var( $wpdb->prepare( $query, get_current_blog_id(), 'warning' ) ) );
+	// Define a unique cache key for our data.
+	$cache_key       = 'edac_warnings_' . get_current_blog_id();
+	$stored_warnings = wp_cache_get( $cache_key );
 
-	return $summary['errors'];
+	// Check if the result exists in the cache.
+	if ( false === $stored_warnings ) {
+		// If not, perform the database query.
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$query = $wpdb->prepare( 'SELECT count(*) FROM ' . $table_name . ' WHERE siteid = %d AND ruletype = %s', get_current_blog_id(), 'warning' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$stored_warnings = intval( $wpdb->get_var( $query ) );
+
+		// Save the result in the cache for future use.
+		wp_cache_set( $cache_key, $stored_warnings );
+	}
+
+	return $stored_warnings;
 }
+
 
 /**
  * Get Database Table Count
@@ -459,12 +495,25 @@ function edac_get_warning_count() {
  * @return int
  */
 function edac_database_table_count( $table ) {
-
 	global $wpdb;
-	$table_name  = $wpdb->prefix . $table;
-	$count_query = "select count(*) from $table_name";
-	$num         = $wpdb->get_var( $count_query );
 
-	return $num;
+	// Create a unique cache key based on the table's name.
+	$cache_key = 'edac_table_count_' . $table;
+	
+	// Try to get the count from the cache first.
+	$count = wp_cache_get( $cache_key );
 
+	if ( false === $count ) {
+		// If the count is not in the cache, perform the database query.
+		$table_name  = $wpdb->prefix . $table;
+		$count_query = "SELECT count(*) FROM $table_name";
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$count = $wpdb->get_var( $count_query );
+		
+		// Save the count to the cache for future use.
+		wp_cache_set( $cache_key, $count );
+	}
+
+	return $count;
 }

--- a/partials/custom-meta-box.php
+++ b/partials/custom-meta-box.php
@@ -8,11 +8,12 @@
 ?>
 <div id="edac-tabs">
 	<ul class="edac-tabs">
-		<li class="edac-tab"><a role="button" aria-current="true" class="edac-tab-summary active" href="#edac-summary">Summary</a></li>
-		<li class="edac-tab"><a role="button" class="edac-tab-details" href="#edac-details">Details</a></li>
-		<li class="edac-tab"><a role="button" class="edac-tab-readability" href="#edac-readability">Readability</a></li>
+		<li class="edac-tab"><a role="button" aria-current="true" class="edac-tab-summary active" href="#edac-summary"><?php esc_html_e( 'Summary', 'accessibility-checker' ); ?></a></li>
+		<li class="edac-tab"><a role="button" class="edac-tab-details" href="#edac-details"><?php esc_html_e( 'Details', 'accessibility-checker' ); ?></a></li>
+		<li class="edac-tab"><a role="button" class="edac-tab-readability" href="#edac-readability"><?php esc_html_e( 'Readability', 'accessibility-checker' ); ?></a></li>
 	</ul>
 	<div class="edac-panel edac-summary" id="edac-summary"></div>
 	<div class="edac-panel edac-details hidden" id="edac-details"></div>
 	<div class="edac-panel edac-readability hidden" id="edac-readability"></div>
 </div>
+

--- a/partials/pro-callout.php
+++ b/partials/pro-callout.php
@@ -7,24 +7,43 @@
 
 ?>
 <div class="edac-pro-callout">
-	<img class="edac-pro-callout-icon" src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/edac-emblem.png" alt="Equalize Digital Logo">
-	<h4 class="edac-pro-callout-title">Upgrade to Accessibility Checker Pro</h4>
+	<img 
+		class="edac-pro-callout-icon" 
+		src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/edac-emblem.png" 
+		alt="<?php esc_attr_e( 'Equalize Digital Logo', 'accessibility-checker' ); ?>"
+	>
+	<h4 class="edac-pro-callout-title">
+		<?php esc_html_e( 'Upgrade to Accessibility Checker Pro', 'accessibility-checker' ); ?>
+	</h4>
 	<div>
 		<ul class="edac-pro-callout-list">
-			<li>Scan all post types</li>
-			<li>Admin columns to see accessibility status at a glance</li>
-			<li>Centralized list of all open issues</li>
-			<li>Ignore log</li>
-			<li>Rename simplified summary</li>
-			<li>User restrictions on ignoring issues</li>
-			<li>Email support</li>
-			<li>...and more</li>
+			<li><?php esc_html_e( 'Scan all post types', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( 'Admin columns to see accessibility status at a glance', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( 'Centralized list of all open issues', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( 'Ignore log', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( 'Rename simplified summary', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( 'User restrictions on ignoring issues', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( 'Email support', 'accessibility-checker' ); ?></li>
+			<li><?php esc_html_e( '...and more', 'accessibility-checker' ); ?></li>
 		</ul>
 	</div>
-	<a class="edac-pro-callout-button" href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank">Get Accessibility Checker Pro</a>
+	<a 
+		class="edac-pro-callout-button" 
+		href="https://equalizedigital.com/accessibility-checker/pricing/" 
+		target="_blank"
+	>
+		<?php esc_html_e( 'Get Accessibility Checker Pro', 'accessibility-checker' ); ?>
+	</a>
 
-	<?php if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) { ?>
-		<br /><a class="edac-pro-callout-activate" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=license' ) ); ?>">Or activate your license key here.</a>
-	<?php } ?>
+	<?php if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) : ?>
+		<br />
+		<a 
+			class="edac-pro-callout-activate" 
+			href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=license' ) ); ?>"
+		>
+			<?php esc_html_e( 'Or activate your license key here.', 'accessibility-checker' ); ?>
+		</a>
+	<?php endif; ?>
 </div>
+
 

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -9,12 +9,12 @@
 $settings_tab_items = array(
 	array(
 		'slug'  => '',
-		'label' => 'General',
+		'label' => esc_html__( 'General', 'accessibility-checker' ),
 		'order' => 1,
 	),
 	array(
 		'slug'  => 'system_info',
-		'label' => 'System Info',
+		'label' => esc_html__( 'System Info', 'accessibility-checker' ),
 		'order' => 4,
 	),
 );
@@ -22,12 +22,13 @@ $settings_tab_items = array(
 if ( has_filter( 'edac_filter_settings_tab_items' ) ) {
 	$settings_tab_items = apply_filters( 'edac_filter_settings_tab_items', $settings_tab_items );
 }
+
 // sort settings tab items.
 if ( is_array( $settings_tab_items ) ) {
 	usort(
 		$settings_tab_items,
 		function( $a, $b ) {
-			return strcmp($b['order'], $a['order']);
+			return strcmp( $b['order'], $a['order'] );
 		}
 	);
 }
@@ -50,15 +51,7 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 			$query_var = $slug ? '&tab=' . $slug : '';
 			$label     = $settings_tab_item['label'];
 			?>
-			<a 
-			<?php
-			if ( $settings_tab === $slug ) :
-				?>
-aria-current="true" <?php endif; ?>href="?page=accessibility_checker_settings<?php echo esc_html( $query_var ); ?>" class="nav-tab 
-			<?php
-			if ( $settings_tab === $slug ) :
-				?>
-nav-tab-active<?php endif; ?>"><?php echo esc_html( $label ); ?></a>
+			<a <?php if ( $settings_tab === $slug ) : ?>aria-current="true" <?php endif; ?>href="?page=accessibility_checker_settings<?php echo esc_html( $query_var ); ?>" class="nav-tab <?php if ( $settings_tab === $slug ) : ?>nav-tab-active<?php endif; ?>"><?php echo esc_html( $label ); ?></a>
 			<?php
 		}
 		echo '</nav>';
@@ -88,7 +81,7 @@ nav-tab-active<?php endif; ?>"><?php echo esc_html( $label ); ?></a>
 		<?php } ?>
 
 		<?php if ( 'system_info' === $settings_tab ) { ?>
-			<h2><?php esc_html_e( 'System Info' ); ?></h2>	
+			<h2><?php esc_html_e( 'System Info', 'accessibility-checker' ); ?></h2>	
 			<div class="edac-settings-system-info">
 				<?php edac_sysinfo_display(); ?>
 			</div>	

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -16,124 +16,126 @@
 				<h1 class="edac-welcome-title">
 					<?php
 					if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) === true && EDAC_KEY_VALID === true ) {
-						$welcome_title = 'Accessibility Checker Pro';
+						$welcome_title = __('Accessibility Checker Pro', 'accessibility-checker');
 						$version       = EDACP_VERSION;
 					} else {
-						$welcome_title = 'Accessibility Checker';
+						$welcome_title = __('Accessibility Checker', 'accessibility-checker');
 						$version       = EDAC_VERSION;
 					}
 
 					echo $welcome_title;
-		
 					?>
 				</h1>
 				<p>
 					<?php 
-					echo 'version ' . $version;
+					printf( __('version %s', 'accessibility-checker' ), $version);
 					?>
-				</p>			
+				</p>
 			</div>
 
 		<div class="edac-welcome-header-right">
 				<a href="https://equalizedigital.com/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" target="_blank">
-					<img src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/Accessibility Checker logo transparent bg.svg" alt="Link to Equalize Digital Website">
+					<img src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/Accessibility Checker logo transparent bg.svg" alt="<?php _e('Link to Equalize Digital Website', 'accessibility-checker'); ?>">
 				</a>
 			</div>
 		</div>
 
-
 		<?php \EDAC\Welcome_Page::render_summary(); ?>
-
 
 		<section class="edac-welcome-section">
 			<div class="edac-welcome-quick-start">
-				<h2>Quick Start Guide</h2>
-				<p>Follow these steps to get started checking your content:</p>
+				<h2><?php _e('Quick Start Guide', 'accessibility-checker'); ?></h2>
+				<p><?php _e('Follow these steps to get started checking your content:', 'accessibility-checker'); ?></p>
 				<ol>
-					<li>On the <a href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings' ) ); ?>">Settings Page</a>, choose which post types you want to scan.</li>
-					<li>Go to the edit screen for the post you want to check.</li>
-					<li>Find the Accessibility Checker meta box below your content. If using a front-end page builder, you must visit the backend edit screen to view Accessibility Checker results.</li>
-					<li>If errors or warnings are present on your post, open the details tab in Accessibility Checker for more information.</li>
-					<li>Expand each issue to see the code, or click "view on page" if you need help finding the element that needs fixing.</li>
-					<li>If you don't know what an error or warning means, click the "i" icon to read the documentation and how to fix it.</li>
-					<li>If an issue is a false positive and the element is accessible, you can remove issues from reports with the "Ignore" feature.</li>
-					<li>After fixing each issue, update the post to see the accessibility report change. Your goal is to get every page to say 100% Passed Tests.</li>
+					<li>
+						<?php printf( __('On the <a href="%s">Settings Page</a>, choose which post types you want to scan.', 'accessibility-checker'), esc_url( admin_url( 'admin.php?page=accessibility_checker_settings' ) ) ); ?>
+					</li>
+					<li><?php _e('Go to the edit screen for the post you want to check.', 'accessibility-checker'); ?></li>
+					<li><?php _e('Find the Accessibility Checker meta box below your content. If using a front-end page builder, you must visit the backend edit screen to view Accessibility Checker results.', 'accessibility-checker'); ?></li>
+					<li><?php _e('If errors or warnings are present on your post, open the details tab in Accessibility Checker for more information.', 'accessibility-checker'); ?></li>
+					<li><?php _e('Expand each issue to see the code, or click "view on page" if you need help finding the element that needs fixing.', 'accessibility-checker'); ?></li>
+					<li><?php _e('If you don\'t know what an error or warning means, click the "i" icon to read the documentation and how to fix it.', 'accessibility-checker'); ?></li>
+					<li><?php _e('If an issue is a false positive and the element is accessible, you can remove issues from reports with the "Ignore" feature.', 'accessibility-checker'); ?></li>
+					<li><?php _e('After fixing each issue, update the post to see the accessibility report change. Your goal is to get every page to say 100% Passed Tests.', 'accessibility-checker'); ?></li>
 				</ol>
 				<p>
-					<a href="https://equalizedigital.com/accessibility-checker/getting-started-quick-guide/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page#demo">Watch a video of Accessibility Checker in use.</a>
+					<a href="https://equalizedigital.com/accessibility-checker/getting-started-quick-guide/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page#demo">
+						<?php _e('Watch a video of Accessibility Checker in use.', 'accessibility-checker'); ?>
+					</a>
 				</p>
 			</div>
 
 			<div class="edac-welcome-documentation">
-				<h2>Documentation and FAQs</h2>
+				<h2><?php _e('Documentation and FAQs', 'accessibility-checker'); ?></h2>
 				<ul>
-					<li><a href="https://a11ychecker.com/help4279" target="_blank">Why do we say 100% Passed Tests, Not 100% Accessible?</a></li>
-					<li><a href="https://a11ychecker.com/help4280" target="_blank">How to Manually Check Your Website for Accessibility</a></li>
-					<li><a href="https://a11ychecker.com/help4206" target="_blank">When to Ignore Accessibility Errors</a></li>
-					<li><a href="https://a11ychecker.com/help4114" target="_blank">What to do if a Plugin You’re Using has Accessibility Errors</a></li>
-					<li><a href="https://a11ychecker.com/help4386" target="_blank">What to do if there are Accessibility Errors in Your Theme</a></li>
-					<li><a href="https://a11ychecker.com/help4293" target="_blank">Can I Hire Equalize Digital to Fix Accessibility Issues on My Website?</a></li>
-					<li><a href="https://a11ychecker.com/help4285" target="_blank">Additional Resources for Learning About Accessibility</a></li>
+					<li><a href="https://a11ychecker.com/help4279" target="_blank"><?php _e('Why do we say 100% Passed Tests, Not 100% Accessible?', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
+					<li><a href="https://a11ychecker.com/help4280" target="_blank"><?php _e('How to Manually Check Your Website for Accessibility', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
+					<li><a href="https://a11ychecker.com/help4206" target="_blank"><?php _e('When to Ignore Accessibility Errors', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
+					<li><a href="https://a11ychecker.com/help4114" target="_blank"><?php _e('What to do if a Plugin You’re Using has Accessibility Errors', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
+					<li><a href="https://a11ychecker.com/help4386" target="_blank"><?php _e('What to do if there are Accessibility Errors in Your Theme', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
+					<li><a href="https://a11ychecker.com/help4293" target="_blank"><?php _e('Can I Hire Equalize Digital to Fix Accessibility Issues on My Website?', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
+					<li><a href="https://a11ychecker.com/help4285" target="_blank"><?php _e('Additional Resources for Learning About Accessibility', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></li>
 				</ul>
-				<p><a class="button" href="https://a11ychecker.com/" target="_blank">Read Full Documentation</a></p>
+				<p><a class="button" href="https://a11ychecker.com/" target="_blank"><?php _e('Read Full Documentation', 'accessibility-checker'); ?> <span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span></a></p>
 			</div>
 		</section>
 
 		<section class="edac-support-section">
-			<h2>Support Information</h2>
+			<h2><?php _e('Support Information', 'accessibility-checker'); ?></h2>
 		
 			<div class="edac-flex-container">
 		<?php
 		if (  edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
 			?>
 				<div class="edac-flex-item edac-flex-item-33 edac-background-light">
-					<h3>Plugin Support</h3>
+					<h3><?php _e('Plugin Support', 'accessibility-checker'); ?></h3>
 					<p>
-						Active license holders of paid Accessibility Checker plans
-						get unlimited email support on plugin usage and troubleshooting.
+						<?php _e('Active license holders of paid Accessibility Checker plans get unlimited email support on plugin usage and troubleshooting.', 'accessibility-checker'); ?>
 					</p>
 					<p>
-						<a href="https://my.equalizedigital.com/support/pro-support/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" class="button">Open Support Ticket</a>
+						<a href="https://my.equalizedigital.com/support/pro-support/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" class="button"><?php _e('Open Support Ticket', 'accessibility-checker'); ?></a>
 					</p>
-				</div>	
+				</div>
 			<?php
 		} else {
 			?>
 				<div class="edac-flex-item edac-flex-item-33 edac-background-light">
-					<h3>Free Plugin Support</h3>
+					<h3><?php _e('Free Plugin Support', 'accessibility-checker'); ?></h3>
 					<p>
-						Free plugin support is available via the WordPress.org forums. You'll need to create an account
-						then you can open a new support thread.
+						<?php _e('Free plugin support is available via the WordPress.org forums. You\'ll need to create an account then you can open a new support thread.', 'accessibility-checker'); ?>
 					</p>
 					<p>
-						<a href="https://wordpress.org/support/plugin/accessibility-checker/" class="button">Go to Support Forum</a>
+						<a href="https://wordpress.org/support/plugin/accessibility-checker/" class="button"><?php _e('Go to Support Forum', 'accessibility-checker'); ?></a>
 					</p>
-				</div>	
+				</div>
 			<?php
 		}
 		?>
 			
 				<div class="edac-flex-item edac-flex-item-33 edac-background-light">
-					<h3>Office Hours</h3>
+					<h3><?php _e('Office Hours', 'accessibility-checker'); ?></h3>
 					<p>
-						Open Q&A on Zoom every other week to help you remediate your website.
-						<a href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page">Included in Small Business and Agency plans</a>.
+						<?php _e('Open Q&A on Zoom every other week to help you remediate your website.', 'accessibility-checker'); ?>
+						<a href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page">
+						<?php _e('Included in Small Business and Agency plans', 'accessibility-checker'); ?></a>.
 					</p>
 					<p>
-						<a href="https://my.equalizedigital.com/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" class="button">Register for Office Hours</a>
+						<a href="https://my.equalizedigital.com/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" class="button">
+						<?php _e('Register for Office Hours', 'accessibility-checker'); ?></a>
 					</p>
-				</div>	
-			
+				</div>
+
 				<div class="edac-flex-item edac-flex-item-33 edac-background-light">
-					<h3>Auditing and Remediation</h3>
+					<h3><?php _e('Auditing and Remediation', 'accessibility-checker'); ?></h3>
 					<p>
-						Get help making your website accessible. Expert auditing, user testing,
-						and dev support. Conformance letters available.
+						<?php _e('Get help making your website accessible. Expert auditing, user testing, and dev support. Conformance letters available.', 'accessibility-checker'); ?>
 					</p>
 					<p>
-						<a href="https://equalizedigital.com/services/website-accessibility-remediation/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" class="button">Get Remediation Help</a>
+						<a href="https://equalizedigital.com/services/website-accessibility-remediation/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=welcome-page" class="button">
+						<?php _e('Get Remediation Help', 'accessibility-checker'); ?></a>
 					</p>
-				</div>	
+				</div>
+	
 			</div>		
 	</section>
 
@@ -151,25 +153,30 @@
 	if ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || ! EDAC_KEY_VALID ) {
 		?>
 		<div class="edac-pro-callout edac-mt-3 edac-mb-3">
-			<img class="edac-pro-callout-icon" src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/edac-emblem.png" alt="Equalize Digital Logo">
-			<h4 class="edac-pro-callout-title">Upgrade to Accessibility Checker Pro</h4>
+			<img class="edac-pro-callout-icon" src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/edac-emblem.png" alt="<?php _e('Equalize Digital Logo', 'accessibility-checker'); ?>">
+			<h4 class="edac-pro-callout-title"><?php _e('Upgrade to Accessibility Checker Pro', 'accessibility-checker'); ?></h4>
 			<div>
 				<ul class="edac-pro-callout-list">
-					<li>Scan all post types</li>
-					<li>Admin columns to see accessibility status at a glance</li>
-					<li>Centralized list of all open issues</li>
-					<li>Ignore log</li>
-					<li>Rename simplified summary</li>
-					<li>User restrictions on ignoring issues</li>
-					<li>Email support</li>
-					<li>...and more</li>
+					<li><?php _e('Scan all post types', 'accessibility-checker'); ?></li>
+					<li><?php _e('Admin columns to see accessibility status at a glance', 'accessibility-checker'); ?></li>
+					<li><?php _e('Centralized list of all open issues', 'accessibility-checker'); ?></li>
+					<li><?php _e('Ignore log', 'accessibility-checker'); ?></li>
+					<li><?php _e('Rename simplified summary', 'accessibility-checker'); ?></li>
+					<li><?php _e('User restrictions on ignoring issues', 'accessibility-checker'); ?></li>
+					<li><?php _e('Email support', 'accessibility-checker'); ?></li>
+					<li><?php _e('...and more', 'accessibility-checker'); ?></li>
 				</ul>
 			</div>
-			<a class="edac-pro-callout-button" href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank">Get Accessibility Checker Pro</a>';
+			<a class="edac-pro-callout-button" href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank">
+				<?php _e('Get Accessibility Checker Pro', 'accessibility-checker'); ?> 
+				<span class="screen-reader-text"><?php _e('(opens in a new window)', 'accessibility-checker'); ?></span>
+			</a>
 		<?php	
 		if ( edac_check_plugin_installed( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) {
 			?>
-			<br /><a class="edac-pro-callout-activate" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=license' ) ); ?>">Or activate your license key here.</a>
+			<br /><a class="edac-pro-callout-activate" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=license' ) ); ?>">
+				<?php _e('Or activate your license key here.', 'accessibility-checker'); ?>
+			</a>
 			<?php
 		}
 		?>
@@ -182,7 +189,7 @@
 
 		<div class="edac-panel">
 			<h2 class="edac-summary-header">
-				Learn Accessibility
+				<?php _e('Learn Accessibility', 'accessibility-checker'); ?>
 			</h2>
 			<?php
 			echo edac_get_upcoming_meetups_html( 'wordpress-accessibility-meetup-group', 2 );

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -60,7 +60,7 @@
     /**
      * Ajax Summary
      */
-    function edac_summary_ajax() {
+    function edac_summary_ajax( callback = null ) {
 
       let post_id = edac_script_vars.postID;
 
@@ -96,6 +96,11 @@
 
           $(".edac-summary").html(response_json.content);
 
+          if (typeof callback == "function") {
+                callback();
+          }
+
+       
         } else {
 
           console.log(response);
@@ -221,8 +226,7 @@
 
                 let response_json = $.parseJSON(response.data);
 
-                edac_readability_ajax();
-                edac_summary_ajax();
+                edac_summary_ajax( edac_readability_ajax );
 
               } else {
 
@@ -271,9 +275,8 @@
           // Wait a bit to give js scan/save time to complete.
           //TODO: listen for a saveComplete event.
           setTimeout(function () {
-            edac_summary_ajax();
+            edac_summary_ajax( edac_readability_ajax );
             edac_details_ajax();
-            edac_readability_ajax();
             $(".edac-panel").removeClass("edac-panel-loading");
 
           }, 1000);

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -370,7 +370,7 @@ class AccessibilityCheckerHighlight {
 			<div class="edac-highlight-panel">
 			<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="Accessibility Checker Tools"></button>
 			<div id="edac-highlight-panel-description" class="edac-highlight-panel-description" role="dialog" aria-labelledby="edac-highlight-panel-description-title" tabindex="0">
-			<button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="Close">×</button>
+			<button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-description-close edac-highlight-panel-controls-close" aria-label="Close">×</button>
 				<div class="edac-highlight-panel-description-title"></div>
 				<div class="edac-highlight-panel-description-content"></div>
 				<div id="edac-highlight-panel-description-code" class="edac-highlight-panel-description-code"><code></code></div>			

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -368,7 +368,7 @@ class AccessibilityCheckerHighlight {
 	addHighlightPanel() {
 		const newElement = `
 			<div class="edac-highlight-panel">
-			<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog">Accessibility Checker Tools</button>
+			<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="Accessibility Checker Tools"></button>
 			<div id="edac-highlight-panel-description" class="edac-highlight-panel-description" role="dialog" aria-labelledby="edac-highlight-panel-description-title" tabindex="0">
 			<button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="Close">×</button>
 				<div class="edac-highlight-panel-description-title"></div>


### PR DESCRIPTION
edac_readability_ajax depends on edac_summary_ajax running and completing edac_summary before being called, otherwise edac_readability_ajax will return results based on the previously run edac_summary. This fix allows us to pass a js callback to edac_readability_ajax so we can run the edac_readability_ajax call after edax_summary_ajax is complete.
