### PR TITLE
Fixes #308

### DIFF
--- a/includes/classes/class-issues-query.php
+++ b/includes/classes/class-issues-query.php
@@ -192,6 +192,23 @@ class Issues_Query {
 	}
 
 	/**
+	 * Gets distinct posts count.
+	 *    
+	 * @return integer posts_count .
+	 */
+	public function distinct_posts_count() {
+
+		global $wpdb;
+
+		$this->query['select'] = 'SELECT COUNT( DISTINCT postid ) ';
+		
+		$sql = $this->get_sql();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return $wpdb->get_var( $sql );
+	}
+
+	/**
 	 * Get the ids of the issues.
 	 *    
 	 * @return array issues .

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -338,7 +338,7 @@ class REST_Api {
 			);
 			unset( $post_types['attachment'] );
 		
-			$scans_stats = new Scans_Stats();   
+			$scans_stats = new Scans_Stats( 60 * 5 );   
 	
 			$post_types_to_check = array_merge( array( 'post', 'page' ), $scannable_post_types );
 					
@@ -384,7 +384,7 @@ class REST_Api {
 
 		try {
 
-			$scans_stats = new Scans_Stats();   
+			$scans_stats = new Scans_Stats( 60 * 5 );   
 
 			$scannable_post_types = Settings::get_scannable_post_types();
 				

--- a/includes/classes/class-settings.php
+++ b/includes/classes/class-settings.php
@@ -72,14 +72,18 @@ class Settings {
 		
 		$post_statuses = self::get_scannable_post_statuses();
 
-		$sql = "SELECT COUNT(id) FROM {$wpdb->posts}  WHERE post_type IN(" . 
+		if($post_types && $post_statuses){
+			$sql = "SELECT COUNT(id) FROM {$wpdb->posts}  WHERE post_type IN(" . 
 				Helpers::array_to_sql_safe_list( $post_types ) . ') and post_status IN(' .
 				Helpers::array_to_sql_safe_list( $post_statuses ) . 
 			')';
-		
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$scannable_posts_count = $wpdb->get_var( $sql );
+	
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$scannable_posts_count = $wpdb->get_var( $sql );
 
+		} else {
+			$scannable_posts_count = 0;
+		}
 		return $scannable_posts_count;
 	}
 }

--- a/includes/classes/class-widgets.php
+++ b/includes/classes/class-widgets.php
@@ -25,12 +25,14 @@ class Widgets {
 	
 		<div class="edac-widget">';
 		
-		$pro_modal_html = '';
-		if ( ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || 
+		if ( Settings::get_scannable_post_types() && Settings::get_scannable_post_statuses() ) {
+		
+			$pro_modal_html = '';
+			if ( ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || 
 			false == EDAC_KEY_VALID ) &&
 			true !== boolval( get_user_meta( get_current_user_id(), 'edac_dashboard_cta_dismissed', true ) ) 
-		) {
-			$pro_modal_html = '
+			) {
+				$pro_modal_html = '
 			<div class="edac-modal">
 				<div class="edac-modal-content">
 					<button class="edac-modal-content-close edac-widget-modal-content-close" aria-label="' . esc_attr__( 'close ad', 'accessibility-checker' ) . '">&times;</button>
@@ -41,19 +43,19 @@ class Widgets {
 					</p>
 				</div>
 			</div>';
-		}
+			}
 	
-		if ( ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' != $pro_modal_html ) {
+			if ( ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' != $pro_modal_html ) {
 	
-			$html .= '
+				$html .= '
 			<div class="edac-summary edac-modal-container edac-hidden">';
 
-			$html .= $pro_modal_html;
+				$html .= $pro_modal_html;
 		
-			$html .= '
+				$html .= '
 			<h3 class="edac-summary-header">' . 
 				__( 'Full Site Accessibility Status', 'accessibility-checker' ) . 
-			'</h3>
+				'</h3>
 			<div class="edac-summary-passed">
 				<div id="edac-summary-passed" class="edac-circle-progress" role="progressbar" aria-valuenow="0" 
 					aria-valuemin="0" aria-valuemax="100"
@@ -72,7 +74,7 @@ class Widgets {
 					<div class="edac-summary-info-date-label">' . __( 'Last Full-Site Scan:', 'accessibility-checker' ) . '</div>
 					<div id="edac-summary-info-date" class="edac-summary-info-date-date edac-timestamp-to-local">-</div>';
 		
-			$html .= '
+				$html .= '
 				</div>
 
 				<div class="edac-summary-info-count">
@@ -82,7 +84,7 @@ class Widgets {
 					<div id="edac-summary-info-count" class="edac-summary-info-count-number">-</div>
 				</div>';
 
-			$html .= '
+				$html .= '
 				<div class="edac-summary-info-stats">
 					<div  class="edac-summary-info-stats-box edac-summary-info-stats-box-error">
 						<div class="edac-summary-info-stats-box-label">' . __( 'Errors:', 'accessibility-checker' ) . ' </div>
@@ -100,7 +102,7 @@ class Widgets {
 			</div>
 			';
 			
-			$html .= '
+				$html .= '
 			<div class="edac-summary-notice edac-summary-notice-has-issues edac-hidden">
 				' . __( 'Your site has accessibility issues that should be addressed as soon as possible to ensure compliance with accessibility guidelines.', 'accessibility-checker' ) . '
 			</div>
@@ -108,12 +110,13 @@ class Widgets {
 				' . __( 'Way to go! Accessibility Checker cannot find any accessibility problems in the content it tested. Some problems cannot be found by automated tools so don\'t forget to', 'accessibility-checker' ) . ' <a href="https://equalizedigital.com/accessibility-checker/how-to-manually-check-your-website-for-accessibility/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">' . __( 'manually test your site', 'accessibility-checker' ) . '</a>.
 			</div>';
 		
-			$html .= '
+				$html .= '
 		</div>
 		<hr class="edac-hr" />';
 		
+			}
 		}
-
+	
 		$html .= '
 		
 		<div class="edac-issues-summary edac-hidden">
@@ -211,6 +214,13 @@ class Widgets {
 		
 		$html .= '<div class="edac-summary-notice edac-summary-notice-is-truncated edac-hidden">Your site has a large number of issues. For performance reasons, not all issues have been included in this report.</div>';
 	
+		if ( ! Settings::get_scannable_post_types() || ! Settings::get_scannable_post_statuses() ) {
+
+			$html .= '<div class="edac-summary-notice edac-summary-notice-no-posts">There are no pages set to be checked. Update the post types to be checked under the 
+			<a href="/wp-admin/admin.php?page=accessibility_checker_settings">general settings</a> tab.</div>';
+	
+		}
+
 		
 		$html .= '
 		<div class="edac-buttons-container edac-mt-3 edac-mb-3">

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -5,6 +5,8 @@
  * @package Accessibility_Checker
  */
 
+use EDAC\Scans_Stats;
+
 /**
  * Check if user can ignore or can manage options
  *
@@ -412,6 +414,16 @@ function edac_sanitize_post_types( $selected_post_types ) {
 		}
 	}
 
+	// clear cached stats if selected posts types change.
+	if ( get_option( 'edac_post_types' ) !== $selected_post_types ) {
+		$scan_stats = new \EDAC\Scans_Stats();
+		$scan_stats->clear_cache();
+
+		if ( class_exists( '\EDACP\Scans' ) ) {
+			delete_option( 'edacp_fullscan_completed_at' );
+		}
+	}
+	
 	return $selected_post_types;
 }
 

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -576,7 +576,6 @@ const fillDashboardWidget = () => {
   getData(edac_script_vars.edacApiUrl + '/scans-stats').then((data) => {
     if(data.success){
  
-      
       // Set passed %
       const passed_percentage = data.stats.passed_percentage;
       const passed_percentage_el = document.querySelector('#edac-summary-passed');
@@ -654,9 +653,11 @@ const fillDashboardWidget = () => {
           has_issues_notice_el.classList.remove('edac-hidden');
         }
       } else {
-        const has_no_issues_notice_el = document.querySelector('.edac-summary-notice-no-issues');
-        if(has_no_issues_notice_el){
-          has_no_issues_notice_el.classList.remove('edac-hidden');
+        if(posts_scanned > 0){
+          const has_no_issues_notice_el = document.querySelector('.edac-summary-notice-no-issues');
+          if(has_no_issues_notice_el){
+            has_no_issues_notice_el.classList.remove('edac-hidden');
+          }
         }
       }
 


### PR DESCRIPTION
If approved this PR will:
- [Correct the error](#308) on the widget and welcome screens.
- Show a notice on the widget if there are no pages set to be scanned.
- Cache widget scan stats for 5 minutes.
- Clear the cached scan stats when the selected page types are changed or when a full scan is completed.

Notice shown if no pages are set to be scanned:
<img width="624" alt="Screenshot 2023-09-18 at 2 53 28 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/f27b29fc-6842-42f2-8452-e6212ed8f8c8">

Widget after the selected pages types are changed but before a scan:
<img width="623" alt="Screenshot 2023-09-18 at 2 53 50 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/8fa06a96-5826-4232-86b4-e455d0720180">

Welcome after the selected pages types are changed but before a scan:
<img width="1073" alt="Screenshot 2023-09-18 at 3 03 44 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/dd375b65-74a4-440f-b74e-9f355a85a7a8">
