### PR TITLE
Fixes #332

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -727,3 +727,51 @@ function edac_count_dom_descendants( $dom_elements ) {
 
 	return $count;
 }
+
+
+
+if ( ! function_exists( 'getallheaders' ) ) {
+
+	/**
+	 * Get all HTTP header key/values as an associative array for the current request.
+	 *
+	 * @see https://github.com/ralouphie/getallheaders/raw/develop/src/getallheaders.php
+	 *
+	 * @return string[string] The HTTP header key/value pairs.
+	 */
+	function getallheaders() {
+		$headers = array();
+
+		$copy_server = array(
+			'CONTENT_TYPE'   => 'Content-Type',
+			'CONTENT_LENGTH' => 'Content-Length',
+			'CONTENT_MD5'    => 'Content-Md5',
+		);
+
+		foreach ( $_SERVER as $key => $value ) {
+			if ( substr( $key, 0, 5 ) === 'HTTP_' ) {
+				$key = substr( $key, 5 );
+				if ( ! isset( $copy_server[ $key ] ) || ! isset( $_SERVER[ $key ] ) ) {
+					$key             = str_replace( ' ', '-', ucwords( strtolower( str_replace( '_', ' ', $key ) ) ) );
+					$headers[ $key ] = $value;
+				}
+			} elseif ( isset( $copy_server[ $key ] ) ) {
+				$headers[ $copy_server[ $key ] ] = $value;
+			}
+		}
+
+		if ( ! isset( $headers['Authorization'] ) ) {
+			if ( isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ) {
+				$headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+			} elseif ( isset( $_SERVER['PHP_AUTH_USER'] ) ) {
+				$basic_pass               = isset( $_SERVER['PHP_AUTH_PW'] ) ? $_SERVER['PHP_AUTH_PW'] : '';
+				$headers['Authorization'] = 'Basic ' . base64_encode( $_SERVER['PHP_AUTH_USER'] . ':' . $basic_pass );
+			} elseif ( isset( $_SERVER['PHP_AUTH_DIGEST'] ) ) {
+				$headers['Authorization'] = $_SERVER['PHP_AUTH_DIGEST'];
+			}
+		}
+
+		return $headers;
+	}
+
+}


### PR DESCRIPTION
Not sure if this makes sense or not to merge.

getallheaders is apache specific (but php-fpm/nginx outputs the same headers) but should be available in php by default - I think issue is a playground edge case.