### PR TITLE
Fix: Correct callback func for rest endpoint

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -134,23 +134,6 @@ class REST_Api {
 					'/scans-stats-by-post-type/(?P<slug>[a-zA-Z0-9_-]+)',
 					array(
 						'methods'             => 'GET',
-						'callback'            => array( $this, 'get_scans_stats' ),
-						'permission_callback' => function () {
-							return current_user_can( 'read' ); // able to access the admin dashboard.
-						},
-					) 
-				);
-			} 
-		);
-
-		add_action(
-			'rest_api_init',
-			function () use ( $ns, $version ) {
-				register_rest_route(
-					$ns . $version,
-					'/scans-stats-by-post-type/(?P<slug>[a-zA-Z0-9_-]+)',
-					array(
-						'methods'             => 'GET',
 						'callback'            => array( $this, 'get_scans_stats_by_post_type' ),
 						'permission_callback' => function () {
 							return current_user_can( 'read' ); // able to access the admin dashboard.


### PR DESCRIPTION
Rest API route : /scans-stats-by-post-type/ is not working as expected.

This same route with same ( GET ) endpoint is declared twice with different callbacks
As a result the first callback function is getting executed on calls which is already used 
in /scans-stats/ route.

If this PR approves it will: 

 - Add the correct callback function 'get_scans_stats_by_post_type' on '/scans-stats-by-post-type/(?P<slug>[a-zA-Z0-9_-]+)'
 - Remove the duplicate route registration