### PR TITLE
Fix: PHP 8+ warning automatic conversion of false to array is deprecated

### DIFF
--- a/includes/classes/class-scans-stats.php
+++ b/includes/classes/class-scans-stats.php
@@ -372,7 +372,7 @@ class Scans_Stats {
 	
 		$transient_name = $this->cache_name_prefix . '_issues_summary_by_post_type_' . $post_type;
 
-		$cache = get_transient( $transient_name );
+		$cache = get_transient( $transient_name ) ?: array();
 	
 		if ( $this->cache_time && $cache ) {
 


### PR DESCRIPTION
Function 'issues_summary_by_post_type' in class-scans-stats.php is calling get_transient and storing the result in $cache

get_transient can return false and at the bottom of this function the cache variable is used in array context without any checks for falsy values.

This through warning on servers with PHP 8+ check the screenshot below:

![php-warning](https://github.com/equalizedigital/accessibility-checker/assets/82345120/40c4b182-50f8-4004-acf6-1ea5965fecb2)

This PR:

 - Solves the warning by assigning empty array to $cache if the result of get_transient is falsy.
 - This may solve syntax issue related message  in browser console you get when the JSON format is incorrect. 