### PR TITLE
Run PHPCS in PRs, for modified files

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,6 +1,8 @@
 name: PHPCS check
 on:
-  push
+  push:
+    paths:
+      - '**.php'
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -33,5 +35,4 @@ jobs:
         # `grep` to only PHP files then remove deleted files via `find`.
         # Run `phpcs` on the remaining files and pass output to `cs2pr`.
         run: |
-          gh pr diff ${{ github.event.number }} --name-only | grep .php | xargs find 2> /dev/null | cat
           gh pr diff ${{ github.event.number }} --name-only | grep .php | xargs find 2> /dev/null | xargs vendor/bin/phpcs -nq --report=checkstyle --report-full --report-checkstyle=./phpcs-report.xml | cs2pr

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,33 @@
+name: PHPCS check
+on:
+  push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: PHPCS check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "7.4"
+          ini-values: "memory_limit=1G"
+          coverage: none
+          tools: cs2pr
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+
+      - name: Run PHPCS checks
+        continue-on-error: true
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -29,7 +29,6 @@ jobs:
         uses: "ramsey/composer-install@v2"
 
       - name: Run PHPCS checks
-        continue-on-error: true
         # Get the changed files from the PR via Github CLI.
         # `grep` to only PHP files then remove deleted files via `find`.
         # Run `phpcs` on the remaining files and pass output to `cs2pr`.

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -2,6 +2,9 @@ name: PHPCS check
 on:
   push
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,6 +1,6 @@
 name: PHPCS check
 on:
-  push:
+  pull_request:
     paths:
       - '**.php'
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Run PHPCS checks
         continue-on-error: true
-        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
-
-      - name: Show PHPCS results in PR
-        run: cs2pr ./phpcs-report.xml
+        # Get the changed files from the PR via Github CLI.
+        # `grep` to only PHP files then remove deleted files via `find`.
+        # Run `phpcs` on the remaining files and pass output to `cs2pr`.
+        run: |
+          gh pr diff ${{ github.event.number }} --name-only | grep .php | xargs find 2> /dev/null | cat
+          gh pr diff ${{ github.event.number }} --name-only | grep .php | xargs find 2> /dev/null | xargs vendor/bin/phpcs -nq --report=checkstyle --report-full --report-checkstyle=./phpcs-report.xml | cs2pr


### PR DESCRIPTION
This PR adds a workflow in PRs to do the following:
* Checks if there are any PHP files changed in the PR
* If any PHP files were changed, then run `phpcs` to those files.

This way, Coding Standards rules can be applied incrementally. If someone makes a change to a PHP file, then the whole file will be checked and any errors will be reported and required to be fixed before the PR gets merged.

The alternative would be to create a massive PR fixing all CS issues at once, but that would be extremely difficult to properly review. 

Having an action consistently run in PRs will help improve and maintain the code quality of this project 👍 