### PR TITLE
Coding Standards & code-quality tweaks

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -769,8 +769,8 @@ function edac_before_page_render() {
 
 	global $pagenow;
 
-	if ( 'index.php' == $pagenow && false == is_customize_preview() && current_user_can( 'edit_posts' ) ) {
-	
+	if ( 'index.php' === $pagenow && false === is_customize_preview() && current_user_can( 'edit_posts' ) ) {
+
 		// Check the page if it hasn't already been checked.
 		global $post;
 		$checked = get_post_meta( $post->ID, '_edac_post_checked', true );
@@ -792,7 +792,7 @@ function edac_wp_dashboard_setup() {
 		array(
 			'\EDAC\Widgets',
 			'render_dashboard_scan_summary',
-		) 
+		)
 	);
 }
 
@@ -837,19 +837,18 @@ function edac_summary_ajax() {
 	$summary                   = edac_summary( $post_id );
 	$simplified_summary_text   = '';
 	$simplified_summary_prompt = get_option( 'edac_simplified_summary_prompt' );
-	
-	
+
 	if ( 'none' !== $simplified_summary_prompt ) {
-		
+
 		if ( $summary['content_grade'] <= 9 ) {
 			$simplified_summary_text = 'Your content has a reading level at or below 9th grade and does not require a simplified summary.';
 		} else {
 			$simplified_summary_text = $summary['simplified_summary'] ? 'A Simplified summary has been included for this content.' : 'A Simplified summary has not been included for this content.';
-		}   
+		}
 	} else {
-	
+
 		$simplified_summary_text = 'A Simplified summary has not been included for this content.';
-	
+
 	}
 
 	$html['content'] .= '<div class="edac-summary-total">';
@@ -957,8 +956,8 @@ function edac_summary( $post_id ) {
 			$postid = $post_id;
 			$siteid = get_current_blog_id();
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-			$rule_count = $wpdb->get_var( $wpdb->prepare( "SELECT count(*) FROM {$table_name} where rule = %s and siteid = %d and postid = %d and ignre = %d", $rule['slug'], $siteid, $postid, 0 ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching  -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+			$rule_count = $wpdb->get_var( $wpdb->prepare( 'SELECT count(*) FROM %i where rule = %s and siteid = %d and postid = %d and ignre = %d', $table_name, $rule['slug'], $siteid, $postid, 0 ) );
 
 			if ( ! $rule_count ) {
 				$rules_passed[] = $rule['slug'];
@@ -968,10 +967,8 @@ function edac_summary( $post_id ) {
 
 	$summary['passed_tests'] = round( count( $rules_passed ) / count( $rules ) * 100 );
 
-	// count errors.
-	$query = 'SELECT count(*) FROM ' . $table_name . ' where siteid = %d and postid = %d and ruletype = %s and ignre = %d';
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-	$summary['errors'] = intval( $wpdb->get_var( $wpdb->prepare( $query, get_current_blog_id(), $post_id, 'error', 0 ) ) );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+	$summary['errors'] = intval( $wpdb->get_var( $wpdb->prepare( 'SELECT count(*) FROM %i where siteid = %d and postid = %d and ruletype = %s and ignre = %d', $table_name, get_current_blog_id(), $post_id, 'error', 0 ) ) );
 
 	// count warnings.
 	$warnings_parameters = array( get_current_blog_id(), $post_id, 'warning', 0 );
@@ -991,14 +988,12 @@ function edac_summary( $post_id ) {
 		array_push( $ignored_parameters, 'link_blank' );
 		$ignored_where .= ' and rule != %s';
 	}
-	$query = 'SELECT count(*) FROM ' . $table_name . ' ' . $ignored_where;
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-	$summary['ignored'] = intval( $wpdb->get_var( $wpdb->prepare( $query, $ignored_parameters ) ) );
 
-	// contrast errors.
-	$query = 'SELECT count(*) FROM ' . $table_name . ' where siteid = %d and postid = %d and rule = %s and ignre = %d';
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-	$summary['contrast_errors'] = intval( $wpdb->get_var( $wpdb->prepare( $query, get_current_blog_id(), $post_id, 'color_contrast_failure', 0 ) ) );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared , WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+	$summary['ignored'] = intval( $wpdb->get_var( $wpdb->prepare( "SELECT count(*) FROM $table_name $ignored_where", $ignored_parameters ) ) );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+	$summary['contrast_errors'] = intval( $wpdb->get_var( $wpdb->prepare( 'SELECT count(*) FROM %i where siteid = %d and postid = %d and rule = %s and ignre = %d', $table_name, get_current_blog_id(), $post_id, 'color_contrast_failure', 0 ) ) );
 
 	// remove color contrast from errors count.
 	$summary['errors'] = $summary['errors'] - $summary['contrast_errors'];
@@ -1007,21 +1002,20 @@ function edac_summary( $post_id ) {
 	$issue_count = $summary['warnings'] + $summary['errors'] + $summary['contrast_errors'];
 
 	$issue_density_array = get_post_meta( $post_id, '_edac_density_data' );
-	
-	
+
 	if ( is_array( $issue_density_array ) &&
 		count( $issue_density_array ) > 0 &&
-		count( $issue_density_array[0] ) > 0  
+		count( $issue_density_array[0] ) > 0
 	) {
-		
+
 		$element_count  = $issue_density_array[0][0];
 		$content_length = $issue_density_array[0][1];
-		
+
 		$issue_density = edac_get_issue_density( $issue_count, $element_count, $content_length );
-	
+
 		if ( ! add_post_meta( $post_id, '_edac_issue_density', $issue_density, true ) ) {
 			update_post_meta( $post_id, '_edac_issue_density', $issue_density );
-		}   
+		}
 	} else {
 		delete_post_meta( $post_id, '_edac_issue_density' );
 	}
@@ -1038,7 +1032,7 @@ function edac_summary( $post_id ) {
 	} else {
 		$summary['content_grade'] = 0;
 	}
-	
+
 	$summary['readability'] = ( 0 === $summary['content_grade'] ) ? 'N/A' : edac_ordinal( $summary['content_grade'] );
 
 	// simplified summary.
@@ -1106,8 +1100,8 @@ function edac_update_post_meta( $rule ) {
 	global $wpdb;
 	$site_id = get_current_blog_id();
 
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-	$posts = $wpdb->get_results( $wpdb->prepare( 'SELECT postid FROM ' . $wpdb->prefix . 'accessibility_checker WHERE rule = %s and siteid = %d', $rule, $site_id ), ARRAY_A );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+	$posts = $wpdb->get_results( $wpdb->prepare( 'SELECT postid FROM %i WHERE rule = %s and siteid = %d', $wpdb->prefix . 'accessibility_checker', $rule, $site_id ), ARRAY_A );
 
 	if ( $posts ) {
 		foreach ( $posts as $post ) {
@@ -1190,8 +1184,8 @@ function edac_details_ajax() {
 		// add count, unset passed error rules and add passed rules to array.
 		if ( $error_rules ) {
 			foreach ( $error_rules as $key => $error_rule ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-				$count = count( $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment FROM ' . $table_name . ' where postid = %d and rule = %s and siteid = %d and ignre = %d', $postid, $error_rule['slug'], $siteid, 0 ), ARRAY_A ) );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+				$count = count( $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment FROM %i where postid = %d and rule = %s and siteid = %d and ignre = %d', $table_name, $postid, $error_rule['slug'], $siteid, 0 ), ARRAY_A ) );
 				if ( $count ) {
 					$error_rules[ $key ]['count'] = $count;
 				} else {
@@ -1205,8 +1199,8 @@ function edac_details_ajax() {
 		// add count, unset passed warning rules and add passed rules to array.
 		if ( $warning_rules ) {
 			foreach ( $warning_rules as $key => $error_rule ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-				$count = count( $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment FROM ' . $table_name . ' where postid = %d and rule = %s and siteid = %d and ignre = %d', $postid, $error_rule['slug'], $siteid, 0 ), ARRAY_A ) );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+				$count = count( $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment FROM %i where postid = %d and rule = %s and siteid = %d and ignre = %d', $table_name, $postid, $error_rule['slug'], $siteid, 0 ), ARRAY_A ) );
 				if ( $count ) {
 					$warning_rules[ $key ]['count'] = $count;
 				} else {
@@ -1256,8 +1250,8 @@ function edac_details_ajax() {
 			$ignore_permission = apply_filters( 'edac_ignore_permission', $ignore_permission );
 		}
 		foreach ( $rules as $rule ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-			$results        = $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment, ignre_global FROM ' . $table_name . ' where postid = %d and rule = %s and siteid = %d', $postid, $rule['slug'], $siteid ), ARRAY_A );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+			$results        = $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment, ignre_global FROM %i where postid = %d and rule = %s and siteid = %d', $table_name, $postid, $rule['slug'], $siteid ), ARRAY_A );
 			$count_classes  = ( 'error' === $rule['rule_type'] ) ? ' edac-details-rule-count-error' : ' edac-details-rule-count-warning';
 			$count_classes .= ( 0 !== $rule['count'] ) ? ' active' : '';
 
@@ -1271,8 +1265,8 @@ function edac_details_ajax() {
 				}
 			}
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-			$expand_rule = count( $wpdb->get_results( $wpdb->prepare( 'SELECT id FROM ' . $table_name . ' where postid = %d and rule = %s and siteid = %d', $postid, $rule['slug'], $siteid ), ARRAY_A ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
+			$expand_rule = count( $wpdb->get_results( $wpdb->prepare( 'SELECT id FROM %i where postid = %d and rule = %s and siteid = %d', $table_name, $postid, $rule['slug'], $siteid ), ARRAY_A ) );
 
 			$tool_tip_link = edac_documentation_link( $rule );
 
@@ -1478,7 +1472,7 @@ function edac_readability_ajax() {
 	}
 	$content = wp_filter_nohtml_kses( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );
-	
+
 	// get readability metadata and determine if a simplified summary is required.
 	$edac_summary           = get_post_meta( $post_id, '_edac_summary', true );
 	$post_grade_readability = ( isset( $edac_summary['readability'] ) ) ? $edac_summary['readability'] : 0;
@@ -1491,7 +1485,7 @@ function edac_readability_ajax() {
 	} else {
 		$simplified_summary_grade = 0;
 	}
-	
+
 	$simplified_summary_grade_failed = ( $simplified_summary_grade > 9 ) ? true : false;
 	$simplified_summary_prompt       = get_option( 'edac_simplified_summary_prompt' );
 
@@ -1520,7 +1514,7 @@ function edac_readability_ajax() {
 		}
 
 		if ( 'none' === $simplified_summary_prompt ) {
-		
+
 			$html .=
 			'<li class="edac-readability-list-item edac-readability-summary-position">
 				<span class="edac-readability-list-item-icon"><img src="' . plugin_dir_url( __FILE__ ) . 'assets/images/warning icon yellow.png" alt="" width="22"></span>
@@ -1528,7 +1522,6 @@ function edac_readability_ajax() {
 					<p class="edac-readability-list-item-description">Your Prompt for Simplified Summary is set to "never." If you would like the simplified summary to be displayed automatically, you can change this on the <a href="' . get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=accessibility_checker_settings">settings page</a>.</p>
 			</li>';
 
-			
 		} elseif ( 'none' !== $simplified_summary_position ) {
 
 			$html .=
@@ -1636,9 +1629,9 @@ function edac_update_simplified_summary() {
  */
 function edac_output_simplified_summary( $content ) {
 	$simplified_summary_prompt = get_option( 'edac_simplified_summary_prompt' );
-	if ( 'none' == $simplified_summary_prompt ) {
+	if ( 'none' === $simplified_summary_prompt ) {
 		return $content;
-	} 
+	}
 	$simplified_summary          = edac_simplified_summary_markup( get_the_ID() );
 	$simplified_summary_position = get_option( 'edac_simplified_summary_position', $default = false );
 	if ( $simplified_summary && 'before' === $simplified_summary_position ) {
@@ -1728,7 +1721,7 @@ function edac_output_accessibility_statement() {
 function edac_dismiss_welcome_cta() {
 	// Update user meta to indicate the button has been clicked.
 	update_user_meta( get_current_user_id(), 'edac_welcome_cta_dismissed', true );
-	
+
 	// Return success response.
 	wp_send_json( 'success' );
 }
@@ -1741,7 +1734,7 @@ function edac_dismiss_welcome_cta() {
 function edac_dismiss_dashboard_cta() {
 	// Update user meta to indicate the button has been clicked.
 	update_user_meta( get_current_user_id(), 'edac_dashboard_cta_dismissed', true );
-	
+
 	// Return success response.
 	wp_send_json( 'success' );
 }
@@ -1754,7 +1747,7 @@ function edac_dismiss_dashboard_cta() {
 function edac_email_opt_in() {
 	// Update user meta to indicate the button has been clicked.
 	update_user_meta( get_current_user_id(), 'edac_email_optin', true );
-		
+
 	// Return success response.
 	wp_send_json( 'success' );
 }

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -129,12 +129,6 @@ register_activation_hook( __FILE__, 'edac_activation' );
 register_deactivation_hook( __FILE__, 'edac_deactivation' );
 
 /**
- * Define file path and basename
- */
-$edac_plugin_directory = __FILE__;
-$edac_plugin_basename  = plugin_basename( __FILE__ );
-
-/**
  * Add simple dom support (need to over ride max file size, if clashes with another install of simple dom there the max file size will be dependednt upon that installation)
  */
 if ( ! defined( 'MAX_FILE_SIZE' ) ) {
@@ -213,7 +207,7 @@ add_action( 'wp_dashboard_setup', 'edac_wp_dashboard_setup' );
  */
 function edac_init() {
 	// instantiate the classes that need to load hooks early.
-	$rest_api = new \EDAC\Rest_Api();
+	new \EDAC\Rest_Api();
 }
 
 /**
@@ -1243,8 +1237,6 @@ function edac_details_ajax() {
 	$rules = array_merge( $error_rules, $warning_rules, $passed_rules );
 
 	if ( $rules ) {
-		global $wp_version;
-		$days_active       = edac_days_active();
 		$ignore_permission = true;
 		if ( has_filter( 'edac_ignore_permission' ) ) {
 			$ignore_permission = apply_filters( 'edac_ignore_permission', $ignore_permission );

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,18 @@
     "prefer-stable": true,
     "repositories": [
         {
-          "type": "vcs",
-          "url": "https://github.com/equalizedigital/accessibility-checker-wp-env"
+            "type": "vcs",
+            "url": "https://github.com/equalizedigital/accessibility-checker-wp-env"
         }
-      ],
+    ],
     "require-dev": {
         "automattic/vipwpcs": "^3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
         "phpcompatibility/php-compatibility": "*",
-        "php-parallel-lint/php-parallel-lint": "^1.3"
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "wp-coding-standards/wpcs": "^3.0",
+        "equalizedigital/accessibility-checker-wp-env": "1.0.0"
     },
     "require": {
         "cbschuld/browser.php": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "981cc16881daa866df30c80aec17e34a",
+    "content-hash": "36c1d341e11a60494de5669857e046f0",
     "packages": [
         {
             "name": "cbschuld/browser.php",
@@ -399,6 +399,37 @@
             "time": "2022-02-04T12:51:07+00:00"
         },
         {
+            "name": "equalizedigital/accessibility-checker-wp-env",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/equalizedigital/accessibility-checker-wp-env.git",
+                "reference": "fd3a97365c258749692fbb900b90e9129deb4a15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/equalizedigital/accessibility-checker-wp-env/zipball/fd3a97365c258749692fbb900b90e9129deb4a15",
+                "reference": "fd3a97365c258749692fbb900b90e9129deb4a15",
+                "shasum": ""
+            },
+            "type": "library",
+            "license": [
+                "GPLv2 or later"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Boone",
+                    "email": "matt@boone.dev"
+                }
+            ],
+            "description": "This package is a customized version of wp-env used for development and testing of Accessibility Checker, Accessibility Checker Pro and Accessibility Checker Audit History.",
+            "support": {
+                "source": "https://github.com/equalizedigital/accessibility-checker-wp-env/tree/v1.0.0",
+                "issues": "https://github.com/equalizedigital/accessibility-checker-wp-env/issues"
+            },
+            "time": "2023-10-23T23:58:23+00:00"
+        },
+        {
             "name": "php-parallel-lint/php-parallel-lint",
             "version": "v1.3.2",
             "source": {
@@ -518,17 +549,129 @@
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsextra",
-            "version": "1.1.2",
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2022-10-25T01:46:02+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "78b2cae1e9de1c05f0416de6f9a658cbb83ac324"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/78b2cae1e9de1c05f0416de6f9a658cbb83ac324",
+                "reference": "78b2cae1e9de1c05f0416de6f9a658cbb83ac324",
                 "shasum": ""
             },
             "require": {
@@ -576,9 +719,24 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-09-20T22:06:18+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-02T14:30:12+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -44,7 +44,7 @@ function edac_add_accessibility_statement_page() {
 	global $wpdb;
 
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
-	if ( null === $wpdb->get_row( "SELECT post_name FROM {$wpdb->prefix}posts WHERE post_name = 'accessibility-statement'", 'ARRAY_A' ) ) {
+	if ( null === $wpdb->get_row( $wpdb->prepare( "SELECT post_name FROM %i WHERE post_name = 'accessibility-statement'", $wpdb->prefix . 'posts' ), 'ARRAY_A' ) ) {
 
 		$current_user = wp_get_current_user();
 		$author_id    = $current_user->ID;

--- a/includes/classes/class-admin-notices.php
+++ b/includes/classes/class-admin-notices.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for admin notices
- * 
+ *
  * @package Accessibility_Checker
  */
 

--- a/includes/classes/class-edac-dom.php
+++ b/includes/classes/class-edac-dom.php
@@ -41,7 +41,7 @@ class EDAC_Dom extends simple_html_dom {
 
 	/**
 	 * List of supported audio file extensions.
-	 * 
+	 *
 	 * @var array $audio_ext Audio extensions.
 	 */
 	protected $audio_ext = array(
@@ -60,7 +60,7 @@ class EDAC_Dom extends simple_html_dom {
 
 	/**
 	 * Array containing URLs of embed sources.
-	 * 
+	 *
 	 * @var array $embed_sources Embed source URLs.
 	 */
 	protected $embed_sources = array(

--- a/includes/classes/class-edac-frontend-highlight.php
+++ b/includes/classes/class-edac-frontend-highlight.php
@@ -33,7 +33,7 @@ class EDAC_Frontend_Highlight {
 		$table_name = $wpdb->prefix . 'accessibility_checker';
 		$post_id    = intval( $post_id );
 		$siteid     = get_current_blog_id();
-		$results    = $wpdb->get_results( $wpdb->prepare( 'SELECT id, rule, ignre, object, ruletype FROM ' . $table_name . ' where postid = %d and siteid = %d', $post_id, $siteid ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name.
+		$results    = $wpdb->get_results( $wpdb->prepare( 'SELECT id, rule, ignre, object, ruletype FROM %i where postid = %d and siteid = %d', $table_name, $post_id, $siteid ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name.
 		if ( ! $results ) {
 			return null;
 		}

--- a/includes/classes/class-helpers.php
+++ b/includes/classes/class-helpers.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for helpers
- * 
+ *
  * @package Accessibility_Checker
  */
 
@@ -46,14 +46,14 @@ class Helpers {
 		if ( ( ! is_numeric( $number ) ) ) {
 			return $number;
 		}
-		
+
 		$locale = get_locale();
 
 		if ( class_exists( 'NumberFormatter' ) ) {
 			$formatter = new \NumberFormatter( $locale, \NumberFormatter::DECIMAL );
 			$formatter->setAttribute( \NumberFormatter::MAX_FRACTION_DIGITS, $precision ); // decimals to include.
 			$formatter->setAttribute( \NumberFormatter::GROUPING_USED, 1 ); // Include thousands separator.
-		
+
 			return $formatter->format( $number );
 
 		} else {
@@ -78,16 +78,15 @@ class Helpers {
 			$number = $number / 100;
 		}
 
-		
 		$locale = get_locale();
 
 		if ( class_exists( 'NumberFormatter' ) ) {
-	
+
 			$formatter = new \NumberFormatter( $locale, \NumberFormatter::PERCENT );
 			$formatter->setAttribute( \NumberFormatter::MAX_FRACTION_DIGITS, $precision ); // decimals to include.
-			
+
 			return $formatter->format( $number );
-		
+
 		} else {
 			return sprintf( '%.2f%%', $number * 100 );
 		}
@@ -103,14 +102,14 @@ class Helpers {
 	public static function format_date( $date, $include_time = false ) {
 
 		if ( ! is_numeric( $date ) ) { // date as string.
-			
-			$timestamp = strtotime( $date ); 
+
+			$timestamp = strtotime( $date );
 
 			if ( ! $timestamp ) { // The passed string is not a valid date.
 				return $date;
-			}       
+			}
 		} else { // unix timestamp.
-			$timestamp = $date; 
+			$timestamp = $date;
 		}
 
 		$datetime = new \DateTime();
@@ -167,32 +166,31 @@ class Helpers {
 	 * @return boolean
 	 */
 	public static function is_domain_loopback( $domain ) {
-	
-		// Check if this is an ipv4 address in the loopback range.  
-	
+
+		// Check if this is an ipv4 address in the loopback range.
+
 		$record         = gethostbyname( $domain );
 		$loopback_start = ip2long( '127.0.0.0' );
 		$loopback_end   = ip2long( '127.255.255.255' );
 		$ip_long        = ip2long( $record );
-	
+
 		if ( $ip_long >= $loopback_start && $ip_long <= $loopback_end ) {
 			return true;
-		}       
+		}
 
-			
 		// Check if this is an ipv6 loopback.
-	
+
 		try {
 			$records = dns_get_record( $domain, DNS_AAAA );
 		} catch ( \Throwable $th ) {
-			return false;           
+			return false;
 		}
-			
+
 		foreach ( $records as $record ) {
-		
+
 			// Do ipv6 check.
 			if ( isset( $record['type'] ) && 'AAAA' === $record['type'] ) {
-			
+
 				// Normalize the IPv6 address for comparison.
 				$normalized_ipv6 = inet_pton( $record['ipv6'] );
 
@@ -201,10 +199,10 @@ class Helpers {
 
 				if ( $normalized_ipv6 === $loopback_ipv6 ) {
 					return true;
-				}     
+				}
 			}
 		}
-	
+
 		return false;
 	}
 }

--- a/includes/classes/class-issues-query.php
+++ b/includes/classes/class-issues-query.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for querying issues from the db
- * 
+ *
  * @package Accessibility_Checker
  */
 
@@ -18,30 +18,30 @@ class Issues_Query {
 	const FLAG_EXCLUDE_IGNORED        = 0; // default.
 	const FLAG_INCLUDE_IGNORED        = 1;
 	const FLAG_ONLY_IGNORED           = 2;
-	const FLAG_INCLUDE_ALL_POST_TYPES = 4;  // If enabled, will ignore the post_type filter and return results for all post types. 
-	
+	const FLAG_INCLUDE_ALL_POST_TYPES = 4;  // If enabled, will ignore the post_type filter and return results for all post types.
+
 
 	const RULETYPE_WARNING        = 'warning';
 	const RULETYPE_ERROR          = 'error';
 	const RULETYPE_COLOR_CONTRAST = 'color_contrast';
-	
-	
+
+
 	/**
 	 * Name of table that stores issues
-	 * 
+	 *
 	 * @var string
 	 */
 	private $table;
 
-	
+
 	/**
 	 * Holds the max number of records we'll query
 	 *
 	 * @var [integer]
 	 */
 	private $record_limit;
-	
-	
+
+
 	/**
 	 * Holds the sql safe elements used to build the query
 	 *
@@ -72,56 +72,50 @@ class Issues_Query {
 
 		$validated_filters = array();
 		foreach ( $filter as $key => $val ) {
-			if ( in_array( $key, $valid_filters ) ) {
+			if ( in_array( $key, $valid_filters, true ) ) {
 				$validated_filters[ $key ] = $val;
 			}
 		}
-	
+
 		$this->record_limit = $record_limit;
 
 		// Setup FROM.
 		global $wpdb;
 		$this->table         = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
 		$this->query['from'] = " FROM {$this->table} ";
-		
+
 		// Setup base WHERE.
 		$siteid = get_current_blog_id();
 
-		
 		if ( $flags & self::FLAG_INCLUDE_IGNORED ) {
 			$this->query['where_base'] = $wpdb->prepare( 'WHERE siteid=%d', array( $siteid ) );
-		
+
 		} elseif ( $flags & self::FLAG_ONLY_IGNORED ) {
 			$this->query['where_base'] = $wpdb->prepare( 'WHERE siteid=%d and (ignre=%d or ignre_global=%d) ', array( $siteid, 1, 1 ) );
-		
+
 		} else { // This is the default.
 			$this->query['where_base'] = $wpdb->prepare( 'WHERE siteid=%d and ignre=%d and ignre_global=%d ', array( $siteid, 0, 0 ) );
 		}
 
-		
 		$filter_defaults = array(
 			'post_types' => array(),
 			'rule_types' => array(),
 			'rule_slugs' => array(),
 		);
-		
-		
+
 		$filter = array_replace_recursive( $filter_defaults, $validated_filters );
 
 		// flag for including all post types is set, so remove that from the filters.
 		if ( $flags & self::FLAG_INCLUDE_ALL_POST_TYPES ) {
-			unset( $filter['post_types'] );      
+			unset( $filter['post_types'] );
 		}
-		
+
 		$this->add_filters( $filter );
 
-	
-		if ( empty( $filter['post_types'] ) && false == ( $flags & self::FLAG_INCLUDE_ALL_POST_TYPES ) ) {
+		if ( empty( $filter['post_types'] ) && false === ( $flags & self::FLAG_INCLUDE_ALL_POST_TYPES ) ) {
 			// no post_types were pass in, but the flag for including all post types is not set.
 			$this->query['filters'] .= ' and 1!=1'; // forces false so no results are returned.
 		}
-		
-
 
 		// Setup LIMIT.
 		$this->query['limit'] = $wpdb->prepare( 'LIMIT %d', array( $record_limit ) );
@@ -135,7 +129,7 @@ class Issues_Query {
 	 */
 	public function get_sql() {
 		$sql = $this->query['select'] . ' ' . $this->query['from'] . ' ' . $this->query['where_base'] . ' ' . $this->query['filters'] . ' ' . $this->query['limit'];
-		
+
 		return $sql;
 	}
 
@@ -156,7 +150,7 @@ class Issues_Query {
 	 */
 	public function has_truncated_results() {
 		global $wpdb;
-		
+
 		$sql = 'SELECT COUNT(*) ' . $this->query['from'];
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -170,7 +164,7 @@ class Issues_Query {
 
 	/**
 	 * Gets issue count.
-	 *    
+	 *
 	 * @return integer issue_count .
 	 */
 	public function count() {
@@ -178,7 +172,7 @@ class Issues_Query {
 		global $wpdb;
 
 		$this->query['select'] = 'SELECT COUNT(id) ';
-		
+
 		$sql = $this->get_sql();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -187,7 +181,7 @@ class Issues_Query {
 
 	/**
 	 * Gets distinct issue count.
-	 *    
+	 *
 	 * @return integer issue_count .
 	 */
 	public function distinct_count() {
@@ -195,7 +189,7 @@ class Issues_Query {
 		global $wpdb;
 
 		$this->query['select'] = 'SELECT COUNT( DISTINCT rule, object ) ';
-		
+
 		$sql = $this->get_sql();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -204,7 +198,7 @@ class Issues_Query {
 
 	/**
 	 * Gets distinct posts count.
-	 *    
+	 *
 	 * @return integer posts_count .
 	 */
 	public function distinct_posts_count() {
@@ -212,7 +206,7 @@ class Issues_Query {
 		global $wpdb;
 
 		$this->query['select'] = 'SELECT COUNT( DISTINCT postid ) ';
-		
+
 		$sql = $this->get_sql();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -221,7 +215,7 @@ class Issues_Query {
 
 	/**
 	 * Get the ids of the issues.
-	 *    
+	 *
 	 * @return array issues .
 	 */
 	public function get_ids() {
@@ -229,9 +223,9 @@ class Issues_Query {
 		global $wpdb;
 
 		$this->query['select'] = 'SELECT id';
-		
+
 		$sql = $this->get_sql();
-		
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		return $wpdb->get_results( $sql );
 	}
@@ -239,13 +233,13 @@ class Issues_Query {
 
 	/**
 	 * Adds the filters to be used by the query.
-	 * 
+	 *
 	 * @param array $filter .
-	 * 
+	 *
 	 * @return void
 	 */
 	private function add_filters( $filter ) {
-		
+
 		if ( array_key_exists( 'post_types', $filter ) && count( $filter['post_types'] ) ) {
 
 			$scannable_post_types = Settings::get_scannable_post_types();
@@ -254,24 +248,24 @@ class Issues_Query {
 				$this->query['filters'] .= ' and type IN (' . Helpers::array_to_sql_safe_list( $post_types ) . ') ';
 			}
 		}
-	
+
 		if ( array_key_exists( 'rule_types', $filter ) && ! empty( $filter['rule_types'] ) ) {
 
 			// Special handler for color contrast rule/ruletype.
-			if ( in_array( self::RULETYPE_COLOR_CONTRAST, $filter['rule_types'] ) ) {
-				
+			if ( in_array( self::RULETYPE_COLOR_CONTRAST, $filter['rule_types'], true ) ) {
+
 				// We are filtering by color contrast but color contrast is a rule not a ruletype.
 				// Remove color_contrast from the rule_type filter.
-				$key = array_search( self::RULETYPE_COLOR_CONTRAST, $filter['rule_types'] );
+				$key = array_search( self::RULETYPE_COLOR_CONTRAST, $filter['rule_types'], true );
 				if ( false !== $key ) {
 					unset( $filter['rule_types'][ $key ] );
 				}
 
 				// Then add color_contrast_failure to the rule_slugs filter.
-				$key = array_search( 'color_contrast_failure', $filter['rule_slugs'] );
-				if ( false == $key ) {
+				$key = array_search( 'color_contrast_failure', $filter['rule_slugs'], true );
+				if ( ! $key ) {
 					$filter['rule_slugs'][] = 'color_contrast_failure';
-				}           
+				}
 			}
 
 			if ( ! empty( $filter['rule_types'] ) ) {
@@ -279,7 +273,6 @@ class Issues_Query {
 			}
 		}
 
-	
 		if ( array_key_exists( 'rule_slugs', $filter ) && ! empty( $filter['rule_slugs'] ) ) {
 			$this->query['filters'] .= ' and rule IN (' . Helpers::array_to_sql_safe_list( $filter['rule_slugs'] ) . ') ';
 		}

--- a/includes/classes/class-playground-check.php
+++ b/includes/classes/class-playground-check.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for Plugin Check
- * 
+ *
  * @package Accessibility_Checker
  */
 

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -52,7 +52,6 @@ class REST_Api {
 					array(
 						'methods'             => array( 'GET', 'POST' ),
 						'callback'            => function () {
-							global $wp;
 							$messages = array();
 							$messages['time'] = time();
 							$messages['perms'] = current_user_can( 'edit_posts' );
@@ -264,7 +263,7 @@ class REST_Api {
 			do_action( 'edac_after_validate', $post_id, 'js' );
 
 			// Update the summary info that is stored in meta this post.
-			$summary = edac_summary( $post_id );
+			edac_summary( $post_id );
 
 			// remove corrected records.
 			edac_remove_corrected_posts( $post_id, $post->post_type, $pre = 2, 'js' );
@@ -418,7 +417,7 @@ class REST_Api {
 	 *
 	 * @return \WP_REST_Response
 	 */
-	public function get_scans_stats_by_post_types( $request ) { //phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	public function get_scans_stats_by_post_types( $request ) { //phpcs:ignore
 
 		try {
 

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for REST api
- * 
+ *
  * @package Accessibility_Checker
  */
 
@@ -28,7 +28,7 @@ class REST_Api {
 	 * Constructor
 	 */
 	public function __construct() {
-			
+
 		if ( ! self::$initialized ) {
 			$this->initialize();
 		}
@@ -56,16 +56,15 @@ class REST_Api {
 							$messages = array();
 							$messages['time'] = time();
 							$messages['perms'] = current_user_can( 'edit_posts' );
-						
-						
+
 							return new \WP_REST_Response( array( 'messages' => $messages ), 200 );
 						},
 						'permission_callback' => function () {
 							return true;
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 
 		add_action(
@@ -87,9 +86,9 @@ class REST_Api {
 						'permission_callback' => function () {
 							return current_user_can( 'edit_posts' );
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 
 		add_action(
@@ -104,9 +103,9 @@ class REST_Api {
 						'permission_callback' => function () {
 							return current_user_can( 'read' ); // able to access the admin dashboard.
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 
 		add_action(
@@ -121,9 +120,9 @@ class REST_Api {
 						'permission_callback' => function () {
 							return current_user_can( 'read' ); // able to access the admin dashboard.
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 
 		add_action(
@@ -138,9 +137,9 @@ class REST_Api {
 						'permission_callback' => function () {
 							return current_user_can( 'read' ); // able to access the admin dashboard.
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 
 		add_action(
@@ -155,9 +154,9 @@ class REST_Api {
 						'permission_callback' => function () {
 							return current_user_can( 'read' ); // able to access the admin dashboard.
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 
 		add_action(
@@ -172,31 +171,31 @@ class REST_Api {
 						'permission_callback' => function () {
 							return current_user_can( 'read' ); // able to access the admin dashboard.
 						},
-					) 
+					)
 				);
-			} 
+			}
 		);
 	}
 
-	
+
 
 	/**
 	 * REST handler that saves to the DB a list of js rule violations for a post.
 	 *
 	 * @param WP_REST_Request $request  The request passed from the REST call.
-	 * 
-	 * @return \WP_REST_Response 
+	 *
+	 * @return \WP_REST_Response
 	 */
 	public function set_post_scan_results( $request ) {
-	
-		if ( ! isset( $request['violations'] ) 
+
+		if ( ! isset( $request['violations'] )
 		) {
 			return new \WP_REST_Response( array( 'message' => 'A required parameter is missing.' ), 400 );
 		}
 
 		$post_id = intval( $request['id'] );
 		$post    = get_post( $post_id );
-		if ( ! is_object( $post ) ) {    
+		if ( ! is_object( $post ) ) {
 
 			return new \WP_REST_Response( array( 'message' => 'The post is not valid.' ), 400 );
 		}
@@ -210,7 +209,7 @@ class REST_Api {
 
 		}
 
-		//phpcs:ignore Generic.Commenting.Todo.TaskFound			
+		//phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: setup a rules class for loading/filtering rules.
 		$rules       = edac_register_rules();
 		$js_rule_ids = array();
@@ -220,31 +219,27 @@ class REST_Api {
 			}
 		}
 
-	
-		
 		try {
 
 			do_action( 'edac_before_validate', $post_id, 'js' );
-	
+
 			$violations = $request['violations'];
-			
-					
+
 			// set record check flag on previous error records.
 			edac_remove_corrected_posts( $post_id, $post->post_type, $pre = 1, 'js' );
 
-	
 			if ( is_array( $violations ) && count( $violations ) > 0 ) {
 
 				foreach ( $violations as $violation ) {
 					$rule_id = $violation['ruleId'];
-				
-					if ( in_array( $rule_id, $js_rule_ids ) ) {
+
+					if ( in_array( $rule_id, $js_rule_ids, true ) ) {
 
 						// This rule is one that we've included in our js ruleset.
-				
+
 						$html   = $violation['html'];
 						$impact = $violation['impact']; // by default, use the impact setting from the js rule.
-					
+
 						//phpcs:ignore Generic.Commenting.Todo.TaskFound
 						// TODO: setup a rules class for loading/filtering rules.
 						foreach ( $rules as $rule ) {
@@ -257,88 +252,88 @@ class REST_Api {
 						// TODO: add support storing $violation['selector'], $violation['tags'].
 
 						do_action( 'edac_before_rule', $post_id, $rule_id, 'js' );
-			
+
 						edac_insert_rule_data( $post, $rule_id, $impact, $html );
 
 						do_action( 'edac_after_rule', $post_id, $rule_id, 'js' );
-			
-					}               
-				}           
+
+					}
+				}
 			}
-	
+
 			do_action( 'edac_after_validate', $post_id, 'js' );
-	
+
 			// Update the summary info that is stored in meta this post.
 			$summary = edac_summary( $post_id );
-	
+
 			// remove corrected records.
 			edac_remove_corrected_posts( $post_id, $post->post_type, $pre = 2, 'js' );
 
 			// store a record of this scan in the post's meta.
 			update_post_meta( $post_id, '_edac_post_checked_js', time() );
-			
+
 			return new \WP_REST_Response(
 				array(
 					'success'   => true,
 					'id'        => $post_id,
 					'timestamp' => time(),
-				) 
+				)
 			);
 
 		} catch ( \Exception $ex ) {
-			
+
 			return new \WP_REST_Response(
 				array(
 					'message' => $ex->getMessage(),
-				), 
+				),
 				500
 			);
 
-		}   
+		}
 	}
 
 
 	/**
 	 * REST handler that clears the cached stats about the scans
 	 *
-	 * @return \WP_REST_Response 
+	 * @return \WP_REST_Response
 	 */
 	public function clear_cached_scans_stats() {
-	
+
 		try {
 
 			// Clear the cache.
 			$scans_stats = new Scans_Stats();
 			$scans_stats->clear_cache();
-			
+
 			// Prime the cache.
 			$scans_stats = new Scans_Stats();
-		
+
 			return new \WP_REST_Response(
 				array(
 					'success' => true,
-				) 
+				)
 			);
 
 		} catch ( \Exception $ex ) {
-			
+
 			return new \WP_REST_Response(
 				array(
 					'message' => $ex->getMessage(),
-				), 
+				),
 				500
 			);
 
-		}   
+		}
 	}
 
 	/**
 	 * REST handler that gets stats about the scans
 	 *
-	 * @return \WP_REST_Response 
+	 * @return \WP_REST_Response
 	 */
 	public function get_scans_stats() {
-	
+
 		try {
 
 			$scans_stats = new Scans_Stats( 60 * 5 );
@@ -348,19 +343,19 @@ class REST_Api {
 				array(
 					'success' => true,
 					'stats'   => $stats,
-				) 
+				)
 			);
 
 		} catch ( \Exception $ex ) {
-			
+
 			return new \WP_REST_Response(
 				array(
 					'message' => $ex->getMessage(),
-				), 
+				),
 				500
 			);
 
-		}   
+		}
 	}
 
 
@@ -368,12 +363,12 @@ class REST_Api {
 	 * REST handler that gets stats about the scans by post type
 	 *
 	 * @param WP_REST_Request $request The request passed from the REST call.
-	 * 
-	 * @return \WP_REST_Response 
+	 *
+	 * @return \WP_REST_Response
 	 */
 	public function get_scans_stats_by_post_type( $request ) {
 
-		if ( ! isset( $request['slug'] ) 
+		if ( ! isset( $request['slug'] )
 		) {
 			return new \WP_REST_Response( array( 'message' => 'A required parameter is missing.' ), 400 );
 		}
@@ -381,97 +376,91 @@ class REST_Api {
 		try {
 
 			$post_type = strval( $request['slug'] );
-		
+
 			$scannable_post_types = Settings::get_scannable_post_types();
-		
-			if ( in_array( $post_type, $scannable_post_types ) ) {
-			
-					$scans_stats = new Scans_Stats( 60 * 5 );   
-	
+
+			if ( in_array( $post_type, $scannable_post_types, true ) ) {
+
+					$scans_stats = new Scans_Stats( 60 * 5 );
+
 					$by_type = $scans_stats->issues_summary_by_post_type( $post_type );
 
 					return new \WP_REST_Response(
 						array(
 							'success' => true,
 							'stats'   => $by_type,
-						) 
+						)
 					);
-			
 
 			} else {
 
 				return new \WP_REST_Response( array( 'message' => 'The post type is not set to be scanned.' ), 400 );
 
-			}       
+			}
 		} catch ( \Exception $ex ) {
-			
+
 			return new \WP_REST_Response(
 				array(
 					'message' => $ex->getMessage(),
-				), 
+				),
 				500
 			);
 
-		}   
+		}
 	}
 
 
-	
+
 	/**
 	 * REST handler that gets stats about the scans by post types
 	 *
 	 * @param WP_REST_Request $request The request passed from the REST call.
-	 * 
-	 * @return \WP_REST_Response 
+	 *
+	 * @return \WP_REST_Response
 	 */
 	public function get_scans_stats_by_post_types( $request ) { //phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 
 		try {
 
-			$scans_stats = new Scans_Stats( 60 * 5 );   
+			$scans_stats = new Scans_Stats( 60 * 5 );
 
 			$scannable_post_types = Settings::get_scannable_post_types();
-				
+
 			$post_types = get_post_types(
 				array(
 					'public' => true,
-				) 
+				)
 			);
 			unset( $post_types['attachment'] );
-	
+
 			$post_types_to_check = array_merge( array( 'post', 'page' ), $scannable_post_types );
-			
+
 			$by_types = array();
 
 			foreach ( $post_types as $post_type ) {
 
-				if ( in_array( $post_type, $scannable_post_types ) && in_array( $post_type, $post_types_to_check ) ) {
-		
+				$by_types[ $post_type ] = false;
+				if ( in_array( $post_type, $scannable_post_types, true ) && in_array( $post_type, $post_types_to_check, true ) ) {
 					$by_types[ $post_type ] = $scans_stats->issues_summary_by_post_type( $post_type );
-				
-				} else {
-					$by_types[ $post_type ] = false;
 				}
 			}
-			
+
 			return new \WP_REST_Response(
 				array(
 					'success' => true,
 					'stats'   => $by_types,
-				) 
+				)
 			);
-	
 
-		
 		} catch ( \Exception $ex ) {
-			
+
 			return new \WP_REST_Response(
 				array(
 					'message' => $ex->getMessage(),
-				), 
+				),
 				500
 			);
 
-		}   
+		}
 	}
 }

--- a/includes/classes/class-scans-stats.php
+++ b/includes/classes/class-scans-stats.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for scans stats
- * 
+ *
  * @package Accessibility_Checker
  */
 
@@ -51,7 +51,7 @@ class Scans_Stats {
 	 * @param integer $cache_time number of seconds to return the results from cache.
 	 */
 	public function __construct( $cache_time = 60 * 60 * 24 ) {
-	
+
 		$this->cache_time        = $cache_time;
 		$this->cache_name_prefix = 'edac_scans_stats_' . EDAC_VERSION . '_' . $this->record_limit;
 		$this->rule_count        = count( edac_register_rules() );
@@ -59,49 +59,48 @@ class Scans_Stats {
 
 	/**
 	 * Load all stats into the cache. Should be called by a background scheduled.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function load_cache() {
-		
+
 		// Cache the summary.
 		$this->summary();
-				
+
 		// Cache the post_types.
 		$scannable_post_types = Settings::get_scannable_post_types();
-					
+
 		$post_types = get_post_types(
 			array(
 				'public' => true,
-			) 
+			)
 		);
-	
+
 		unset( $post_types['attachment'] );
-	
-			
+
 		foreach ( $post_types as $post_type ) {
-			if ( in_array( $post_type, $scannable_post_types ) ) {
-				$this->issues_summary_by_post_type( $post_type ); 
+			if ( in_array( $post_type, $scannable_post_types, true ) ) {
+				$this->issues_summary_by_post_type( $post_type );
 			}
 		}
 	}
-	
+
 	/**
 	 * Clear the summary and post type scans stats that have been cached
-	 * 
+	 *
 	 * @return void
 	 */
 	public function clear_cache() {
-	
+
 		// Delete the cached summary stats.
 		$transient_name = $this->cache_name_prefix . '_summary';
 		delete_transient( $transient_name );
-		
+
 		// Delete the cached post_type stats.
 		$post_types = get_post_types(
 			array(
 				'public' => true,
-			) 
+			)
 		);
 		unset( $post_types['attachment'] );
 		foreach ( $post_types as $post_type ) {
@@ -116,7 +115,7 @@ class Scans_Stats {
 	 * @return array .
 	 */
 	public function summary() {
-	
+
 		global $wpdb;
 
 		$transient_name = $this->cache_name_prefix . '_summary';
@@ -125,52 +124,44 @@ class Scans_Stats {
 
 		if ( $this->cache_time && $cache ) {
 
-		
-			if ( $cache['expires_at'] >= time() && $cache['cached_at'] + $this->cache_time >= time() 
+			if ( $cache['expires_at'] >= time() && $cache['cached_at'] + $this->cache_time >= time()
 			) {
-		
+
 				$full_scan_completed_at = (int) get_option( 'edacp_fullscan_completed_at' );
 				if ( $full_scan_completed_at <= $cache['cached_at'] ) {
 					// There hasn't been a full scan completed since we've cached, so return these results.
 					$cache['cache_hit'] = true;
 					return $cache;
-				}           
-			}       
+				}
+			}
 		}
 
-	
-		
 		$data = array();
 
-	
 		$scannable_posts_count = Settings::get_scannable_posts_count();
 		$tests_count           = $scannable_posts_count * $this->rule_count;
 		$siteid                = get_current_blog_id();
-
 
 		$data['scannable_posts_count']      = (int) $scannable_posts_count;
 		$data['rule_count']                 = (int) $this->rule_count;
 		$data['tests_count']                = (int) $tests_count;
 		$data['scannable_post_types_count'] = (int) count( Settings::get_scannable_post_types() );
-		
+
 		$post_types = get_post_types(
 			array(
 				'public' => true,
-			) 
+			)
 		);
 		unset( $post_types['attachment'] );
 
 		$data['public_post_types_count'] = (int) count( $post_types );
-		
 
 		$issues_query = new \EDAC\Issues_Query( array(), $this->record_limit, Issues_Query::FLAG_INCLUDE_ALL_POST_TYPES );
-	
+
 		$data['is_truncated']  = $issues_query->has_truncated_results();
 		$data['posts_scanned'] = (int) $issues_query->distinct_posts_count();
 		$data['rules_failed']  = 0;
-		
-		
-		
+
 		// Get a count of rules that are not in the issues table.
 		$rule_slugs = array_map(
 			function ( $item ) {
@@ -178,19 +169,19 @@ class Scans_Stats {
 			},
 			edac_register_rules()
 		);
-	
+
 		foreach ( $rule_slugs as $rule_slug ) {
-			$rule_query = new \EDAC\Issues_Query( 
+			$rule_query = new \EDAC\Issues_Query(
 				array(
 					'rule_slugs' => array( $rule_slug ),
 				),
 				1,
-				Issues_Query::FLAG_INCLUDE_ALL_POST_TYPES 
+				Issues_Query::FLAG_INCLUDE_ALL_POST_TYPES
 			);
 
 			if ( $rule_query->count() ) {
 				++$data['rules_failed'];
-			}       
+			}
 		}
 		$data['rules_passed'] = $this->rule_count - $data['rules_failed'];
 
@@ -199,44 +190,43 @@ class Scans_Stats {
 		} else {
 			$data['passed_percentage'] = 0;
 		}
-	
-		$warning_issues_query      = new \EDAC\Issues_Query( 
-			array( 
+
+		$warning_issues_query      = new \EDAC\Issues_Query(
+			array(
 				'post_types' => Settings::get_scannable_post_types(),
-				'rule_types' => array( Issues_Query::RULETYPE_WARNING ), 
-			), 
-			$this->record_limit 
+				'rule_types' => array( Issues_Query::RULETYPE_WARNING ),
+			),
+			$this->record_limit
 		);
 		$data['warnings']          = (int) $warning_issues_query->count();
 		$data['distinct_warnings'] = (int) $warning_issues_query->distinct_count();
 
-		$contrast_issues_query = new \EDAC\Issues_Query( 
-			array( 
+		$contrast_issues_query = new \EDAC\Issues_Query(
+			array(
 				'post_types' => Settings::get_scannable_post_types(),
-				'rule_types' => array( Issues_Query::RULETYPE_COLOR_CONTRAST ), 
+				'rule_types' => array( Issues_Query::RULETYPE_COLOR_CONTRAST ),
 			),
-			$this->record_limit 
+			$this->record_limit
 		);
-		
+
 		$data['contrast_errors']          = (int) $contrast_issues_query->count();
 		$data['distinct_contrast_errors'] = (int) $contrast_issues_query->distinct_count();
-		
-		$error_issues_query      = new \EDAC\Issues_Query( 
-			array( 
+
+		$error_issues_query      = new \EDAC\Issues_Query(
+			array(
 				'post_types' => Settings::get_scannable_post_types(),
 				'rule_types' => array( Issues_Query::RULETYPE_ERROR ),
 			),
-			$this->record_limit 
+			$this->record_limit
 		);
 		$data['errors']          = (int) $error_issues_query->count();
 		$data['distinct_errors'] = (int) $error_issues_query->distinct_count();
-		
+
 		$data['errors_without_contrast']          = $data['errors'] - $data['contrast_errors'];
 		$data['distinct_errors_without_contrast'] = $data['distinct_errors'] - $data['distinct_contrast_errors'];
-	
-		
-		$ignored_issues_query     = new Issues_Query( 
-			array( 
+
+		$ignored_issues_query     = new Issues_Query(
+			array(
 				'post_types' => Settings::get_scannable_post_types(),
 			),
 			$this->record_limit,
@@ -244,24 +234,22 @@ class Scans_Stats {
 		);
 		$data['ignored']          = (int) $ignored_issues_query->count();
 		$data['distinct_ignored'] = (int) $ignored_issues_query->distinct_count();
-		
-		
-		
-		if ( $data['posts_scanned'] > 0 && 
-			! empty( Settings::get_scannable_post_types() ) && 
-			! empty( Settings::get_scannable_post_statuses() ) 
+
+		if ( $data['posts_scanned'] > 0 &&
+			! empty( Settings::get_scannable_post_types() ) &&
+			! empty( Settings::get_scannable_post_statuses() )
 		) {
-		
-			$sql = "SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts}  
+
+			$sql = "SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts}
 			LEFT JOIN " . $wpdb->prefix . "accessibility_checker ON {$wpdb->posts}.ID = " .
-			$wpdb->prefix . 'accessibility_checker.postid WHERE ' . 
-			$wpdb->prefix . 'accessibility_checker.postid IS NULL and post_type IN(' . 
-			Helpers::array_to_sql_safe_list( 
-				Settings::get_scannable_post_types() 
-			) . ') and post_status IN(' . Helpers::array_to_sql_safe_list( 
+			$wpdb->prefix . 'accessibility_checker.postid WHERE ' .
+			$wpdb->prefix . 'accessibility_checker.postid IS NULL and post_type IN(' .
+			Helpers::array_to_sql_safe_list(
+				Settings::get_scannable_post_types()
+			) . ') and post_status IN(' . Helpers::array_to_sql_safe_list(
 				Settings::get_scannable_post_statuses()
 			) . ')';
-		
+
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 			$data['posts_without_issues'] = $wpdb->get_var( $sql );
 
@@ -270,53 +258,48 @@ class Scans_Stats {
 			$data['posts_without_issues'] = 0;
 			$data['avg_issues_per_post']  = 0;
 		}
-	
 
-		$data['avg_issue_density_percentage'] = 
+		$data['avg_issue_density_percentage'] =
 		$wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 			$wpdb->prepare(
-				'SELECT avg(meta_value) from ' . $wpdb->postmeta . ' 
+				'SELECT avg(meta_value) from ' . $wpdb->postmeta . '
 				JOIN ' . $wpdb->prefix . 'accessibility_checker ON postid=post_id
-				WHERE meta_key = %s and meta_value > %d 
-				and ' . $wpdb->prefix . 'accessibility_checker.siteid=%d and ignre=%d and ignre_global=%d LIMIT %d', 
+				WHERE meta_key = %s and meta_value > %d
+				and ' . $wpdb->prefix . 'accessibility_checker.siteid=%d and ignre=%d and ignre_global=%d LIMIT %d',
 				array( '_edac_issue_density', 0, $siteid, 0, 0, $this->record_limit )
 			)
 		);
-		
+
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';
 		} else {
 			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 2 );
 
 		}
-	
-
 
 		$data['fullscan_running'] = false;
 		$data['fullscan_state']   = '';
-		
+
 		if ( class_exists( '\EDACP\Scans' ) ) {
 			$scans      = new \EDACP\Scans();
 			$scan_state = $scans->scan_state();
-			
+
 			$data['fullscan_state'] = $scan_state;
-			if ( \EDACP\Scans::SCAN_STATE_PHP_SCAN_RUNNING == $scan_state 
-				|| \EDACP\Scans::SCAN_STATE_JS_SCAN_RUNNING == $scan_state
+			if ( \EDACP\Scans::SCAN_STATE_PHP_SCAN_RUNNING === $scan_state
+				|| \EDACP\Scans::SCAN_STATE_JS_SCAN_RUNNING === $scan_state
 			) {
 				$data['fullscan_running'] = true;
-			} 
+			}
 			$data['fullscan_completed_at'] = $scans->scan_date( 'php' );
-	
+
 		} else {
 			$data['fullscan_completed_at'] = 0;
 		}
 
-		$data['cache_id']   = $transient_name; 
-		$data['cached_at']  = time(); 
-		$data['expires_at'] = time() + $this->cache_time; 
+		$data['cache_id']   = $transient_name;
+		$data['cached_at']  = time();
+		$data['expires_at'] = time() + $this->cache_time;
 		$data['cache_hit']  = false;
-		
-
 
 		// Handle formatting. Assumes all are numbers except for those listed in exceptions.
 		$formatting            = array();
@@ -332,9 +315,9 @@ class Scans_Stats {
 			'expires_at',
 			'cache_hit',
 		);
-		
+
 		foreach ( $data as $key => $value ) {
-			if ( ! in_array( $key, $formatting_exceptions ) ) {
+			if ( ! in_array( $key, $formatting_exceptions, true ) ) {
 				$formatting[ $key . '_formatted' ] = Helpers::format_number( $value );
 			}
 		}
@@ -347,9 +330,8 @@ class Scans_Stats {
 		}
 		$formatting['passed_percentage_formatted']            = Helpers::format_percentage( $data['passed_percentage'] );
 		$formatting['avg_issue_density_percentage_formatted'] = Helpers::format_percentage( $data['avg_issue_density_percentage'] );
-		
+
 		$data = array_merge( $data, $formatting );
-		
 
 		if ( $data['posts_scanned'] > 0 ) {
 			set_transient( $transient_name, $data, $this->cache_time );
@@ -357,7 +339,7 @@ class Scans_Stats {
 			// no posts have been scanned, so clear any previously cache results.
 			$this->clear_cache();
 		}
-	
+
 		return $data;
 	}
 
@@ -368,31 +350,29 @@ class Scans_Stats {
 	 * @return array .
 	 */
 	public function issues_summary_by_post_type( $post_type ) {
-	
+
 		$transient_name = $this->cache_name_prefix . '_issues_summary_by_post_type_' . $post_type;
 
 		$cache = get_transient( $transient_name );
-	
+
 		if ( $this->cache_time && $cache ) {
 
-			if ( $cache['expires_at'] >= time() && $cache['cached_at'] + $this->cache_time >= time() 
+			if ( $cache['expires_at'] >= time() && $cache['cached_at'] + $this->cache_time >= time()
 			) {
-		
+
 				$full_scan_completed_at = (int) get_option( 'edacp_fullscan_completed_at' );
 				if ( $full_scan_completed_at <= $cache['cached_at'] ) {
 					// There hasn't been a full scan completed since we've cached, so return these results.
 					$cache['cache_hit'] = true;
 					return $cache;
-				}           
-			}       
+				}
+			}
 		}
-
 
 		$data = array();
 
-	
 		$error_issues_query      = new \EDAC\Issues_Query(
-			array( 
+			array(
 				'rule_types' => array( Issues_Query::RULETYPE_ERROR ),
 				'post_types' => array( $post_type ),
 			),
@@ -400,11 +380,9 @@ class Scans_Stats {
 		);
 		$data['errors']          = $error_issues_query->count();
 		$data['distinct_errors'] = $error_issues_query->distinct_count();
-		
-	
 
 		$warning_issues_query      = new \EDAC\Issues_Query(
-			array( 
+			array(
 				'rule_types' => array( Issues_Query::RULETYPE_WARNING ),
 				'post_types' => array( $post_type ),
 			),
@@ -412,10 +390,9 @@ class Scans_Stats {
 		);
 		$data['warnings']          = $warning_issues_query->count();
 		$data['distinct_warnings'] = $warning_issues_query->distinct_count();
-		
-	
+
 		$color_contrast_issues_query      = new \EDAC\Issues_Query(
-			array( 
+			array(
 				'rule_types' => array( Issues_Query::RULETYPE_COLOR_CONTRAST ),
 				'post_types' => array( $post_type ),
 			),
@@ -423,25 +400,21 @@ class Scans_Stats {
 		);
 		$data['contrast_errors']          = $color_contrast_issues_query->count();
 		$data['distinct_contrast_errors'] = $color_contrast_issues_query->distinct_count();
-		
-	
+
 		$data['errors_without_contrast']          = $data['errors'] - $data['contrast_errors'];
 		$data['distinct_errors_without_contrast'] = $data['distinct_errors'] - $data['distinct_contrast_errors'];
-	
-		
+
 		foreach ( $data as $key => $val ) {
 			$data[ $key . '_formatted' ] = Helpers::format_number( $val );
 		}
 
-	
-		$data['cache_id']   = $transient_name; 
-		$data['cached_at']  = time(); 
-		$data['expires_at'] = time() + $this->cache_time; 
+		$data['cache_id']   = $transient_name;
+		$data['cached_at']  = time();
+		$data['expires_at'] = time() + $this->cache_time;
 		$cache['cache_hit'] = false;
 
 		set_transient( $transient_name, $data, $this->cache_time );
 
-	
 		return $data;
 	}
 }

--- a/includes/classes/class-settings.php
+++ b/includes/classes/class-settings.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for scan settings
- * 
+ *
  * @package Accessibility_Checker
  */
 
@@ -22,7 +22,7 @@ class Settings {
 	 */
 	public static function get_scannable_post_statuses() {
 		return array( 'publish', 'future', 'draft', 'pending', 'private' );
-	} 
+	}
 
 
 	/**
@@ -32,14 +32,13 @@ class Settings {
 	 */
 	public static function get_scannable_post_types() {
 
-	
 		if ( ! class_exists( '\EDACP\Settings' ) ) {
-			
+
 			$post_types = Helpers::get_option_as_array( 'edac_post_types' );
 
 			// remove duplicates.
 			$post_types = array_unique( $post_types );
-			
+
 			// validate post types.
 			$args             = array(
 				'public'   => true,
@@ -53,16 +52,15 @@ class Settings {
 				if ( ! post_type_exists( $post_type ) || ! array_key_exists( $post_type, $valid_post_types ) ) {
 					unset( $post_types[ $key ] );
 				}
-			}       
+			}
 		} else {
 			$post_types = \EDACP\Settings::get_scannable_post_types();
 		}
 
-		
 		return $post_types;
 	}
 
-	
+
 	/**
 	 * Gets a count of posts that are scannable.
 	 *
@@ -73,15 +71,15 @@ class Settings {
 		global $wpdb;
 
 		$post_types = self::get_scannable_post_types();
-		
+
 		$post_statuses = self::get_scannable_post_statuses();
 
 		if ( ! empty( $post_types ) && ! empty( $post_statuses ) ) {
-			$sql = "SELECT COUNT(id) FROM {$wpdb->posts}  WHERE post_type IN(" . 
+			$sql = "SELECT COUNT(id) FROM {$wpdb->posts}  WHERE post_type IN(" .
 				Helpers::array_to_sql_safe_list( $post_types ) . ') and post_status IN(' .
-				Helpers::array_to_sql_safe_list( $post_statuses ) . 
+				Helpers::array_to_sql_safe_list( $post_statuses ) .
 			')';
-	
+
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$scannable_posts_count = $wpdb->get_var( $sql );
 

--- a/includes/classes/class-welcome-page.php
+++ b/includes/classes/class-welcome-page.php
@@ -24,7 +24,6 @@ class Welcome_Page {
 	 */
 	public static function render_summary() {
 
-		$html        = '';
 		$scans_stats = new Scans_Stats();
 		$summary     = $scans_stats->summary();
 		?>

--- a/includes/classes/class-welcome-page.php
+++ b/includes/classes/class-welcome-page.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * Class file for Welcome Page
- * 
+ *
  * @package Accessibility_Checker
+ *
+ * phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
  */
 
 namespace EDAC;
@@ -13,7 +15,7 @@ use EDAC\Scans_Stats;
  * Class that handles welcome page
  */
 class Welcome_Page {
-	
+
 
 	/**
 	 * Renders page summary
@@ -25,197 +27,295 @@ class Welcome_Page {
 		$html        = '';
 		$scans_stats = new Scans_Stats();
 		$summary     = $scans_stats->summary();
-		
-		$html .= '
-			<div id="edac_welcome_page_summary">';
+		?>
 
+		<div id="edac_welcome_page_summary">
 
-		if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
-	
-			$html .= '
-			<section>
-				<div class="edac-cols edac-cols-header">
-					<div class="edac-cols-left">
-						<h2>
-							' . __( 'Most Recent Test Summary', 'accessibility-checker' ) . '
-						</h2>
-					</div>
-					<p class="edac-cols-right"> 
-						<button class="button" id="edac_clear_cached_stats">' . __( 'Update Counts', 'accessibility-checker' ) . '</button>	
-	
-						<a class="edac-ml-1 button" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=scan' ) ) . '">' . __( 'Start New Scan', 'accessibility-checker' ) . '</a>
-					
-						<a class="edac-ml-1 button button-primary" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_issues' ) ) . '">' . __( 'View All Open Issues', 'accessibility-checker' ) . '</a>';
+			<?php if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) : ?>
+				<section>
+					<div class="edac-cols edac-cols-header">
+						<div class="edac-cols-left">
+							<h2>
+								<?php esc_html_e( 'Most Recent Test Summary', 'accessibility-checker' ); ?>
+							</h2>
+						</div>
 
-			if ( get_option( 'edacah_enable_show_history_button', false ) ) {
-				$html .= '
-				<a class="edac-ml-1 button button-primary" href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_audit_history' ) ) . '">' . __( 'See History', 'accessibility-checker' ) . '</a>';
-			}
-						
-			$html .= '		
-					</p>
-				</div>
-				<div class="edac-welcome-grid-container">';
+						<p class="edac-cols-right">
+							<button class="button" id="edac_clear_cached_stats">
+								<?php esc_html_e( 'Update Counts', 'accessibility-checker' ); ?>
+							</button>
 
-			$html .= '
-				<div class="edac-welcome-grid-c1 edac-welcome-grid-item edac-background-light" style="grid-area: 1 / 1 / span 2;">
-					<div class="edac-circle-progress" role="progressbar" aria-valuenow="' . esc_attr( $summary['passed_percentage'] ) . '" 
-						aria-valuemin="0" aria-valuemax="100"
-						style="text-align: center; 
-						background: radial-gradient(closest-side, white 90%, transparent 80% 100%), 
-						conic-gradient(#006600 ' . esc_attr( $summary['passed_percentage'] ) . '%, #e2e4e7 0);">
-						<div class="edac-progress-percentage edac-xxx-large-text">' . esc_html( $summary['passed_percentage_formatted'] ) . '</div>
-						<div class="edac-progress-label edac-large-text">' . __( 'Passed Tests', 'accessibility-checker' ) . '</div>
-					</div>
-				</div>';
+							<a class="edac-ml-1 button" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=scan' ) ); ?>">
+								<?php esc_html_e( 'Start New Scan', 'accessibility-checker' ); ?>
+							</a>
 
-			$html .= '
-				<div class="edac-welcome-grid-c2 edac-welcome-grid-item' . ( ( $summary['distinct_errors_without_contrast'] > 0 ) ? ' has-errors' : ' has-no-errors' ) . '">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['distinct_errors_without_contrast_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . sprintf( _n( 'Unique Error', 'Unique Errors', $summary['distinct_errors_without_contrast_formatted'], 'accessibility-checker' ), $summary['distinct_errors_without_contrast_formatted'] ) . '</div>
-					</div>
-				</div>
-			
-				<div class="edac-welcome-grid-c3 edac-welcome-grid-item' . ( ( $summary['distinct_contrast_errors'] > 0 ) ? ' has-contrast-errors' : ' has-no-contrast-errors' ) . '">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['distinct_contrast_errors_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . sprintf( _n( 'Unique Color Contrast Error', 'Unique Color Contrast Errors', $summary['distinct_contrast_errors_formatted'], 'accessibility-checker' ), $summary['distinct_contrast_errors_formatted'] ) . '</div>
-					</div>
-				</div>
-			
-				<div class="edac-welcome-grid-c4 edac-welcome-grid-item' . ( ( $summary['distinct_warnings'] > 0 ) ? ' has-warning' : ' has-no-warning' ) . '">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['distinct_warnings_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . sprintf( _n( 'Unique Warning', 'Unique Warnings', $summary['distinct_warnings_formatted'], 'accessibility-checker' ), $summary['distinct_warnings_formatted'] ) . '</div>
-					</div>
-				</div>
-			
-				<div class="edac-welcome-grid-c5 edac-welcome-grid-item' . ( ( $summary['distinct_ignored'] > 0 ) ? ' has-ignored' : ' has-no-ignored' ) . '">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['distinct_ignored_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . sprintf( _n( 'Ignored Item', 'Ignored Items', $summary['distinct_ignored_formatted'], 'accessibility-checker' ), $summary['distinct_ignored_formatted'] ) . '</div>
-					</div>
-				</div>';
-			
-			$html .= '
-				<div class="edac-welcome-grid-c6 edac-welcome-grid-item edac-background-light">
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . esc_html__( 'Average Issues Per Page', 'accessibility-checker' ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . $summary['avg_issues_per_post_formatted'] . '</div>
-					</div>
-				</div>
-			
-				<div class="edac-welcome-grid-c7 edac-welcome-grid-item edac-background-light">
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . esc_html__( 'Average Issue Density', 'accessibility-checker' ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['avg_issue_density_percentage_formatted'] ) . '</div>
-					</div>
-				</div>
-			
-				<div class="edac-welcome-grid-c8 edac-welcome-grid-item edac-background-light">
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . esc_html__( 'Report Last Updated:', 'accessibility-checker' ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						';
-				
-			if ( $summary['fullscan_completed_at'] > 0 ) {
-				$html .= '
-							<div class="edac-stat-number edac-timestamp-to-local">' . esc_html( $summary['fullscan_completed_at_formatted'] ) . '</div>';
-			} else {
-				$html .= '
-							<div class="edac-stat-number">' . esc_html__( 'Never', 'accessibility-checker' ) . '</div>';
-			}
+							<a class="edac-ml-1 button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_issues' ) ); ?>">
+								<?php esc_html_e( 'View All Open Issues', 'accessibility-checker' ); ?>
+							</a>
 
-			$html .= '
-					</div>
-				</div>
-
-				<div class="edac-welcome-grid-c9 edac-welcome-grid-item edac-background-light">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['posts_scanned_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . esc_html__( 'URLs Scanned', 'accessibility-checker' ) . '</div>
-					</div>
-				</div>
-
-				<div class="edac-welcome-grid-c10 edac-welcome-grid-item edac-background-light">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['scannable_post_types_count_formatted'] ) . ' ' . esc_html__( 'of', 'accessibility-checker' ) . ' ' . esc_html( $summary['public_post_types_count_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . esc_html__( 'Post Types Checked', 'accessibility-checker' ) . '</div>
-					</div>
-				</div>
-
-				<div class="edac-welcome-grid-c11 edac-welcome-grid-item edac-background-light">
-					<div class="edac-inner-row">
-						<div class="edac-stat-number">' . esc_html( $summary['posts_without_issues_formatted'] ) . '</div>
-					</div>
-					<div class="edac-inner-row">
-						<div class="edac-stat-label">' . esc_html__( 'URLs with 100% score', 'accessibility-checker' ) . '</div>
-					</div>
-				</div>
-
-			</div>';
-
-			$html .= '<div><p>' . __( 'This summary is automatically updated every 24 hours, or any time a full site scan is completed. You can also manually update these results by clicking the Update Counts button.', 'accessibility-checker' ) . '</p></div>';
-
-			if ( $summary['is_truncated'] ) {
-				$html .= '<div class="edac-center-text edac-mt-3">Your site has a large number of issues. For performance reasons, not all issues have been included in this summary.</div>';
-			}
-	
-			$html .= '
-			</section>';
-			
-		} elseif ( true !== boolval( get_user_meta( get_current_user_id(), 'edac_welcome_cta_dismissed', true ) ) ) {
-	
-			$html .= '
-			<section>
-				<div class="edac-cols edac-cols-header">
-					<h3 class="edac-cols-left">' . esc_html__( 'Site-Wide Accessibility Reports', 'accessibility-checker' ) . '</h3>
-
-					<p class="edac-cols-right"> 
-						<button id="dismiss_welcome_cta" class="button">' . esc_html__( 'Hide banner', 'accessibility-checker' ) . '</button>
-					</p>
-				</div>
-
-				<div class="edac-modal-container"> 
-					<div class="edac-modal">
-						<div class="edac-modal-content">
-							<h3 class="edac-align-center">' . esc_html__( 'Unlock Detailed Accessibility Reports', 'accessibility-checker' ) . '</h3>
-							<p class="edac-align-center">' . esc_html__( 'Start scanning your entire website for accessibility issues, get full-site reports, and become compliant with accessibility guidelines faster.', 'accessibility-checker' ) . '</p>
-							<p class="edac-align-center">
-								<a class="button button-primary" href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">
-									' . esc_html__( 'Upgrade Accessibility Checker', 'accessibility-checker' ) . '
+							<?php if ( get_option( 'edacah_enable_show_history_button', false ) ) : ?>
+								<a class="edac-ml-1 button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_audit_history' ) ); ?>">
+									<?php esc_html_e( 'See History', 'accessibility-checker' ); ?>
 								</a>
-							</p>
-						</div>	
-					</div>					
-				</div>
-			</section>';
+							<?php endif; ?>
+						</p>
+					</div>
 
-		}
-		
-		$html .= '
-		</div>';
+					<div class="edac-welcome-grid-container">
+						<div class="edac-welcome-grid-c1 edac-welcome-grid-item edac-background-light" style="grid-area: 1 / 1 / span 2;">
+							<div class="edac-circle-progress" role="progressbar" aria-valuenow="<?php echo esc_attr( $summary['passed_percentage'] ); ?>" aria-valuemin="0" aria-valuemax="100" style="text-align: center; background: radial-gradient(closest-side, white 90%, transparent 80% 100%), conic-gradient(#006600 <?php echo esc_attr( $summary['passed_percentage'] ); ?>%, #e2e4e7 0);">
+								<div class="edac-progress-percentage edac-xxx-large-text">
+									<?php echo esc_html( $summary['passed_percentage_formatted'] ); ?>
+								</div>
+								<div class="edac-progress-label edac-large-text">
+									<?php esc_html_e( 'Passed Tests', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+						</div>
 
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $html;
+						<div class="edac-welcome-grid-c2 edac-welcome-grid-item <?php echo ( $summary['distinct_errors_without_contrast'] > 0 ) ? 'has-errors' : ' has-no-errors'; ?>">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['distinct_errors_without_contrast_formatted'] ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php
+										echo esc_html(
+											sprintf(
+												_n(
+													'Unique Error',
+													'Unique Errors',
+													$summary['distinct_errors_without_contrast_formatted'],
+													'accessibility-checker'
+												),
+												$summary['distinct_errors_without_contrast_formatted']
+											)
+										);
+									?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c3 edac-welcome-grid-item <?php echo ( $summary['distinct_contrast_errors'] > 0 ) ? 'has-contrast-errors' : 'has-no-contrast-errors'; ?>">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['distinct_contrast_errors_formatted'] ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php
+										echo esc_html(
+											sprintf(
+												_n(
+													'Unique Color Contrast Error',
+													'Unique Color Contrast Errors',
+													$summary['distinct_contrast_errors_formatted'],
+													'accessibility-checker'
+												),
+												$summary['distinct_contrast_errors_formatted']
+											)
+										);
+									?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c4 edac-welcome-grid-item <?php echo ( $summary['distinct_warnings'] > 0 ) ? 'has-warning' : 'has-no-warning'; ?>">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['distinct_warnings_formatted'] ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php
+										echo esc_html(
+											sprintf(
+												_n(
+													'Unique Warning',
+													'Unique Warnings',
+													$summary['distinct_warnings_formatted'],
+													'accessibility-checker'
+												),
+												$summary['distinct_warnings_formatted']
+											)
+										);
+									?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c5 edac-welcome-grid-item <?php echo ( $summary['distinct_ignored'] > 0 ) ? 'has-ignored' : 'has-no-ignored'; ?>">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['distinct_ignored_formatted'] ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php
+										echo esc_html(
+											sprintf(
+												_n(
+													'Ignored Item',
+													'Ignored Items',
+													$summary['distinct_ignored_formatted'],
+													'accessibility-checker'
+												),
+												$summary['distinct_ignored_formatted']
+											)
+										);
+									?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c6 edac-welcome-grid-item edac-background-light">
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php esc_html_e( 'Average Issues Per Page', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['avg_issues_per_post_formatted'] ); ?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c7 edac-welcome-grid-item edac-background-light">
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php esc_html_e( 'Average Issue Density', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['avg_issue_density_percentage_formatted'] ); ?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c8 edac-welcome-grid-item edac-background-light">
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php esc_html_e( 'Report Last Updated:', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<?php if ( $summary['fullscan_completed_at'] > 0 ) : ?>
+									<div class="edac-stat-number edac-timestamp-to-local">
+										<?php echo esc_html( $summary['fullscan_completed_at_formatted'] ); ?>
+									</div>
+								<?php else : ?>
+									<div class="edac-stat-number">
+										<?php esc_html_e( 'Never', 'accessibility-checker' ); ?>
+									</div>
+								<?php endif; ?>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c9 edac-welcome-grid-item edac-background-light">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['posts_scanned_formatted'] ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php esc_html_e( 'URLs Scanned', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c10 edac-welcome-grid-item edac-background-light">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php
+										printf(
+											// translators: %1$s is the number of post types with issues, %2$s is the number of public post types.
+											esc_html__( '%1$s of %2$s', 'accessibility-checker' ),
+											esc_html( $summary['scannable_post_types_count_formatted'] ),
+											esc_html( $summary['public_post_types_count_formatted'] )
+										);
+									?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php esc_html_e( 'Post Types Checked', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+						</div>
+
+						<div class="edac-welcome-grid-c11 edac-welcome-grid-item edac-background-light">
+							<div class="edac-inner-row">
+								<div class="edac-stat-number">
+									<?php echo esc_html( $summary['posts_without_issues_formatted'] ); ?>
+								</div>
+							</div>
+							<div class="edac-inner-row">
+								<div class="edac-stat-label">
+									<?php echo esc_html__( 'URLs with 100% score', 'accessibility-checker' ); ?>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<div>
+						<p>
+							<?php esc_html_e( 'This summary is automatically updated every 24 hours, or any time a full site scan is completed. You can also manually update these results by clicking the Update Counts button.', 'accessibility-checker' ); ?>
+						</p>
+					</div>
+
+					<?php if ( $summary['is_truncated'] ) : ?>
+						<div class="edac-center-text edac-mt-3">
+							<?php esc_html_e( 'Your site has a large number of issues. For performance reasons, not all issues have been included in this summary.', 'accessibility-checker' ); ?>
+						</div>
+					<?php endif; ?>
+				</section>
+
+			<?php elseif ( true !== boolval( get_user_meta( get_current_user_id(), 'edac_welcome_cta_dismissed', true ) ) ) : ?>
+
+				<section>
+					<div class="edac-cols edac-cols-header">
+						<h3 class="edac-cols-left">
+							<?php esc_html_e( 'Site-Wide Accessibility Reports', 'accessibility-checker' ); ?>
+						</h3>
+
+						<p class="edac-cols-right">
+							<button id="dismiss_welcome_cta" class="button">
+								<?php esc_html_e( 'Hide banner', 'accessibility-checker' ); ?>
+							</button>
+						</p>
+					</div>
+
+					<div class="edac-modal-container">
+						<div class="edac-modal">
+							<div class="edac-modal-content">
+								<h3 class="edac-align-center">
+									<?php esc_html_e( 'Unlock Detailed Accessibility Reports', 'accessibility-checker' ); ?>
+								</h3>
+								<p class="edac-align-center">
+									<?php esc_html_e( 'Start scanning your entire website for accessibility issues, get full-site reports, and become compliant with accessibility guidelines faster.', 'accessibility-checker' ); ?>
+								</p>
+								<p class="edac-align-center">
+									<a class="button button-primary" href="https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">
+										<?php esc_html_e( 'Upgrade Accessibility Checker', 'accessibility-checker' ); ?>
+									</a>
+								</p>
+							</div>
+						</div>
+					</div>
+				</section>
+
+			<?php endif; ?>
+
+		</div>
+		<?php
 	}
 
 
@@ -229,7 +329,7 @@ class Welcome_Page {
 	 * @return void
 	 */
 	public static function render_email_opt_in( $zx, $zcld, $zctd, $zc_form_ix ) {
-		
+
 		$current_user = wp_get_current_user();
 		$email        = $current_user->user_email;
 
@@ -238,59 +338,65 @@ class Welcome_Page {
 		}
 
 		$form_id = 'sf' . $zc_form_ix;
+		?>
 
-		$html = '
-			<script type="text/javascript" src="https://zmp-glf.maillist-manage.com/js/optin.min.js" onload="setupSF(\'' . esc_attr( $form_id ) . '\',\'ZCFORMVIEW\',false,\'light\',false,\'0\')"></script>
-			<script type="text/javascript">
-				var _edac_email_opt_in_email = "";
-				function runOnFormSubmit_' . esc_html( $form_id ) . '(th){
-					_edac_email_opt_in_email = document.querySelector("#EMBED_FORM_EMAIL_LABEL").value;
-				};
-			</script>
+		<script type="text/javascript" src="https://zmp-glf.maillist-manage.com/js/optin.min.js" onload="setupSF(\'<?php echo esc_attr( $form_id ); ?>\',\'ZCFORMVIEW\',false,\'light\',false,\'0\')"></script>
+		<script type="text/javascript">
+			var _edac_email_opt_in_email = "";
+			function runOnFormSubmit_<?php echo esc_html( $form_id ); ?>(th) {
+				_edac_email_opt_in_email = document.querySelector("#EMBED_FORM_EMAIL_LABEL").value;
+			};
+		</script>
 
-			<div class="edac-panel edac-mt-1 edac-pb-3">
-			<div id="' . esc_attr( $form_id ) . '" data-type="signupform" style="opacity: 1;">
-
-			<div id="customForm">
+		<div class="edac-panel edac-mt-1 edac-pb-3">
+			<div id="<?php echo esc_attr( $form_id ); ?>" data-type="signupform" style="opacity: 1;">
+				<div id="customForm">
 					<div class="quick_form_8_css" name="SIGNUP_BODY">
 						<div>
-							<h2 id="SIGNUP_HEADING">' . __( 'Get Notified of Upcoming Events', 'accessibility-checker' ) . '</h2>
-							<div>' . __( 'Join our email list and get event reminders and recordings in your inbox.', 'accessibility-checker' ) . '</div>
+							<h2 id="SIGNUP_HEADING">
+								<?php esc_html_e( 'Get Notified of Upcoming Events', 'accessibility-checker' ); ?>
+							</h2>
+							<div>
+								<?php esc_html_e( 'Join our email list and get event reminders and recordings in your inbox.', 'accessibility-checker' ); ?>
+							</div>
 							<div>
 								<div id="Zc_SignupSuccess" style="display: none;"></div>
 							</div>
-							
+
 							<form method="POST" id="zcampaignOptinForm" style="margin: 0px; width: 100%" action="https://zmp-glf.maillist-manage.com/weboptin.zc" target="_zcSignup">
-							
-							<div class="SIGNUP_FLD edac-mt-3" id="edac-opt-in-email">
-								<label style="font-weight: 600;" for="EMBED_FORM_EMAIL_LABEL">Email Address (Required)</label>
-								<input style="max-width: 100%;" type="email" changeitem="SIGNUP_FORM_FIELD" name="CONTACT_EMAIL" id="EMBED_FORM_EMAIL_LABEL" aria-describedby="email-info-region" value="' . esc_attr( $email ) . '">
-							</div>
-							<div class="edac-mt-0" style="display: none;" id="errorMsgDiv">' . __( 'Please enter a valid email address.', 'accessibility-checker' ) . '</div>
-						
-							<div class="SIGNUP_FLD edac-mt-3">
-								<input type="button" class="button" name="SIGNUP_SUBMIT_BUTTON" id="zcWebOptin" value="' . __( 'Subscribe', 'accessibility-checker' ) . '">
-							</div>
-						
-							
-							<input type="hidden" id="fieldBorder" value="">
-							<input type="hidden" id="submitType" name="submitType" value="optinCustomView">
-							<input type="hidden" id="emailReportId" name="emailReportId" value="">
-							<input type="hidden" id="formType" name="formType" value="QuickForm">
-							<input type="hidden" name="zcvers" value="3.0">
-							<input type="hidden" name="oldListIds" id="allCheckedListIds" value="">
-							<input type="hidden" id="mode" name="mode" value="OptinCreateView">
-							<input type="hidden" id="document_domain" value="">
-							<input type="hidden" id="zc_Url" value="zmp-glf.maillist-manage.com">
-							<input type="hidden" id="new_optin_response_in" value="2">
-							<input type="hidden" id="duplicate_optin_response_in" value="2">
-							<input type="hidden" name="zc_trackCode" id="zc_trackCode" value="ZCFORMVIEW">
-							<input type="hidden" id="viewFrom" value="URL_ACTION">
-							<input type="hidden" name="zx" id="cmpZuid" value="' . esc_attr( $zx ) . '">
-							<input type="hidden" id="zcld" name="zcld" value="' . esc_attr( $zcld ) . '">
-							<input type="hidden" id="zctd" name="zctd" value="' . esc_attr( $zctd ) . '">
-							<input type="hidden" id="zc_formIx" name="zc_formIx" value="' . esc_attr( $zc_form_ix ) . '">
-							<span style="display: none" id="dt_CONTACT_EMAIL">1,true,6,Contact Email,2</span>
+
+								<div class="SIGNUP_FLD edac-mt-3" id="edac-opt-in-email">
+									<label style="font-weight: 600;" for="EMBED_FORM_EMAIL_LABEL">
+										<?php esc_html_e( 'Email Address (Required)', 'accessibility-checker' ); ?>
+									</label>
+									<input style="max-width: 100%;" type="email" changeitem="SIGNUP_FORM_FIELD" name="CONTACT_EMAIL" id="EMBED_FORM_EMAIL_LABEL" aria-describedby="email-info-region" value="<?php echo esc_attr( $email ); ?>">
+								</div>
+								<div class="edac-mt-0" style="display: none;" id="errorMsgDiv">
+									<?php esc_html_e( 'Please enter a valid email address.', 'accessibility-checker' ); ?>
+								</div>
+
+								<div class="SIGNUP_FLD edac-mt-3">
+									<input type="button" class="button" name="SIGNUP_SUBMIT_BUTTON" id="zcWebOptin" value="<?php esc_attr_e( 'Subscribe', 'accessibility-checker' ); ?>">
+								</div>
+
+								<input type="hidden" id="fieldBorder" value="">
+								<input type="hidden" id="submitType" name="submitType" value="optinCustomView">
+								<input type="hidden" id="emailReportId" name="emailReportId" value="">
+								<input type="hidden" id="formType" name="formType" value="QuickForm">
+								<input type="hidden" name="zcvers" value="3.0">
+								<input type="hidden" name="oldListIds" id="allCheckedListIds" value="">
+								<input type="hidden" id="mode" name="mode" value="OptinCreateView">
+								<input type="hidden" id="document_domain" value="">
+								<input type="hidden" id="zc_Url" value="zmp-glf.maillist-manage.com">
+								<input type="hidden" id="new_optin_response_in" value="2">
+								<input type="hidden" id="duplicate_optin_response_in" value="2">
+								<input type="hidden" name="zc_trackCode" id="zc_trackCode" value="ZCFORMVIEW">
+								<input type="hidden" id="viewFrom" value="URL_ACTION">
+								<input type="hidden" name="zx" id="cmpZuid" value="<?php echo esc_attr( $zx ); ?>">
+								<input type="hidden" id="zcld" name="zcld" value="<?php echo esc_attr( $zcld ); ?>">
+								<input type="hidden" id="zctd" name="zctd" value="<?php echo esc_attr( $zctd ); ?>">
+								<input type="hidden" id="zc_formIx" name="zc_formIx" value="<?php echo esc_attr( $zc_form_ix ); ?>">
+								<span style="display: none" id="dt_CONTACT_EMAIL">1,true,6,Contact Email,2</span>
 							</form>
 
 							<!-- Confirmation Message -->
@@ -310,13 +416,13 @@ class Welcome_Page {
 				<span style="position: absolute;top: -16px;right:-14px;z-index:99999;cursor: pointer;" id="closeSuccess">
 					<img src="https://zmp-glf.maillist-manage.com/images/videoclose.png" alt="close">
 				</span>
-				<div>' . __( 'There was a problem saving your email. Please try again.', 'accessibility-checker' ) . '
+				<div>
+					<?php esc_html_e( 'There was a problem saving your email. Please try again.', 'accessibility-checker' ); ?>
 					<div id="zcOptinSuccessPanel"></div>
 				</div>
 			</div>
-			
-			<script>
 
+			<script>
 				function initOnComplete(){
 					const optIn = document.querySelector("#edac-opt-in-email");
 
@@ -324,48 +430,38 @@ class Welcome_Page {
 					function handleHtmlChange(mutationsList, observer) {
 						for (const mutation of mutationsList) {
 							if (mutation.type === "childList") {
-		
 
 								const data = { action: "edac_email_opt_in_ajax", nonce: edac_script_vars.nonce };
 								const queryString = Object.keys(data)
 									.map(key => encodeURIComponent(key) + "=" + encodeURIComponent(data[key]))
 									.join("&");
 
-
 								fetch(ajaxurl + "?" + queryString )
 								.then(response => {
 									if (!response.ok) {
 										throw new Error("There was a network problem. Please try again.");
 									} else {
-									
-										// HTML content of the element has changed so assume zoho has saved the email.
 
+										// HTML content of the element has changed so assume zoho has saved the email.
 										document.querySelector("#zcampaignOptinForm").remove();
-				
+
 										// Populate the confirmation message
 										const confirmMessage = document.getElementById("confirmationMessage");
-										confirmMessage.textContent = "' . esc_js( __( 'Thank-you for joining!', 'accessibility-checker' ) ) . '";
+										confirmMessage.textContent = "<?php echo esc_js( esc_html__( 'Thank-you for joining!', 'accessibility-checker' ) ); ?>";
 										confirmMessage.classList.add("edac-mt-3");
 										confirmMessage.focus();
-				
-										
+
 										document.querySelectorAll(".opt-in-show").forEach((item) => {
 											item.style.display = "block";
 										});
-						
 									}
 								})
 								.catch(error => {
 									// Handle errors here
 								});
-
-					
-								
 							}
 						}
 					}
-				
-				
 
 					// Create a MutationObserver to watch for changes in the HTML content
 					const observer = new MutationObserver(handleHtmlChange);
@@ -380,9 +476,7 @@ class Welcome_Page {
 
 				initOnComplete();
 			</script>
-			</div>';
-	
-		//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped	
-		echo $html;
+		</div>
+		<?php
 	}
 }

--- a/includes/classes/class-widgets.php
+++ b/includes/classes/class-widgets.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class file for widgets
- * 
+ *
  * @package Accessibility_Checker
  */
 
@@ -11,7 +11,7 @@ namespace EDAC;
  * Class that handles widgets
  */
 class Widgets {
-	
+
 
 	/**
 	 * Renders as widget
@@ -22,15 +22,15 @@ class Widgets {
 
 		$html  = '';
 		$html .= '
-	
+
 		<div class="edac-widget">';
-		
+
 		if ( Settings::get_scannable_post_types() && Settings::get_scannable_post_statuses() ) {
-		
+
 			$pro_modal_html = '';
-			if ( ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || 
-			false == EDAC_KEY_VALID ) &&
-			true !== boolval( get_user_meta( get_current_user_id(), 'edac_dashboard_cta_dismissed', true ) ) 
+			if ( ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ||
+			false === EDAC_KEY_VALID ) &&
+			true !== boolval( get_user_meta( get_current_user_id(), 'edac_dashboard_cta_dismissed', true ) )
 			) {
 				$pro_modal_html = '
 			<div class="edac-modal">
@@ -44,36 +44,36 @@ class Widgets {
 				</div>
 			</div>';
 			}
-	
-			if ( ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' != $pro_modal_html ) {
-	
+
+			if ( ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' !== $pro_modal_html ) {
+
 				$html .= '
 			<div class="edac-summary edac-modal-container edac-hidden">';
 
 				$html .= $pro_modal_html;
-		
+
 				$html .= '
-			<h3 class="edac-summary-header">' . 
-				__( 'Full Site Accessibility Status', 'accessibility-checker' ) . 
+			<h3 class="edac-summary-header">' .
+				__( 'Full Site Accessibility Status', 'accessibility-checker' ) .
 				'</h3>
 			<div class="edac-summary-passed">
-				<div id="edac-summary-passed" class="edac-circle-progress" role="progressbar" aria-valuenow="0" 
+				<div id="edac-summary-passed" class="edac-circle-progress" role="progressbar" aria-valuenow="0"
 					aria-valuemin="0" aria-valuemax="100"
-					style="text-align: center; 
-					background: radial-gradient(closest-side, white 85%, transparent 80% 100%), 
+					style="text-align: center;
+					background: radial-gradient(closest-side, white 85%, transparent 80% 100%),
 					conic-gradient(#006600 0%, #e2e4e7 0);">
 					<div class="edac-progress-percentage">-</div>
-					<div class="edac-progress-label">' . 
-					__( 'Passed Tests', 'accessibility-checker' ) . 
+					<div class="edac-progress-label">' .
+					__( 'Passed Tests', 'accessibility-checker' ) .
 					'</div>
 				</div>
 			</div>
-		
+
 			<div class="edac-summary-info">
 				<div class="edac-summary-info-date">
 					<div class="edac-summary-info-date-label">' . __( 'Report Last Updated:', 'accessibility-checker' ) . '</div>
 					<div id="edac-summary-info-date" class="edac-summary-info-date-date edac-timestamp-to-local">-</div>';
-		
+
 				$html .= '
 				</div>
 
@@ -101,7 +101,7 @@ class Widgets {
 				</div>
 			</div>
 			';
-			
+
 				$html .= '
 			<div class="edac-summary-notice edac-summary-notice-has-issues edac-hidden">
 				' . __( 'Your site has accessibility issues that should be addressed as soon as possible to ensure compliance with accessibility guidelines.', 'accessibility-checker' ) . '
@@ -109,21 +109,21 @@ class Widgets {
 			 <div class="edac-summary-notice edac-summary-notice-no-issues edac-hidden">
 				' . __( 'Way to go! Accessibility Checker cannot find any accessibility problems in the content it tested. Some problems cannot be found by automated tools so don\'t forget to', 'accessibility-checker' ) . ' <a href="https://equalizedigital.com/accessibility-checker/how-to-manually-check-your-website-for-accessibility/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=dashboard-widget">' . __( 'manually test your site', 'accessibility-checker' ) . '</a>.
 			</div>';
-		
+
 				$html .= '
 		</div>
 		<hr class="edac-hr" />';
-		
+
 			}
 		}
-	
+
 		$html .= '
-		
+
 		<div class="edac-issues-summary edac-hidden">
 
 			<h3 class="edac-issues-summary-header">
 				' . __( 'Issues By Post Type', 'accessibility-checker' ) . '
-			</h3> 
+			</h3>
 
 			<table class="widefat striped">
 				<thead>
@@ -144,25 +144,24 @@ class Widgets {
 				</thead>
 
 				<tbody>';
-			
+
 				$scannable_post_types = Settings::get_scannable_post_types();
-			
+
 				$post_types = get_post_types(
 					array(
 						'public' => true,
-					) 
+					)
 				);
 				unset( $post_types['attachment'] );
-					
-			
+
 		foreach ( $post_types as $post_type ) {
 
 			$post_types_to_check = array_merge( array( 'post', 'page' ), $scannable_post_types );
-				
-			if ( in_array( $post_type, $post_types_to_check ) ) {
-		
-				if ( in_array( $post_type, $scannable_post_types ) ) {
-		
+
+			if ( in_array( $post_type, $post_types_to_check, true ) ) {
+
+				if ( in_array( $post_type, $scannable_post_types, true ) ) {
+
 					$html .= '
 							<tr>
 								<th scope="col">' . esc_html( ucwords( $post_type ) ) . '</th>
@@ -178,10 +177,10 @@ class Widgets {
 								<td>-</td>
 								<td>-</td>
 							</tr>';
-							
-				}           
+
+				}
 			} elseif ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
-						
+
 				$html .= '
 						<tr >
 							<th scope="col">' . esc_html( ucwords( $post_type ) ) . '</th>
@@ -189,7 +188,7 @@ class Widgets {
 							<td>-</td>
 							<td>-</td>
 						</tr>';
-			
+
 			} else {
 
 				$html .= '
@@ -203,25 +202,24 @@ class Widgets {
 								</div>
 							</td>
 						</tr>';
-				
-			}       
-		}   
+
+			}
+		}
 
 		$html .= '
 				</tbody>
 			</table>
 		</div>';
-		
+
 		$html .= '<div class="edac-summary-notice edac-summary-notice-is-truncated edac-hidden">Your site has a large number of issues. For performance reasons, not all issues have been included in this report.</div>';
-	
+
 		if ( ! Settings::get_scannable_post_types() || ! Settings::get_scannable_post_statuses() ) {
 
-			$html .= '<div class="edac-summary-notice edac-summary-notice-no-posts">There are no pages set to be checked. Update the post types to be checked under the 
+			$html .= '<div class="edac-summary-notice edac-summary-notice-no-posts">There are no pages set to be checked. Update the post types to be checked under the
 			<a href="/wp-admin/admin.php?page=accessibility_checker_settings">general settings</a> tab.</div>';
-	
+
 		}
 
-		
 		$html .= '
 		<div class="edac-buttons-container edac-mt-3 edac-mb-3">
 		';
@@ -230,8 +228,6 @@ class Widgets {
 			$html .= '
 			<a class="button edac-mr-1" href="/wp-admin/admin.php?page=accessibility_checker">' . __( 'See More Reports', 'accessibility-checker' ) . '</a>';
 		}
-			
-		
 
 		$html .= '
 		<a href="/wp-admin/admin.php?page=accessibility_checker_settings">Edit Accessibility Checker Settings</a>

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -48,13 +48,13 @@ function edac_admin_enqueue_scripts() {
 		if ( 'post.php' === $pagenow ) {
 			// Load the app in scan mode when editing a post/page.
 			edac_enqueue_scripts( 'editor-scan' );
-		}   
+		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
-		if ( 'accessibility-checker_page_accessibility_checker_settings' === get_current_screen()->id && isset( $_GET['tab'] ) && 'scan' === sanitize_text_field( $_GET['tab'] ) ) { 
+		if ( 'accessibility-checker_page_accessibility_checker_settings' === get_current_screen()->id && isset( $_GET['tab'] ) && 'scan' === sanitize_text_field( $_GET['tab'] ) ) {
 			// Load the app in scan mode on the scan tab in the settings.
 			edac_enqueue_scripts( 'full-scan' );
-		}   
+		}
 	}
 }
 
@@ -62,11 +62,11 @@ function edac_admin_enqueue_scripts() {
 /**
  * Enqueue scripts
  *
- * @param string $mode 
+ * @param string $mode The enqueue scripts mode (ui, full-scan, editor-scan).
  * @return void
  */
 function edac_enqueue_scripts( $mode = '' ) {
-	
+
 	global $post;
 	$post_id = is_object( $post ) ? $post->ID : null;
 
@@ -76,7 +76,7 @@ function edac_enqueue_scripts( $mode = '' ) {
 
 	$pro               = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true;
 	$has_pending_scans = false;
-	
+
 	$headers = array(
 		'Content-Type' => 'application/json',
 		'X-WP-Nonce'   => wp_create_nonce( 'wp_rest' ),
@@ -84,16 +84,16 @@ function edac_enqueue_scripts( $mode = '' ) {
 
 	if ( '' === $mode ) {
 		if ( ( current_user_can( 'edit_post', $post_id ) && ! is_customize_preview() )
-		) {  
+		) {
 			$mode = 'ui';
 		} else {
 			return;
 		}
 	}
-	
+
 	if ( ( 'full-scan' === $mode && $pro )
 			||
-			( 'ui' === $mode || 'editor-scan' === $mode  
+			( 'ui' === $mode || 'editor-scan' === $mode
 			&&
 			$post_id && current_user_can( 'edit_post', $post_id ) )
 	) {
@@ -101,7 +101,7 @@ function edac_enqueue_scripts( $mode = '' ) {
 		wp_enqueue_script( 'edac-app', plugin_dir_url( __DIR__ ) . 'build/app.bundle.js', false, EDAC_VERSION, false );
 
 		$active = null;
-	
+
 		if ( 'ui' === $mode ) {
 			// We are on ui/preview page. Set $active true to have the scanner show.
 			$post_types        = get_option( 'edac_post_types' );
@@ -113,24 +113,22 @@ function edac_enqueue_scripts( $mode = '' ) {
 			}
 		}
 
-
-	
-	
 		if ( $pro ) {
 
 			$username = get_option( 'edacp_authorization_username' );
-			$password = get_option( 'edacp_authorization_password' );   
+			$password = get_option( 'edacp_authorization_password' );
 			if ( $username && $password ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				$headers['Authorization'] = 'Basic ' . base64_encode( "$username:$password" );
-			}       
+			}
 		} else {
-			
+
 			$server_headers = getallheaders();
 			if ( isset( $server_headers['Authorization'] ) ) {
 				$headers['Authorization'] = 'None';
-			}       
+			}
 		}
-	
+
 		wp_enqueue_style( 'edac-app', plugin_dir_url( __DIR__ ) . 'build/css/app.css', false, EDAC_VERSION, 'all' );
 
 		wp_localize_script(
@@ -148,7 +146,7 @@ function edac_enqueue_scripts( $mode = '' ) {
 				'active'      => $active,
 				'mode'        => $mode,
 				'scanUrl'     => get_preview_post_link(
-					$post_id, 
+					$post_id,
 					array(
 						'edac-action'        => 'js-scan',
 						'edac-preview-nonce' => wp_create_nonce( 'edac-preview_nonce' ),
@@ -158,5 +156,5 @@ function edac_enqueue_scripts( $mode = '' ) {
 			)
 		);
 
-	}       
+	}
 }

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -74,8 +74,7 @@ function edac_enqueue_scripts( $mode = '' ) {
 		return;
 	}
 
-	$pro               = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true;
-	$has_pending_scans = false;
+	$pro = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true;
 
 	$headers = array(
 		'Content-Type' => 'application/json',

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -311,7 +311,7 @@ function edac_str_get_html(
 	$target_charset = DEFAULT_TARGET_CHARSET,
 	$strip_rn = true,
 	$default_br_text = DEFAULT_BR_TEXT,
-	$default_span_text = DEFAULT_SPAN_TEXT 
+	$default_span_text = DEFAULT_SPAN_TEXT
 ) {
 	$dom = new EDAC_Dom(
 		null,
@@ -341,13 +341,13 @@ function edac_str_get_html(
 function edac_remove_elements( $dom, $css_selectors = array() ) {
 
 	if ( $dom ) {
-		
+
 		foreach ( $css_selectors as $css_selector ) {
 			$elements = $dom->find( $css_selector );
 			foreach ( $elements as $element ) {
 				if ( null !== $element ) {
 					$element->remove();
-				}   
+				}
 			}
 		}
 	}
@@ -362,13 +362,13 @@ function edac_remove_elements( $dom, $css_selectors = array() ) {
  * The function first checks if the provided table name only contains alphanumeric characters, underscores, or hyphens.
  * If not, it returns null.
  *
- * After that, it checks if a table with that name actually exists in the database using the SHOW TABLES LIKE query. 
+ * After that, it checks if a table with that name actually exists in the database using the SHOW TABLES LIKE query.
  * If the table doesn't exist, it also returns null.
  *
  * If both checks are passed, it returns the valid table name.
  *
  * @param string $table_name The name of the table to be validated.
- * 
+ *
  * @return string|null The validated table name, or null if the table name is invalid or the table does not exist.
  */
 function edac_get_valid_table_name( $table_name ) {
@@ -381,8 +381,8 @@ function edac_get_valid_table_name( $table_name ) {
 	}
 
 	// Verify that the table actually exists in the database.
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared 
-	if ( $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) != $table_name ) {
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
 		// Table does not exist.
 		return null;
 	}
@@ -444,7 +444,7 @@ function edac_replace_css_variables( $value, $css_array ) {
 
 /**
  * Generates a nonce that expires after a specified number of seconds.
- * 
+ *
  * @param string $secret secret.
  * @param int    $timeout_seconds The number of seconds after which the nonce expires.
  * @return string
@@ -476,18 +476,18 @@ function edac_generate_nonce( $secret, $timeout_seconds = 120 ) {
  * @return boolean
  */
 function edac_is_valid_nonce( $secret, $nonce ) {
-	if ( is_string( $nonce ) == false ) {
+	if ( ! is_string( $nonce ) ) {
 		return false;
 	}
 	$a = explode( ',', $nonce );
-	if ( count( $a ) != 3 ) {
+	if ( count( $a ) !== 3 ) {
 		return false;
 	}
 	$salt     = $a[0];
 	$max_time = intval( $a[1] );
 	$hash     = $a[2];
 	$back     = sha1( $salt . $secret . $max_time );
-	if ( $back != $hash ) {
+	if ( $back !== $hash ) {
 		return false;
 	}
 	if ( time() > $max_time ) {
@@ -507,7 +507,7 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 
 	$key    = 'upcoming_meetups__' . sanitize_title( $meetup ) . '__' . intval( $count );
 	$output = get_transient( $key );
-	
+
 	if ( false === $output ) {
 
 		$query_args = array(
@@ -519,7 +519,7 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 		$request_uri = 'https://api.meetup.com/' . sanitize_title( $meetup ) . '/events';
 		$request     = wp_remote_get( add_query_arg( $query_args, $request_uri ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get -- wp_remote_get needed to be compatible with all environments.
 
-		if ( is_wp_error( $request ) || '200' != wp_remote_retrieve_response_code( $request ) ) {
+		if ( is_wp_error( $request ) || '200' !== (int) wp_remote_retrieve_response_code( $request ) ) {
 			return;
 		}
 
@@ -528,7 +528,6 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 			return;
 		}
 
-	
 		set_transient( $key, $output, DAY_IN_SECONDS );
 	}
 
@@ -545,7 +544,7 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
  * @param  integer $paragraph_count number of paragraphs to return.
  * @return json
  */
-function edac_get_upcoming_meetups_html( $meetup, $count = 5, $truncate = true, $paragraph_count = 1 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- $truncate is used in the future.	
+function edac_get_upcoming_meetups_html( $meetup, $count = 5, $truncate = true, $paragraph_count = 1 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- $truncate is used in the future.
 
 	$json = edac_get_upcoming_meetups_json( $meetup, $count );
 
@@ -554,11 +553,11 @@ function edac_get_upcoming_meetups_html( $meetup, $count = 5, $truncate = true, 
 	}
 
 	$html = '<ul class="edac-upcoming-meetup-list">';
-	
+
 	foreach ( $json as $event ) {
 
 		$desc = edac_truncate_html_content( $event->description, $paragraph_count );
-		
+
 		$link_text = 'Attend Free';
 
 		$html .= '
@@ -594,30 +593,29 @@ function edac_truncate_html_content( $html, $paragraph_count = 1 ) {
 		'em'     => array(),
 		'i'      => array(),
 	);
-	
 
 	$html = wp_kses( $html, $allowed_tags );
 
 	// Create a new DOMDocument instance.
 	$dom = new DOMDocument();
 	$dom->loadHTML( $html );
-	
+
 	// Find the <body> element.
 	$body_element = $dom->getElementsByTagName( 'body' )->item( 0 );
-	
+
 	if ( $body_element ) {
-		
+
 		$content = array();
-	
+
 		// Loop through the child nodes of the <body> element.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOMDocument uses camelCase.
-		foreach ( $body_element->childNodes as $child_node ) { 
+		foreach ( $body_element->childNodes as $child_node ) {
 			if ( 'p' === $child_node->nodeName || 'div' === $child_node->nodeName ) {
 				$content[] = '<p>' . $child_node->textContent . '</p>';
 			}
 		}
 		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		
+
 		if ( count( $content ) > 0 ) {
 			return implode(
 				PHP_EOL,
@@ -648,12 +646,12 @@ function edac_get_issue_density( $issue_count, $element_count, $content_length )
 
 	$error_elements_percentage = $issue_count / $element_count;
 	$error_content_percentage  = $issue_count / $content_length;
-	
+
 	$score = ( ( $error_elements_percentage * $element_weight ) + ( $error_content_percentage * $content_weight ) );
-	
+
 	return round( $score * 100, 2 );
 }
-	
+
 
 /**
  * Get info from html that we need for calculating density
@@ -663,15 +661,14 @@ function edac_get_issue_density( $issue_count, $element_count, $content_length )
  */
 function edac_get_body_density_data( $html ) {
 
-			
 	if ( $html && trim( $html ) !== '' ) {
-	
+
 		$density_dom = new simple_html_dom();
 		$density_dom->load( $html );
 
 		$body_element = $density_dom->find( 'body', 0 );
-	
-		if ( null == $body_element ) {
+
+		if ( ! $body_element ) {
 			return false;
 		}
 
@@ -679,22 +676,21 @@ function edac_get_body_density_data( $html ) {
 		foreach ( $body_element->find( '.edac-highlight-panel,#wpadminbar,style,script' ) as $element ) {
 			$element->remove();
 		}
-		
+
 		if ( $body_element ) {
-		
+
 			$body_elements_count = edac_count_dom_descendants( $body_element );
-			
+
 			$body_content = preg_replace( '/[^A-Za-z0-9]/', '', $body_element->plaintext );
 
 			return array(
 				$body_elements_count,
 				strlen( $body_content ),
 			);
-		
-		}   
+
+		}
 	}
-			
-	
+
 	return false;
 }
 
@@ -703,13 +699,13 @@ function edac_get_body_density_data( $html ) {
  * Recursively count elements in a dom
  *
  * @param object $dom_elements dom elements.
- * @return int 
+ * @return int
  */
 function edac_count_dom_descendants( $dom_elements ) {
 	$count = 0;
 
 	foreach ( $dom_elements->children() as $child ) {
-		++$count; 
+		++$count;
 		$count += edac_count_dom_descendants( $child ); // Recursively count descendants.
 	}
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -519,7 +519,7 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 		$request_uri = 'https://api.meetup.com/' . sanitize_title( $meetup ) . '/events';
 		$request     = wp_remote_get( add_query_arg( $query_args, $request_uri ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get -- wp_remote_get needed to be compatible with all environments.
 
-		if ( is_wp_error( $request ) || '200' !== (int) wp_remote_retrieve_response_code( $request ) ) {
+		if ( is_wp_error( $request ) || 200 !== (int) wp_remote_retrieve_response_code( $request ) ) {
 			return;
 		}
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -544,7 +544,7 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
  * @param  integer $paragraph_count number of paragraphs to return.
  * @return json
  */
-function edac_get_upcoming_meetups_html( $meetup, $count = 5, $truncate = true, $paragraph_count = 1 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- $truncate is used in the future.
+function edac_get_upcoming_meetups_html( $meetup, $count = 5, $truncate = true, $paragraph_count = 1 ) { // phpcs:ignore -- $truncate is used in the future.
 
 	$json = edac_get_upcoming_meetups_json( $meetup, $count );
 
@@ -555,10 +555,7 @@ function edac_get_upcoming_meetups_html( $meetup, $count = 5, $truncate = true, 
 	$html = '<ul class="edac-upcoming-meetup-list">';
 
 	foreach ( $json as $event ) {
-
-		$desc = edac_truncate_html_content( $event->description, $paragraph_count );
-
-		$link_text = 'Attend Free';
+		$link_text = esc_html__( 'Attend Free', 'accessibility-checker' );
 
 		$html .= '
 		<li class="edac-upcoming-meetup-item edac-mb-3">

--- a/includes/insert.php
+++ b/includes/insert.php
@@ -8,13 +8,13 @@
 /**
  * Insert rule date into database
  *
- * @param object $post the post object.
- * @param string $rule the rule.
- * @param string $ruletype the rule type.
- * @param string $object the object.
+ * @param object $post     The post object.
+ * @param string $rule     The rule.
+ * @param string $ruletype The rule type.
+ * @param string $rule_obj The object.
  * @return void
  */
-function edac_insert_rule_data( $post, $rule, $ruletype, $object ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound -- Object is a valid parameter name in this context.
+function edac_insert_rule_data( $post, $rule, $ruletype, $rule_obj ) {
 
 	global $wpdb;
 	$table_name = $wpdb->prefix . 'accessibility_checker';
@@ -26,7 +26,7 @@ function edac_insert_rule_data( $post, $rule, $ruletype, $object ) { // phpcs:ig
 		'type'          => $post->post_type,
 		'rule'          => $rule,
 		'ruletype'      => $ruletype,
-		'object'        => esc_attr( $object ),
+		'object'        => esc_attr( $rule_obj ),
 		'recordcheck'   => 1,
 		'user'          => get_current_user_id(),
 		'ignre'         => 0,
@@ -45,8 +45,8 @@ function edac_insert_rule_data( $post, $rule, $ruletype, $object ) { // phpcs:ig
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 	$results = $wpdb->get_results(
 		$wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe variable used for table name.
-			'SELECT postid, ignre FROM ' . $table_name . ' where type = %s and postid = %d and rule = %s and object = %s and siteid = %d',
+			'SELECT postid, ignre FROM %i where type = %s and postid = %d and rule = %s and object = %s and siteid = %d',
+			$table_name,
 			$rule_data['type'],
 			$rule_data['postid'],
 			$rule_data['rule'],
@@ -69,8 +69,8 @@ function edac_insert_rule_data( $post, $rule, $ruletype, $object ) { // phpcs:ig
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 			$wpdb->query(
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe variable used for table name.
-					'UPDATE ' . $table_name . ' SET recordcheck = %d, ignre = %d  WHERE siteid = %d and postid = %d and rule = %s and object = %s and type = %s',
+					'UPDATE %i SET recordcheck = %d, ignre = %d  WHERE siteid = %d and postid = %d and rule = %s and object = %s and type = %s',
+					$table_name,
 					1,
 					$rule_data['ignre'],
 					$rule_data['siteid'],
@@ -136,8 +136,8 @@ function edac_insert_ignore_data() {
 	$ignore_global        = ( 'enable' === $action && isset( $_REQUEST['ignore_global'] ) ) ? sanitize_textarea_field( $_REQUEST['ignore_global'] ) : 0;
 
 	foreach ( $ids as $id ) {
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
-		$wpdb->query( $wpdb->prepare( 'UPDATE ' . $table_name . ' SET ignre = %d, ignre_user = %d, ignre_date = %s, ignre_comment = %s, ignre_global = %d WHERE siteid = %d and id = %d', $ignre, $ignre_user, $ignre_date, $ignre_comment, $ignore_global, $siteid, $id ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		$wpdb->query( $wpdb->prepare( 'UPDATE %i SET ignre = %d, ignre_user = %d, ignre_date = %s, ignre_comment = %s, ignre_global = %d WHERE siteid = %d and id = %d', $table_name, $ignre, $ignre_user, $ignre_date, $ignre_comment, $ignore_global, $siteid, $id ) );
 	}
 
 	$data = array(

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -210,8 +210,7 @@ function edac_register_setting() {
  */
 function edac_general_cb() {
 	echo '<p>';
-	
-	
+
 	printf(
 		/* translators: %1$s: link to the plugin documentation website. */
 		esc_html__( 'Use the settings below to configure Accessibility Checker. Additional information about each setting can be found in the %1$s.', 'accessibility-checker' ),
@@ -364,7 +363,7 @@ function edac_post_types_cb() {
 		</fieldset>
 		<?php if ( EDAC_KEY_VALID === false ) { ?>
 			<p class="edac-description">
-				<?php 
+				<?php
 				echo esc_html__( 'To check content other than posts and pages, please ', 'accessibility-checker' );
 				?>
 				<a href="https://my.equalizedigital.com/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'upgrade to pro', 'accessibility-checker' ); ?></a>
@@ -372,11 +371,11 @@ function edac_post_types_cb() {
 			</p>
 		<?php } else { ?>
 			<p class="edac-description">
-				<?php 
+				<?php
 				esc_html_e( 'Choose which post types should be checked during a scan. Please note, removing a previously selected post type will remove its scanned information and any custom ignored warnings that have been setup.', 'accessibility-checker' );
 				?>
 			</p>
-			<?php 
+			<?php
 		}
 }
 
@@ -421,7 +420,7 @@ function edac_sanitize_post_types( $selected_post_types ) {
 			delete_option( 'edacp_fullscan_completed_at' );
 		}
 	}
-	
+
 	return $selected_post_types;
 }
 

--- a/includes/purge.php
+++ b/includes/purge.php
@@ -16,8 +16,8 @@ function edac_delete_post( $post_id ) {
 	$site_id    = get_current_blog_id();
 	$table_name = $wpdb->prefix . 'accessibility_checker';
 
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
-	$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $table_name . ' WHERE postid = %d and siteid = %d', $post_id, $site_id ) );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+	$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE postid = %d and siteid = %d', $table_name, $post_id, $site_id ) );
 
 	edac_delete_post_meta( $post_id );
 }
@@ -59,12 +59,14 @@ function edac_delete_cpt_posts( $post_type ) {
 	global $wpdb;
 	$site_id = get_current_blog_id();
 
-	$postmeta_table = $wpdb->postmeta;
-	$ac_table       = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
-
-	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Safe variable used for table name.
-	$sql = $wpdb->prepare( "DELETE T1,T2 from {$postmeta_table} as T1 JOIN {$ac_table} as T2 ON t1.post_id = T2.postid WHERE t1.meta_key like %s and T2.siteid=%d and T2.type=%s", array( '_edac%', $site_id, $post_type ) );
-
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
-	return $wpdb->query( $sql );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+	return $wpdb->query(
+		$wpdb->prepare(
+			"DELETE T1,T2 from $wpdb->postmeta as T1 JOIN %i as T2 ON t1.post_id = T2.postid WHERE t1.meta_key like %s and T2.siteid=%d and T2.type=%s",
+			edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' ),
+			'_edac%',
+			$site_id,
+			$post_type
+		)
+	);
 }

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom      = $content['html'];
 	$errors   = array();

--- a/includes/rules/broken_aria_reference.php
+++ b/includes/rules/broken_aria_reference.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_broken_aria_reference( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_broken_aria_reference( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	// rule vars.
 	$dom                 = $content['html'];

--- a/includes/rules/broken_skip_anchor_link.php
+++ b/includes/rules/broken_skip_anchor_link.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_broken_skip_anchor_link( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_broken_skip_anchor_link( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom             = $content['html'];
 	$errors          = array();

--- a/includes/rules/broken_skip_anchor_link.php
+++ b/includes/rules/broken_skip_anchor_link.php
@@ -22,11 +22,11 @@ function edac_rule_broken_skip_anchor_link( $content, $post ) { // phpcs:ignore 
 		$href = $anchor_element->getAttribute( 'href' );
 
 		// exclude: '<a href="#"></a>' and '<a></a>' checked by the link_improper rule.
-		if ( trim( $anchor_element->getAttribute( 'href' ) ) == '#' || ( trim( $anchor_element->getAttribute( 'href' ) ) == '#' && $anchor_element->getAttribute( 'role' ) == 'button' ) ) {
+		if ( trim( $anchor_element->getAttribute( 'href' ) ) === '#' || ( trim( $anchor_element->getAttribute( 'href' ) ) === '#' && $anchor_element->getAttribute( 'role' ) === 'button' ) ) {
 			continue;
 		}
 
-		if ( substr( $href, 0, 1 ) == '#' ) {
+		if ( substr( $href, 0, 1 ) === '#' ) {
 			if ( ! $dom->find( $href, 0 ) ) {
 				$errors[] = $anchor_element;
 			}

--- a/includes/rules/color_contrast_failure.php
+++ b/includes/rules/color_contrast_failure.php
@@ -55,7 +55,7 @@ function edac_rule_color_contrast_failure( $content, $post ) { // phpcs:ignore G
 
 				$preference = edac_deteremine_hierarchy( $rules );
 
-				if ( 'background' == $preference ) {
+				if ( 'background' === $preference ) {
 					$background = edac_check_color_match2( $rules['background'] );
 				} elseif ( 'background-color' === $preference ) {
 					$background = $rules['background-color'];
@@ -92,11 +92,11 @@ function edac_rule_color_contrast_failure( $content, $post ) { // phpcs:ignore G
 									preg_match_all( '!\d+!', $absolute_fontsize_errorcode, $matches );
 
 									// convert pixels to points.
-									if ( stristr( $absolute_fontsize_errorcode, 'px' ) == 'px' ) {
+									if ( stristr( $absolute_fontsize_errorcode, 'px' ) === 'px' ) {
 										$font_size = implode( ' ', $matches[0] ) * 0.75;
 									}
 
-									if ( stristr( $absolute_fontsize_errorcode, 'pt' ) == 'pt' ) {
+									if ( stristr( $absolute_fontsize_errorcode, 'pt' ) === 'pt' ) {
 										$font_size = implode( ' ', $matches[0] );
 									}
 								}
@@ -230,7 +230,7 @@ function edac_check_contrast( $content ) {
 			if ( ( $font_size >= 14 && true === $font_bold ) || $font_size >= 18 ) {
 				$ratio = 3;
 			}
-			
+
 			if ( edac_coldiff( $foreground, $background, $ratio ) ) {
 
 				$error_code = $element . ' { ';
@@ -260,7 +260,7 @@ function edac_check_contrast( $content ) {
 function edac_deteremine_hierarchy( $rules ) {
 	$first = '';
 	$rules = array_reverse( $rules );
-	
+
 	foreach ( $rules as $key => $value ) {
 		if ( ( 'background' === $key || 'background-color' === $key ) && '' !== $value ) {
 			$first = $key;
@@ -269,7 +269,7 @@ function edac_deteremine_hierarchy( $rules ) {
 	}
 
 	// if background color has preference and is marked important then return background color.
-	if ( 'background-color' == $first && stristr( $rules['background-color'], '!important' ) ) {
+	if ( 'background-color' === $first && stristr( $rules['background-color'], '!important' ) ) {
 		return 'background-color';
 	}
 

--- a/includes/rules/color_contrast_failure.php
+++ b/includes/rules/color_contrast_failure.php
@@ -15,7 +15,7 @@
  * WCAG 2.0 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text.
  * Large text is defined as 14 point (typically 18.66px) and bold or larger, or 18 point (typically 24px) or larger.
  */
-function edac_rule_color_contrast_failure( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_color_contrast_failure( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	// check links in content for style tags.
 	$dom    = $content['html'];
@@ -714,13 +714,13 @@ function edac_check_color_match2( $background_rule ) {
 
 	$rules = explode( ' ', $background_rule );
 
-	foreach ( $rules as $key => $value ) {
+	foreach ( $rules as $rule ) {
 
-		if ( array_key_exists( $value, $colors ) ) {
-			return $colors[ $value ];
+		if ( array_key_exists( $rule, $colors ) ) {
+			return $colors[ $rule ];
 		}
 
-		if ( preg_match( '/(rgb\(\s*\d{1,3},\s*\d{1,3},\s*\d{1,3}\)|\#[\w]{3,6})/i', $value, $matches, PREG_OFFSET_CAPTURE ) ) {
+		if ( preg_match( '/(rgb\(\s*\d{1,3},\s*\d{1,3},\s*\d{1,3}\)|\#[\w]{3,6})/i', $rule, $matches, PREG_OFFSET_CAPTURE ) ) {
 			return $matches[1][0];
 		}
 	}

--- a/includes/rules/duplicate_form_label.php
+++ b/includes/rules/duplicate_form_label.php
@@ -24,7 +24,7 @@ function edac_rule_duplicate_form_label( $content, $post ) { // phpcs:ignore Gen
 	foreach ( $labels as $label ) {
 		$for_attr = $label->getAttribute( 'for' );
 		if ( count( $dom->find( 'label[for="' . $for_attr . '"]' ) ) > 1 ) {
-			$errors[] = __( 'Duplicate label', 'accessibility_checker' ) . ' for="' . $for_attr . '"';
+			$errors[] = __( 'Duplicate label', 'accessibility-checker' ) . ' for="' . $for_attr . '"';
 		}
 	}
 	return $errors;

--- a/includes/rules/duplicate_form_label.php
+++ b/includes/rules/duplicate_form_label.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_duplicate_form_label( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_duplicate_form_label( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/empty_button.php
+++ b/includes/rules/empty_button.php
@@ -18,7 +18,7 @@
  * <input type="reset">
  * role="button"
  */
-function edac_rule_empty_button( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_empty_button( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 	$dom     = $content['html'];
 	$buttons = $dom->find( 'button, [role=button]' );
 	$inputs  = $dom->find( 'input[type=button], input[type=submit], input[type=reset]' );

--- a/includes/rules/empty_button.php
+++ b/includes/rules/empty_button.php
@@ -27,9 +27,9 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore Generic.Cod
 	// check buttons.
 	foreach ( $buttons as $button ) {
 		if (
-			str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', trim( $button->plaintext ) ) == ''
-			&& $button->getAttribute( 'aria-label' ) == ''
-			&& $button->getAttribute( 'title' ) == ''
+			str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', trim( $button->plaintext ) ) === ''
+			&& $button->getAttribute( 'aria-label' ) === ''
+			&& $button->getAttribute( 'title' ) === ''
 		) {
 
 			$error_code = $button->outertext;
@@ -39,9 +39,9 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore Generic.Cod
 
 			if (
 				'' !== $error_code
-				&& ( ! isset( $image[0] ) || trim( $image[0]->getAttribute( 'alt' ) ) == '' )
-				&& ( ! isset( $input[0] ) || trim( $input[0]->getAttribute( 'value' ) ) == '' )
-				&& ( ! isset( $i[0] ) || ( trim( $i[0]->getAttribute( 'title' ) ) == '' ) && trim( $i[0]->getAttribute( 'aria-label' ) ) == '' )
+				&& ( ! isset( $image[0] ) || trim( $image[0]->getAttribute( 'alt' ) ) === '' )
+				&& ( ! isset( $input[0] ) || trim( $input[0]->getAttribute( 'value' ) ) === '' )
+				&& ( ! isset( $i[0] ) || ( trim( $i[0]->getAttribute( 'title' ) ) === '' ) && trim( $i[0]->getAttribute( 'aria-label' ) ) === '' )
 			) {
 				$errors[] = $error_code;
 			}
@@ -50,7 +50,7 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore Generic.Cod
 
 	// check inputs.
 	foreach ( $inputs as $input ) {
-		if ( $input->getAttribute( 'value' ) == '' ) {
+		if ( $input->getAttribute( 'value' ) === '' ) {
 			$errors[] = $input->outertext;
 		}
 	}

--- a/includes/rules/empty_form_label.php
+++ b/includes/rules/empty_form_label.php
@@ -21,7 +21,7 @@ function edac_rule_empty_form_label( $content, $post ) { // phpcs:ignore Generic
 
 	foreach ( $labels as $label ) {
 
-		$label_text = str_ireplace( array( '*', __( 'required', 'edac' ) ), '', $label->plaintext );
+		$label_text = str_ireplace( array( '*', __( 'required', 'accessibility-checker' ) ), '', $label->plaintext );
 		if ( empty( preg_replace( '/\s+/', '', $label_text ) ) ) {
 			$errors[] = $label->outertext;
 		}

--- a/includes/rules/empty_form_label.php
+++ b/includes/rules/empty_form_label.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_empty_form_label( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_empty_form_label( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	// rule vars.
 	$dom    = $content['html'];

--- a/includes/rules/empty_heading_tag.php
+++ b/includes/rules/empty_heading_tag.php
@@ -26,7 +26,7 @@ function edac_rule_empty_heading_tag( $content, $post ) { // phpcs:ignore Generi
 
 			$heading_code = $heading->outertext;
 
-			if ( ( str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', htmlentities( trim( $heading->plaintext ) ) ) == '' || str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', trim( $heading->plaintext ) ) == '' ) && ! preg_match( '#<img(\S|\s)*alt=(\'|\")(\w|\s)(\w|\s|\p{P}|\(|\)|\p{Sm}|~|`|’|\^|\$)+(\'|\")#', $heading_code ) ) {
+			if ( ( str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', htmlentities( trim( $heading->plaintext ) ) ) === '' || str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', trim( $heading->plaintext ) ) === '' ) && ! preg_match( '#<img(\S|\s)*alt=(\'|\")(\w|\s)(\w|\s|\p{P}|\(|\)|\p{Sm}|~|`|’|\^|\$)+(\'|\")#', $heading_code ) ) {
 
 				$errors[] = $heading_code;
 

--- a/includes/rules/empty_heading_tag.php
+++ b/includes/rules/empty_heading_tag.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_empty_heading_tag( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_empty_heading_tag( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	// rule vars.
 	$dom    = $content['html'];

--- a/includes/rules/empty_link.php
+++ b/includes/rules/empty_link.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_empty_link( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/empty_link.php
+++ b/includes/rules/empty_link.php
@@ -13,7 +13,7 @@
  * @return array
  */
 function edac_rule_empty_link( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
-	
+
 	$dom    = $content['html'];
 	$errors = array();
 	$links  = $dom->find( 'a' );
@@ -22,19 +22,19 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore Generic.CodeA
 		$error = false;
 
 		if (
-			str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', trim( $link->plaintext ) ) == ''
+			str_ireplace( array( ' ', '&nbsp;', '-', '_' ), '', trim( $link->plaintext ) ) === ''
 			&& $link->hasAttribute( 'href' )
-			&& $link->getAttribute( 'aria-label' ) == ''
-			&& $link->getAttribute( 'title' ) == ''
+			&& $link->getAttribute( 'aria-label' ) === ''
+			&& $link->getAttribute( 'title' ) === ''
 		) {
-	
+
 			// This link does not have plaintext within the tag &
 			// does have an href &
 			// does not have an aria-label &
 			// does not have a title.
 
 			$a_tag_code = $link->outertext;
-		
+
 			if (
 				'' !== $a_tag_code
 				&& ! $link->hasAttribute( 'id' )
@@ -45,37 +45,37 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore Generic.CodeA
 				// does not have a name.
 
 				$image = $link->find( 'img' );
-				if ( ! $error && isset( $input[0] ) && trim( $image[0]->getAttribute( 'alt' ) ) == '' ) {
+				if ( ! $error && isset( $input[0] ) && trim( $image[0]->getAttribute( 'alt' ) ) === '' ) {
 
 					// The first image inside the link does not have an alt.
 					// Throw error.
 					$error = $a_tag_code;
 				}
-			
+
 				$input = $link->find( 'input' );
-				if ( ! $error && isset( $input[0] ) && trim( $image[0]->getAttribute( 'value' ) ) == '' ) {
-			
+				if ( ! $error && isset( $input[0] ) && trim( $image[0]->getAttribute( 'value' ) ) === '' ) {
+
 					// The first input inside the link does not have a value.
 					// Throw error.
 					$error = $a_tag_code;
 				}
-	
+
 				$i = $link->find( 'i' );
-				if ( ! $error && isset( $input[0] ) && 
-				trim( $i[0]->getAttribute( 'title' ) ) == '' &&
-				trim( $i[0]->getAttribute( 'aria-label' ) ) == ''
+				if ( ! $error && isset( $input[0] ) &&
+				trim( $i[0]->getAttribute( 'title' ) ) === '' &&
+				trim( $i[0]->getAttribute( 'aria-label' ) ) === ''
 				) {
-		
+
 					// The first i inside the link does not have a title &
 					// does not have an aria-lable.
 					// Throw error.
 					$error = $a_tag_code;
-				}           
+				}
 			}
 
 			if ( $error ) {
 				$errors[] = $error;
-			}       
+			}
 		}
 	}
 	return $errors;

--- a/includes/rules/empty_table_header.php
+++ b/includes/rules/empty_table_header.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_empty_table_header( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_empty_table_header( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	// rule vars.
 	$dom            = $content['html'];

--- a/includes/rules/iframe_missing_title.php
+++ b/includes/rules/iframe_missing_title.php
@@ -19,7 +19,7 @@ function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore Gen
 	$errors      = array();
 
 	foreach ( $iframe_tags as $iframe ) {
-		if ( isset( $iframe ) && $iframe->getAttribute( 'title' ) == '' && $iframe->getAttribute( 'aria-label' ) == '' ) {
+		if ( isset( $iframe ) && $iframe->getAttribute( 'title' ) === '' && $iframe->getAttribute( 'aria-label' ) === '' ) {
 
 			$iframecode = htmlspecialchars( $iframe->outertext );
 

--- a/includes/rules/iframe_missing_title.php
+++ b/includes/rules/iframe_missing_title.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom         = $content['html'];
 	$iframe_tags = $dom->find( 'iframe' );

--- a/includes/rules/image_map_missing_alt_text.php
+++ b/includes/rules/image_map_missing_alt_text.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_image_map_missing_alt_text( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_image_map_missing_alt_text( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$maps   = $dom->find( 'map' );
@@ -20,8 +20,7 @@ function edac_rule_image_map_missing_alt_text( $content, $post ) { // phpcs:igno
 
 	foreach ( $maps as $map ) {
 
-		$mapcode = $map->outertext;
-		$areas   = $map->find( 'area' );
+		$areas = $map->find( 'area' );
 
 		foreach ( $areas as $area ) {
 

--- a/includes/rules/img_alt_empty.php
+++ b/includes/rules/img_alt_empty.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_alt_empty( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_alt_empty( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$tags   = array( 'img', 'input' );

--- a/includes/rules/img_alt_empty.php
+++ b/includes/rules/img_alt_empty.php
@@ -24,14 +24,14 @@ function edac_rule_img_alt_empty( $content, $post ) { // phpcs:ignore Generic.Co
 			foreach ( $elements as $element ) {
 				if (
 					isset( $element )
-					&& 'img' == $element->tag
+					&& 'img' === $element->tag
 					&& $element->hasAttribute( 'alt' )
-					&& $element->getAttribute( 'alt' ) == ''
-					&& $element->getAttribute( 'role' ) != 'presentation'
-					|| ( 'input' == $element->tag
+					&& $element->getAttribute( 'alt' ) === ''
+					&& $element->getAttribute( 'role' ) !== 'presentation'
+					|| ( 'input' === $element->tag
 						&& $element->hasAttribute( 'alt' )
-						&& $element->getAttribute( 'type' ) == 'image'
-						&& $element->getAttribute( 'alt' ) == '' )
+						&& $element->getAttribute( 'type' ) === 'image'
+						&& $element->getAttribute( 'alt' ) === '' )
 				) {
 
 					$image_code = $element->outertext;

--- a/includes/rules/img_alt_invalid.php
+++ b/includes/rules/img_alt_invalid.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom = $content['html'];
 

--- a/includes/rules/img_alt_invalid.php
+++ b/includes/rules/img_alt_invalid.php
@@ -93,7 +93,7 @@ function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore Generic.
 				$alt         = strtolower( $image->getAttribute( 'alt' ) );
 				$alt_trimmed = preg_replace( '/\s+/', ' ', trim( $alt ) );
 				$image_code  = $image->outertext;
-				
+
 				// ignore certain images.
 				if ( edac_img_alt_ignore_plugin_issues( $image_code ) ) {
 					break;
@@ -103,9 +103,9 @@ function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore Generic.
 				if ( edac_img_alt_ignore_inside_valid_caption( $image_code, $dom ) ) {
 					break;
 				}
-				
+
 				// check if alt contains only whitespace.
-				if ( strlen( $alt ) > 0 && ctype_space( $alt ) == true ) {
+				if ( strlen( $alt ) > 0 && ctype_space( $alt ) === true ) {
 					$error = true;
 				}
 
@@ -132,7 +132,7 @@ function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore Generic.
 				// check for image extensions.
 				if ( false === $error && $image_extensions ) {
 					foreach ( $image_extensions as $image_extension ) {
-						if ( strpos( $alt, $image_extension ) == true ) {
+						if ( strpos( $alt, $image_extension ) === true ) {
 							$error = true;
 							break;
 						}
@@ -142,7 +142,7 @@ function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore Generic.
 				// check for specific keyword matches.
 				if ( false === $error && $keywords ) {
 					foreach ( $keywords as $keyword ) {
-						if ( $alt_trimmed == $keyword ) {
+						if ( $alt_trimmed === $keyword ) {
 							$error = true;
 							break;
 						}
@@ -158,7 +158,7 @@ function edac_rule_img_alt_invalid( $content, $post ) { // phpcs:ignore Generic.
 						}
 					}
 				}
-				
+
 				// check if the alt is composed of only numbers.
 				if ( false === $error ) {
 					if ( ctype_digit( $alt_trimmed ) ) {

--- a/includes/rules/img_alt_long.php
+++ b/includes/rules/img_alt_long.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_alt_long( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_alt_long( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/img_alt_long.php
+++ b/includes/rules/img_alt_long.php
@@ -19,7 +19,7 @@ function edac_rule_img_alt_long( $content, $post ) { // phpcs:ignore Generic.Cod
 	$images = $dom->find( 'img' );
 
 	foreach ( $images as $image ) {
-		if ( isset( $image ) && $image->hasAttribute( 'alt' ) && $image->getAttribute( 'alt' ) != '' ) {
+		if ( isset( $image ) && $image->hasAttribute( 'alt' ) && $image->getAttribute( 'alt' ) !== '' ) {
 			$alt = $image->getAttribute( 'alt' );
 			if ( strlen( $alt ) > 300 ) {
 				$image_code = $image;

--- a/includes/rules/img_alt_missing.php
+++ b/includes/rules/img_alt_missing.php
@@ -25,11 +25,11 @@ function edac_rule_img_alt_missing( $content, $post ) { // phpcs:ignore Generic.
 			if ( isset( $element )
 			&& ( 'img' === $element->tag
 			&& ! $element->hasAttribute( 'alt' )
-			&& $element->getAttribute( 'role' ) != 'presentation' )
-			&& $element->getAttribute( 'aria-hidden' ) != 'true'
+			&& $element->getAttribute( 'role' ) !== 'presentation' )
+			&& $element->getAttribute( 'aria-hidden' ) !== 'true'
 			|| ( 'input' === $element->tag
 			&& ! $element->hasAttribute( 'alt' )
-			&& $element->getAttribute( 'type' ) == 'image' )
+			&& $element->getAttribute( 'type' ) === 'image' )
 			) {
 
 				$image_code = $element->outertext;
@@ -91,7 +91,7 @@ function edac_img_alt_ignore_inside_valid_caption( $image_code, $content ) {
 	foreach ( $figures as $figure ) {
 		$images = $figure->find( 'img' );
 		foreach ( $images as $image ) {
-			if ( $image->getAttribute( 'src' ) != '' && strstr( $image_code, $image->getAttribute( 'src' ) ) && trim( $figure->plaintext ) != '' ) {
+			if ( $image->getAttribute( 'src' ) !== '' && strstr( $image_code, $image->getAttribute( 'src' ) ) && trim( $figure->plaintext ) !== '' ) {
 				return 1;
 			}
 		}
@@ -103,7 +103,7 @@ function edac_img_alt_ignore_inside_valid_caption( $image_code, $content ) {
 		if ( stristr( $div->getAttribute( 'class' ), 'wp-caption' ) ) {
 			$images = $div->find( 'img' );
 			foreach ( $images as $image ) {
-				if ( $image->getAttribute( 'src' ) != '' && strstr( $image_code, $image->getAttribute( 'src' ) ) && strlen( $div->plaintext ) > 5 ) {
+				if ( $image->getAttribute( 'src' ) !== '' && strstr( $image_code, $image->getAttribute( 'src' ) ) && strlen( $div->plaintext ) > 5 ) {
 					return 1;
 				}
 			}
@@ -113,10 +113,10 @@ function edac_img_alt_ignore_inside_valid_caption( $image_code, $content ) {
 	// anchors with aria-label or title or valid node text.
 	$as = $dom->find( 'a' );
 	foreach ( $as as $a ) {
-		if ( $a->getAttribute( 'aria-label' ) != '' || $a->getAttribute( 'title' ) != '' || strlen( $a->plaintext ) > 5 ) {
+		if ( $a->getAttribute( 'aria-label' ) !== '' || $a->getAttribute( 'title' ) !== '' || strlen( $a->plaintext ) > 5 ) {
 			$images = $a->find( 'img' );
 			foreach ( $images as $image ) {
-				if ( $image->getAttribute( 'src' ) != '' && strstr( $image_code, $image->getAttribute( 'src' ) ) ) {
+				if ( $image->getAttribute( 'src' ) !== '' && strstr( $image_code, $image->getAttribute( 'src' ) ) ) {
 					return 1;
 				}
 			}

--- a/includes/rules/img_alt_missing.php
+++ b/includes/rules/img_alt_missing.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_alt_missing( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_alt_missing( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$tags   = array( 'img', 'input' );

--- a/includes/rules/img_alt_redundant.php
+++ b/includes/rules/img_alt_redundant.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_alt_redundant( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_alt_redundant( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$content = $content['html'];
 	$dom     = $content;

--- a/includes/rules/img_alt_redundant.php
+++ b/includes/rules/img_alt_redundant.php
@@ -24,7 +24,7 @@ function edac_rule_img_alt_redundant( $content, $post ) { // phpcs:ignore Generi
 	 */
 	$images = $dom->find( 'img' );
 	foreach ( $images as $image ) {
-		if ( $image->getAttribute( 'alt' ) != '' ) {
+		if ( $image->getAttribute( 'alt' ) !== '' ) {
 			$pattern = '/' . "(.*?)alt=[\"\']\b" . preg_quote( strtolower( trim( $image->getAttribute( 'alt' ) ) ), '/' ) . "\b[\"\'](.*?)\b" . preg_quote( strtolower( trim( $image->getAttribute( 'alt' ) ) ), '/' ) . "\b" . '/';
 			if ( preg_match( $pattern, $content, $matches ) ) {
 				if ( ! stristr( $matches[0], '<a' ) ) {
@@ -40,7 +40,7 @@ function edac_rule_img_alt_redundant( $content, $post ) { // phpcs:ignore Generi
 	 */
 	$images = $dom->find( 'img' );
 	foreach ( $images as $image ) {
-		if ( $image->getAttribute( 'alt' ) != '' && $image->getAttribute( 'title' ) != '' ) {
+		if ( $image->getAttribute( 'alt' ) !== '' && $image->getAttribute( 'title' ) !== '' ) {
 			if ( isset( $image ) && edac_compare_strings( $image->getAttribute( 'title' ), $image->getAttribute( 'alt' ) ) ) {
 				$errors[] = $image->outertext;
 			}
@@ -55,9 +55,9 @@ function edac_rule_img_alt_redundant( $content, $post ) { // phpcs:ignore Generi
 	foreach ( $links as $link ) {
 		$images = $link->getElementsByTagName( 'img' );
 		foreach ( $images as $image ) {
-			if ( $image->getAttribute( 'alt' ) != '' ) {
+			if ( $image->getAttribute( 'alt' ) !== '' ) {
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Simple HTML DOM Parser uses camelCase.
-				if ( isset( $link ) && isset( $image ) && ( strtolower( trim( $link->nodeValue ) ) === strtolower( trim( $image->getAttribute( 'alt' ) ) ) || strtolower( trim( $image->getAttribute( 'title' ) ) ) == strtolower( trim( $image->getAttribute( 'alt' ) ) )
+				if ( isset( $link ) && isset( $image ) && ( strtolower( trim( $link->nodeValue ) ) === strtolower( trim( $image->getAttribute( 'alt' ) ) ) || strtolower( trim( $image->getAttribute( 'title' ) ) ) === strtolower( trim( $image->getAttribute( 'alt' ) ) )
 					)
 				) {
 					$errors[] = $link->outertext;
@@ -82,8 +82,8 @@ function edac_rule_img_alt_redundant( $content, $post ) { // phpcs:ignore Generi
 				$image          = $figure->getElementsByTagName( 'img' )[0];
 				$figcaptioncode = $figurecaption->plaintext;
 				if ( isset( $image )
-					&& strtolower( trim( $figcaptioncode ) ) == strtolower( trim( $image->getAttribute( 'alt' ) ) )
-					&& $image->getAttribute( 'alt' ) != '' ) {
+					&& strtolower( trim( $figcaptioncode ) ) === strtolower( trim( $image->getAttribute( 'alt' ) ) )
+					&& $image->getAttribute( 'alt' ) !== '' ) {
 
 					$errors[] = $figure;
 				}

--- a/includes/rules/img_animated_gif.php
+++ b/includes/rules/img_animated_gif.php
@@ -25,7 +25,7 @@ function edac_rule_img_animated_gif( $content, $post ) { // phpcs:ignore Generic
 	if ( $gifs ) {
 		foreach ( $gifs as $gif ) {
 
-			if ( edac_img_gif_is_animated( $gif->getAttribute( 'src' ) ) == false ) {
+			if ( edac_img_gif_is_animated( $gif->getAttribute( 'src' ) ) === false ) {
 				continue;
 			}
 
@@ -38,7 +38,7 @@ function edac_rule_img_animated_gif( $content, $post ) { // phpcs:ignore Generic
 	if ( $webps ) {
 		foreach ( $webps as $webp ) {
 
-			if ( edac_img_webp_is_animated( $webp->getAttribute( 'src' ) ) == false ) {
+			if ( edac_img_webp_is_animated( $webp->getAttribute( 'src' ) ) === false ) {
 				continue;
 			}
 
@@ -75,7 +75,7 @@ function edac_rule_img_animated_gif( $content, $post ) { // phpcs:ignore Generic
  * @return bool
  */
 function edac_img_gif_is_animated( $filename ) {
-	
+
 	$upload_dir_info  = wp_get_upload_dir();
 	$uploads_base_dir = trailingslashit( $upload_dir_info['basedir'] );
 
@@ -120,6 +120,7 @@ function edac_img_gif_is_animated( $filename ) {
 		$count += preg_match_all( '#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $chunk, $matches );
 	}
 
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 	fclose( $fh );
 	return $count > 1;
 }
@@ -156,7 +157,7 @@ function edac_img_webp_is_animated( $filename ) {
 		// Handle the error, for example, by logging it or returning false.
 		return false;
 	}
-	
+
 	// See: https://stackoverflow.com/questions/45190469/how-to-identify-whether-webp-image-is-static-or-animated.
 	$result = false;
 	fseek( $fh, 12 );
@@ -167,6 +168,8 @@ function edac_img_webp_is_animated( $filename ) {
 		$byte   = fread( $fh, 1 );
 		$result = ( ( ord( $byte ) >> 1 ) & 1 ) ? true : false;
 	}
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 	fclose( $fh );
 	return $result;
 }

--- a/includes/rules/img_animated_gif.php
+++ b/includes/rules/img_animated_gif.php
@@ -15,7 +15,7 @@
  * checks all gif images that are animated
  * checks for giphy and tenor gif embeds
  */
-function edac_rule_img_animated_gif( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_animated_gif( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/img_linked_alt_empty.php
+++ b/includes/rules/img_linked_alt_empty.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_linked_alt_empty( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_linked_alt_empty( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/img_linked_alt_empty.php
+++ b/includes/rules/img_linked_alt_empty.php
@@ -17,19 +17,19 @@ function edac_rule_img_linked_alt_empty( $content, $post ) { // phpcs:ignore Gen
 	$dom    = $content['html'];
 	$errors = array();
 	$as     = $dom->find( 'a' );
-	
+
 	foreach ( $as as $a ) {
 
 		// anchors with aria-label or title or valid node text.
-		if ( $a->getAttribute( 'aria-label' ) == '' && $a->getAttribute( 'title' ) == '' && strlen( $a->plaintext ) <= 5 ) {
+		if ( $a->getAttribute( 'aria-label' ) === '' && $a->getAttribute( 'title' ) === '' && strlen( $a->plaintext ) <= 5 ) {
 
 			$images = $a->find( 'img' );
 			foreach ( $images as $image ) {
 
 				if ( isset( $image )
 					&& $image->hasAttribute( 'alt' )
-					&& $image->getAttribute( 'alt' ) == ''
-					&& $image->getAttribute( 'role' ) != 'presentation' ) {
+					&& $image->getAttribute( 'alt' ) === ''
+					&& $image->getAttribute( 'role' ) !== 'presentation' ) {
 
 					$image_code = $a;
 

--- a/includes/rules/img_linked_alt_missing.php
+++ b/includes/rules/img_linked_alt_missing.php
@@ -17,16 +17,16 @@ function edac_rule_img_linked_alt_missing( $content, $post ) { // phpcs:ignore G
 	$dom    = $content['html'];
 	$errors = array();
 	$as     = $dom->find( 'a' );
-	
+
 	foreach ( $as as $a ) {
 
 		// anchors with aria-label or title or valid node text.
-		if ( $a->getAttribute( 'aria-label' ) == '' && $a->getAttribute( 'title' ) == '' && strlen( $a->plaintext ) <= 5 ) {
+		if ( $a->getAttribute( 'aria-label' ) === '' && $a->getAttribute( 'title' ) === '' && strlen( $a->plaintext ) <= 5 ) {
 
 			$images = $a->find( 'img' );
 			foreach ( $images as $image ) {
 
-				if ( isset( $image ) && ( ! $image->hasAttribute( 'alt' ) && $image->getAttribute( 'role' ) != 'presentation' ) && $image->getAttribute( 'aria-hidden' ) != 'true' ) {
+				if ( isset( $image ) && ( ! $image->hasAttribute( 'alt' ) && $image->getAttribute( 'role' ) !== 'presentation' ) && $image->getAttribute( 'aria-hidden' ) !== 'true' ) {
 
 					$image_code = $a;
 

--- a/includes/rules/img_linked_alt_missing.php
+++ b/includes/rules/img_linked_alt_missing.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_img_linked_alt_missing( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_img_linked_alt_missing( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/incorrect_heading_order.php
+++ b/includes/rules/incorrect_heading_order.php
@@ -24,7 +24,7 @@ function edac_rule_incorrect_heading_order( $content, $post ) {
 	$previous               = $starting_heading_level;
 
 	if ( $elements ) {
-		foreach ( $elements as $key => $element ) {
+		foreach ( $elements as $element ) {
 			if ( $element->hasAttribute( 'aria-level' ) ) {
 				$current = $element->getAttribute( 'aria-level' );
 			} else {

--- a/includes/rules/incorrect_heading_order.php
+++ b/includes/rules/incorrect_heading_order.php
@@ -32,8 +32,8 @@ function edac_rule_incorrect_heading_order( $content, $post ) {
 			}
 
 			// Only process the logic if $previous is set and $current is not equal to $previous.
-			if ( $previous && $current != $previous ) {
-				if ( $current > $previous && $current != $previous + 1 ) {
+			if ( $previous && $current !== $previous ) {
+				if ( $current > $previous && $current !== $previous + 1 ) {
 					$errors[] = $element->outertext;
 				}
 			}

--- a/includes/rules/link_ambiguous_text.php
+++ b/includes/rules/link_ambiguous_text.php
@@ -32,7 +32,7 @@
  * img alt:
  * <a href="link.html"><img src="image.jpg" alt="Read More"></a>
  */
-function edac_rule_link_ambiguous_text( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_link_ambiguous_text( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/link_ambiguous_text.php
+++ b/includes/rules/link_ambiguous_text.php
@@ -144,7 +144,7 @@ function edac_check_ambiguous_phrase( $text ) {
 
 	// check if text is equal to.
 	foreach ( $ambiguous_phrases as $ambiguous_phrase ) {
-		if ( $text == $ambiguous_phrase ) {
+		if ( $text === $ambiguous_phrase ) {
 			return true;
 		}
 	}

--- a/includes/rules/link_blank.php
+++ b/includes/rules/link_blank.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_link_blank( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_link_blank( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$content  = $content['html'];
 	$errors   = array();

--- a/includes/rules/link_improper.php
+++ b/includes/rules/link_improper.php
@@ -20,7 +20,7 @@ function edac_rule_link_improper( $content, $post ) { // phpcs:ignore Generic.Co
 	$errors = array();
 	$links  = $dom->find( 'a' );
 	foreach ( $links as $link ) {
-		if ( ( ! $link->hasAttribute( 'href' ) || trim( $link->getAttribute( 'href' ) ) == '#' ) && $link->getAttribute( 'role' ) != 'button' ) {
+		if ( ( ! $link->hasAttribute( 'href' ) || trim( $link->getAttribute( 'href' ) ) === '#' ) && $link->getAttribute( 'role' ) !== 'button' ) {
 			$a_tag_code = $link->outertext;
 			$errors[]   = $a_tag_code;
 		}

--- a/includes/rules/link_improper.php
+++ b/includes/rules/link_improper.php
@@ -14,7 +14,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_link_improper( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_link_improper( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/link_ms_office_file.php
+++ b/includes/rules/link_ms_office_file.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_link_ms_office_file( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_link_ms_office_file( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom             = $content['html'];
 	$file_extensions = array( '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.pps', '.ppsx' );

--- a/includes/rules/link_non_html_file.php
+++ b/includes/rules/link_non_html_file.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_link_non_html_file( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_link_non_html_file( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom             = $content['html'];
 	$file_extensions = array( '.rtf', '.wpd', '.ods', '.odt', '.odp', '.sxw', '.sxc', '.sxd', '.sxi', '.pages', '.key' );

--- a/includes/rules/link_pdf.php
+++ b/includes/rules/link_pdf.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_link_pdf( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_link_pdf( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/link_pdf.php
+++ b/includes/rules/link_pdf.php
@@ -17,7 +17,7 @@ function edac_rule_link_pdf( $content, $post ) { // phpcs:ignore Generic.CodeAna
 	$dom    = $content['html'];
 	$errors = array();
 	$as     = $dom->find( 'a' );
-	
+
 	foreach ( $as as $a ) {
 
 		if ( $a->getAttribute( 'href' ) ) {

--- a/includes/rules/long_description_invalid.php
+++ b/includes/rules/long_description_invalid.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_long_description_invalid( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_long_description_invalid( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom              = $content['html'];
 	$images           = $dom->find( 'img' );

--- a/includes/rules/long_description_invalid.php
+++ b/includes/rules/long_description_invalid.php
@@ -28,11 +28,11 @@ function edac_rule_long_description_invalid( $content, $post ) { // phpcs:ignore
 				$file_parts = pathinfo( $longdesc );
 				$valid_url  = filter_var( $longdesc, FILTER_VALIDATE_URL );
 
-				if ( $image->getAttribute( 'longdesc' ) == ''
+				if ( $image->getAttribute( 'longdesc' ) === ''
 				|| ! $valid_url
 				|| ! $file_parts['extension']
 				|| ! $file_parts['filename']
-				|| in_array( '.' . $file_parts['extension'], $image_extensions )
+				|| in_array( '.' . $file_parts['extension'], $image_extensions, true )
 				) {
 					$errors[] = $image_code;
 				}

--- a/includes/rules/missing_form_label.php
+++ b/includes/rules/missing_form_label.php
@@ -12,10 +12,9 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_missing_form_label( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_missing_form_label( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
-	$labels = $dom->find( 'label' );
 	$fields = $dom->find( 'input' );
 	$errors = array();
 

--- a/includes/rules/missing_form_label.php
+++ b/includes/rules/missing_form_label.php
@@ -13,15 +13,14 @@
  * @return array
  */
 function edac_rule_missing_form_label( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
-	
-	$dom          = $content['html'];
-	$labels       = $dom->find( 'label' );
-	$fields       = $dom->find( 'input' );
-	$ignore_types = array( 'submit', 'hidden', 'button', 'reset' );
-	$errors       = array();
-	
+
+	$dom    = $content['html'];
+	$labels = $dom->find( 'label' );
+	$fields = $dom->find( 'input' );
+	$errors = array();
+
 	foreach ( $fields as $field ) {
-		if ( in_array( $field->getAttribute( 'type' ), $ignore_types ) ) {
+		if ( in_array( $field->getAttribute( 'type' ), array( 'submit', 'hidden', 'button', 'reset' ), true ) ) {
 			continue;
 		}
 		if ( ! ac_input_has_label( $field, $dom ) ) {
@@ -43,7 +42,7 @@ function ac_input_has_label( $field, $dom ) {
 		return true;
 	} elseif ( $field->getAttribute( 'aria-label' ) ) {
 		return true;
-	} elseif ( $dom->find( 'label[for="' . $field->getAttribute( 'id' ) . '"]', -1 ) != '' ) {
+	} elseif ( $dom->find( 'label[for="' . $field->getAttribute( 'id' ) . '"]', -1 ) !== '' ) {
 		return true;
 	} else {
 		return edac_field_has_label_parent( $field );
@@ -65,7 +64,7 @@ function edac_field_has_label_parent( $field ) {
 	if ( null === $parent ) {
 		return false;
 	}
-	
+
 	$tag = $parent->tag;
 	if ( 'label' === $tag ) {
 		return true;

--- a/includes/rules/missing_headings.php
+++ b/includes/rules/missing_headings.php
@@ -29,7 +29,7 @@ function edac_rule_missing_headings( $content, $post ) { // phpcs:ignore Generic
 	$headings = ( $h2 + $h3 + $h4 + $h5 + $h6 );
 
 	if ( 0 === $headings ) {
-		$errorcode = __( 'Missing headings - Post ID: ', 'edac' ) . $post->ID;
+		$errorcode = __( 'Missing headings - Post ID: ', 'accessibility-checker' ) . $post->ID;
 		return array( $errorcode );
 	}
 }

--- a/includes/rules/missing_headings.php
+++ b/includes/rules/missing_headings.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_missing_headings( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- $content is reserved for future use or for compliance with a specific interface.
+function edac_rule_missing_headings( $content, $post ) { // phpcs:ignore -- $content is reserved for future use or for compliance with a specific interface.
 
 	$word_count = str_word_count( wp_strip_all_tags( $post->post_content ) );
 

--- a/includes/rules/missing_lang_attr.php
+++ b/includes/rules/missing_lang_attr.php
@@ -17,7 +17,7 @@ function edac_rule_missing_lang_attr( $content, $post ) { // phpcs:ignore Generi
 	$errors   = array();
 	$elements = $content['html']->find( 'html' );
 	if ( $elements[0] ) {
-		if ( ( $elements[0]->hasAttribute( 'lang' ) && $elements[0]->getAttribute( 'lang' ) != '' ) || ( $elements[0]->hasAttribute( 'xml:lang' ) && $elements[0]->getAttribute( 'xml:lang' ) != '' ) ) {
+		if ( ( $elements[0]->hasAttribute( 'lang' ) && $elements[0]->getAttribute( 'lang' ) !== '' ) || ( $elements[0]->hasAttribute( 'xml:lang' ) && $elements[0]->getAttribute( 'xml:lang' ) !== '' ) ) {
 			return;
 		}
 		$errors[] = edac_simple_dom_remove_child( $elements[0] );

--- a/includes/rules/missing_lang_attr.php
+++ b/includes/rules/missing_lang_attr.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_missing_lang_attr( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_missing_lang_attr( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$errors   = array();
 	$elements = $content['html']->find( 'html' );

--- a/includes/rules/missing_table_header.php
+++ b/includes/rules/missing_table_header.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_missing_table_header( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_missing_table_header( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/missing_title.php
+++ b/includes/rules/missing_title.php
@@ -23,7 +23,7 @@ function edac_rule_missing_title( $content, $post ) {
 		$error = array( "Missing Title - Post ID: $post->ID" );
 	} elseif (
 		( ! isset( $title ) || '' === $title->innertext || '-' === $title->innertext )
-		&& ( ! isset( $meta_title ) || ( $meta_title->hasAttribute( 'content' ) && ( $meta_title->getAttribute( 'content' ) == '' || strlen( $meta_title->getAttribute( 'content' ) ) <= 1 ) ) )
+		&& ( ! isset( $meta_title ) || ( $meta_title->hasAttribute( 'content' ) && ( $meta_title->getAttribute( 'content' ) === '' || strlen( $meta_title->getAttribute( 'content' ) ) <= 1 ) ) )
 	) {
 		$error = array( "Missing title tag or meta title tag - Post ID: $post->ID" );
 	}

--- a/includes/rules/missing_transcript.php
+++ b/includes/rules/missing_transcript.php
@@ -24,7 +24,7 @@ function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore Gener
 
 	$dom->convert_tag_to_marker( array( 'img', 'iframe', 'audio', 'video', '.is-type-video' ) );
 	foreach ( $elements as $element ) {
-		if ( ! $dom->text_around_element_contains( $element, __( 'transcript', 'edac' ), 25 ) ) {
+		if ( ! $dom->text_around_element_contains( $element, __( 'transcript', 'accessibility-checker' ), 25 ) ) {
 			$element->innertext = '';
 			$errors[]           = $element;
 		}
@@ -32,7 +32,7 @@ function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore Gener
 	$linked_media = $dom->find_linked_media( true );
 
 	foreach ( $linked_media as $media_link ) {
-		if ( ! $dom->text_around_element_contains( $media_link, __( 'transcript', 'edac' ), 25 ) ) {
+		if ( ! $dom->text_around_element_contains( $media_link, __( 'transcript', 'accessibility-checker' ), 25 ) ) {
 			$errors[] = $media_link;
 		}
 	}

--- a/includes/rules/missing_transcript.php
+++ b/includes/rules/missing_transcript.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- $content is reserved for future use or for compliance with a specific interface.
+function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore -- $content is reserved for future use or for compliance with a specific interface.
 
 	if ( empty( $post->post_content ) ) {
 		return array();

--- a/includes/rules/possible_heading.php
+++ b/includes/rules/possible_heading.php
@@ -111,14 +111,14 @@ function edac_css_font_size_weight_check( $content ) {
 						if ( array_key_exists( 'font-weight', $rules ) ) {
 							// replace CSS variables.
 							$rules['font-weight'] = edac_replace_css_variables( $rules['font-weight'], $css_array );
-							if ( in_array( $rules['font-weight'], array( 'bold', 'bolder', '700', '800', '900' ) ) ) {
+							if ( in_array( $rules['font-weight'], array( 'bold', 'bolder', '700', '800', '900' ), true ) ) {
 								$has_bold_or_italic = true;
 							}
 						}
 						if ( array_key_exists( 'font-style', $rules ) ) {
 							// replace CSS variables.
 							$rules['font-style'] = edac_replace_css_variables( $rules['font-style'], $css_array );
-							if ( in_array( $rules['font-style'], array( 'italic', 'oblique' ) ) ) {
+							if ( 'italic' === $rules['font-style'] || 'oblique' === $rules['font-style'] ) {
 								$has_bold_or_italic = true;
 							}
 						}

--- a/includes/rules/possible_heading.php
+++ b/includes/rules/possible_heading.php
@@ -16,7 +16,7 @@
  * 20 pixels or bigger, or
  * 16 pixels or bigger and bold and/or italicized.
  */
-function edac_rule_possible_heading( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_possible_heading( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/slider_present.php
+++ b/includes/rules/slider_present.php
@@ -35,7 +35,7 @@
  * bxSlider: .bxslider, .bx-wrapper - https://bxslider.com/
  * Glidejs: .glide--slider - https://glidejs.com/
  */
-function edac_rule_slider_present( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_slider_present( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom      = $content['html'];
 	$errors   = array();

--- a/includes/rules/slider_present.php
+++ b/includes/rules/slider_present.php
@@ -36,7 +36,7 @@
  * Glidejs: .glide--slider - https://glidejs.com/
  */
 function edac_rule_slider_present( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
-	
+
 	$dom      = $content['html'];
 	$errors   = array();
 	$elements = $dom->find( '.slider, .carousel, .owl-carousel, .soliloquy-container, .n2-section-smartslider, .metaslider, .master-slider, [data-layerslider-uid], .rev_slider, .royalSlider, .wonderpluginslider, .meteor-slides, .flexslider, .slick-slider, .swiper-container, .flickity-slider, .spacegallery, .blueimp-gallery, .seq-active, .siema, .keen-slider, [data-jssor-slider], .bxslider, .glide--slider' );

--- a/includes/rules/tab_order_modified.php
+++ b/includes/rules/tab_order_modified.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_tab_order_modified( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_tab_order_modified( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$tags   = array( 'a', 'input', 'select', 'textarea', 'button', 'datalist', 'output', 'area' );

--- a/includes/rules/text_blinking_scrolling.php
+++ b/includes/rules/text_blinking_scrolling.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_text_blinking_scrolling( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_text_blinking_scrolling( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
 	$errors = array();

--- a/includes/rules/text_justified.php
+++ b/includes/rules/text_justified.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_text_justified( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_text_justified( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$fontsearchpatterns   = array();
 	$fontsearchpatterns[] = '|(text-)?align:\s?justify|i';

--- a/includes/rules/text_small.php
+++ b/includes/rules/text_small.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_text_small( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_text_small( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$fontsearchpatterns   = array();
 	$fontsearchpatterns[] = '|font\-size:\s?([\d]+)pt|i';

--- a/includes/rules/text_small.php
+++ b/includes/rules/text_small.php
@@ -43,8 +43,8 @@ function edac_rule_text_small( $content, $post ) { // phpcs:ignore Generic.CodeA
 								preg_match_all( '!\d+!', $absolute_fontsize_errorcode, $matches );
 
 								if (
-									stristr( $absolute_fontsize_errorcode, 'px' ) == 'px' && implode( ' ', $matches[0] ) <= 10
-									|| stristr( $absolute_fontsize_errorcode, 'pt' ) == 'pt' && implode( ' ', $matches[0] ) <= 13
+									stristr( $absolute_fontsize_errorcode, 'px' ) === 'px' && implode( ' ', $matches[0] ) <= 10
+									|| stristr( $absolute_fontsize_errorcode, 'pt' ) === 'pt' && implode( ' ', $matches[0] ) <= 13
 								) {
 									$errors[] = $element;
 								}

--- a/includes/rules/underlined_text.php
+++ b/includes/rules/underlined_text.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_underlined_text( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_underlined_text( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$errors   = array();
 	$elements = $content['html']->find( 'u' );

--- a/includes/rules/video_present.php
+++ b/includes/rules/video_present.php
@@ -12,7 +12,7 @@
  * @param object $post Object to check.
  * @return array
  */
-function edac_rule_video_present( $content, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is reserved for future use or for compliance with a specific interface.
+function edac_rule_video_present( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom             = $content['html'];
 	$file_extensions = array( '.3gp', '.asf', '.asx', '.avi', '.flv', '.m4p', '.mov', '.mp4', '.mpeg', '.mpeg2', '.mpg', '.mpv', '.ogg', '.ogv', '.qtl', '.smi', '.smil', '.wax', '.webm', '.wmv', '.wmp', '.wmx' );

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -187,13 +187,9 @@ function edac_remove_corrected_posts( $post_ID, $type, $pre = 1, $ruleset = 'php
 	$rules      = edac_register_rules();
 	$rule_slugs = array();
 	foreach ( $rules as $rule ) {
-		if ( isset( $rule['ruleset'] ) && 'js' === $rule['ruleset'] ) {
-			if ( 'js' === $ruleset ) {
-				$rule_slugs[] = $rule['slug'];
-			}
-			continue;
-		}
-		if ( 'js' !== $ruleset ) {
+		if ( 'js' === $ruleset && isset( $rule['ruleset'] ) && 'js' === $rule['ruleset'] ) {
+			$rule_slugs[] = $rule['slug'];
+		} elseif ( 'js' !== $ruleset ) {
 			$rule_slugs[] = $rule['slug'];
 		}
 	}

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -193,7 +193,9 @@ function edac_remove_corrected_posts( $post_ID, $type, $pre = 1, $ruleset = 'php
 			}
 			continue;
 		}
-		$rule_slugs[] = $rule['slug'];
+		if ( 'js' !== $ruleset ) {
+			$rule_slugs[] = $rule['slug'];
+		}
 	}
 
 	if ( 1 === $pre ) {

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -184,10 +184,8 @@ function edac_validate( $post_ID, $post, $action ) {
 function edac_remove_corrected_posts( $post_ID, $type, $pre = 1, $ruleset = 'php' ) {
 	global $wpdb;
 
-	$rules        = edac_register_rules();
-	$js_rule_ids  = array();
-	$php_rule_ids = array();
-	$rule_slugs   = array();
+	$rules      = edac_register_rules();
+	$rule_slugs = array();
 	foreach ( $rules as $rule ) {
 		if ( isset( $rule['ruleset'] ) && 'js' === $rule['ruleset'] ) {
 			if ( 'js' === $ruleset ) {

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -17,7 +17,7 @@
  *
  * @return void
  */
-function edac_oxygen_builder_save_post( $meta_id, $post_id, $meta_key, $meta_value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed, Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- This function is a hook and the parameters are required.
+function edac_oxygen_builder_save_post( $meta_id, $post_id, $meta_key, $meta_value ) { // phpcs:ignore -- This function is a hook and the parameters are required.
 	if ( 'ct_builder_shortcodes' === $meta_key ) {
 
 		$post = get_post( $post_id, OBJECT );
@@ -32,7 +32,7 @@ function edac_oxygen_builder_save_post( $meta_id, $post_id, $meta_key, $meta_val
  * @return void
  */
 function edac_post_on_load() {
-	global $pagenow, $typenow;
+	global $pagenow;
 	if ( 'post.php' === $pagenow ) {
 		global $post;
 		$checked = get_post_meta( $post->ID, '_edac_post_checked', true );

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -30,11 +30,11 @@ if ( is_array( $settings_tab_items ) ) {
 		function ( $a, $b ) {
 			if ( $a['order'] < $b['order'] ) {
 				return -1;
-			} elseif ( $a['order'] == $b['order'] ) {
-				return 0;
-			} else {
-				return 1;
 			}
+			if ( $a['order'] === $b['order'] ) {
+				return 0;
+			}
+			return 1;
 		}
 	);
 }
@@ -42,7 +42,7 @@ if ( is_array( $settings_tab_items ) ) {
 // Get the active tab from the $_GET param.
 $default_tab  = null;
 $settings_tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : $default_tab; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification and sanitization not required for tab display.
-$settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items, 'slug' ) ) !== false ) ? $settings_tab : $default_tab;
+$settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items, 'slug' ), true ) !== false ) ? $settings_tab : $default_tab;
 ?>
 
 <div class="wrap edac-settings">
@@ -57,12 +57,12 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 			$query_var = $slug ? '&tab=' . $slug : '';
 			$label     = $settings_tab_item['label'];
 			?>
-			<a 
-			<?php 
+			<a
+			<?php
 			if ( $settings_tab === $slug ) :
 				?>
-				aria-current="true" <?php endif; ?>href="?page=accessibility_checker_settings<?php echo esc_html( $query_var ); ?>" class="nav-tab 
-				<?php 
+				aria-current="true" <?php endif; ?>href="?page=accessibility_checker_settings<?php echo esc_html( $query_var ); ?>" class="nav-tab
+				<?php
 				if ( $settings_tab === $slug ) :
 					?>
 				nav-tab-active<?php endif; ?>"><?php echo esc_html( $label ); ?></a>
@@ -75,7 +75,7 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 	<div class="tab-content">
 
 		<?php if ( null === $settings_tab ) { ?>
-			<div class="edac-settings-general 
+			<div class="edac-settings-general
 			<?php
 			if ( EDAC_KEY_VALID === false ) {
 				echo 'edac-show-pro-callout';}
@@ -95,13 +95,13 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 		<?php } ?>
 
 		<?php if ( 'system_info' === $settings_tab ) { ?>
-			<h2><?php esc_html_e( 'System Info', 'accessibility-checker' ); ?></h2>	
+			<h2><?php esc_html_e( 'System Info', 'accessibility-checker' ); ?></h2>
 			<div class="edac-settings-system-info">
 				<?php edac_sysinfo_display(); ?>
-			</div>	
+			</div>
 		<?php } ?>
 
-		<?php do_action( 'edac_settings_tab_content', $settings_tab ); ?>	
+		<?php do_action( 'edac_settings_tab_content', $settings_tab ); ?>
 	</div>
 
 </div>

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -27,7 +27,7 @@
 					?>
 				</h1>
 				<p>
-					<?php 
+					<?php
 					echo( esc_html__( 'version ', 'accessibility-checker' ) . esc_html( $version ) );
 					?>
 				</p>
@@ -48,14 +48,14 @@
 				<p><?php esc_html_e( 'Follow these steps to get started checking your content:', 'accessibility-checker' ); ?></p>
 				<ol>
 					<li>
-						<?php 
-						printf( 
+						<?php
+						printf(
 							wp_kses(
 								// translators: %s: path to settings page.
-								__( 'On the <a href="%s">Settings Page</a>, choose which post types you want to scan.', 'accessibility-checker' ), 
+								__( 'On the <a href="%s">Settings Page</a>, choose which post types you want to scan.', 'accessibility-checker' ),
 								array( 'a' => array( 'href' => array() ) )
 							),
-							esc_url( admin_url( 'admin.php?page=accessibility_checker_settings' ) ) 
+							esc_url( admin_url( 'admin.php?page=accessibility_checker_settings' ) )
 						);
 						?>
 					</li>
@@ -178,7 +178,7 @@
 				<?php esc_html_e( 'Get Accessibility Checker Pro', 'accessibility-checker' ); ?> 
 				<span class="screen-reader-text"><?php esc_html_e( '(opens in a new window)', 'accessibility-checker' ); ?></span>
 			</a>
-		<?php	
+		<?php
 		if ( edac_check_plugin_installed( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) {
 			?>
 			<br /><a class="edac-pro-callout-activate" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_settings&tab=license' ) ); ?>">
@@ -190,7 +190,7 @@
 		</div>
 		<?php
 	}
-	
+
 	?>
 
 		<div class="edac-panel">
@@ -203,16 +203,16 @@
 			?>
 		</div>
 
-		<?php 
-		
-		
+		<?php
+
+
 		if ( true !== boolval( get_user_meta( get_current_user_id(), 'edac_email_optin', true ) ) ) {
-			\EDAC\Welcome_Page::render_email_opt_in( 
+			\EDAC\Welcome_Page::render_email_opt_in(
 				'1273a5c7a',
-				'1a0796bc2303c2cb', 
-				'', 
-				'3zdf37c20714225fe975e2772c61e00bf3a196e8e7f12fdcb55c14b48b8778764e' 
-			); 
+				'1a0796bc2303c2cb',
+				'',
+				'3zdf37c20714225fe975e2772c61e00bf3a196e8e7f12fdcb55c14b48b8778764e'
+			);
 		}
 		?>
 	</div>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -63,6 +63,64 @@
 		<severity>1</severity>
 	</rule>
 
+	<!-- Thw WP VIP ruleset disables some of the default rules, so we re-enable them
+	as they may not be "required", but are still good practices. -->
+	<rule ref="Internal.LineEndings.Mixed">
+		<severity>6</severity>
+	</rule>
+	<rule ref="Generic.CodeAnalysis.AssignmentInCondition">
+		<severity>6</severity>
+	</rule>
+	<rule ref="WordPress.CodeAnalysis.AssignmentInTernaryCondition.FoundInTernaryCondition">
+		<severity>6</severity>
+	</rule>
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode">
+		<severity>6</severity>
+	</rule>
+	<rule ref="WordPress.PHP.DontExtract">
+		<severity>6</severity>
+	</rule>
+	<rule ref="Universal.Operators.StrictComparisons">
+		<severity>6</severity>
+	</rule>
+	<rule ref="WordPress.PHP.StrictInArray.MissingTrueStrict">
+		<severity>6</severity>
+	</rule>
+	<rule ref="WordPress.Security.EscapeOutput.UnsafePrintingFunction">
+		<!-- We trust that translations are safe on VIP Go -->
+		<severity>6</severity>
+	</rule>
+	<rule ref="Generic.PHP.NoSilencedErrors">
+		<severity>6</severity>
+	</rule>
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
+		<severity>5</severity>
+	</rule>
+
+	<rule ref="WordPress.DB.SlowDBQuery.slow_db_query_meta_key">
+		<severity>6</severity>
+	</rule>
+	<rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
+		<severity>6</severity>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_readfile">
+		<severity>4</severity>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fclose">
+		<severity>4</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
+
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+		<properties>
+			<!-- Do not report on unused variables before require nor usused or undefined variables in file scope. -->
+			<property name="allowUnusedVariablesBeforeRequire" value="false"/>
+			<property name="allowUndefinedVariablesInFileScope" value="false"/>
+		</properties>
+	</rule>
+	<!-- End of VIP resets -->
+
 	<config name="minimum_supported_wp_version" value="6.2.0"/>
 
 	<!--

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -35,13 +35,13 @@
 	<!-- Add the WordPress-VIP-Go standard -->
 	<rule ref="WordPress-VIP-Go"/>
 
-    <!-- Run against the PHPCompatibility ruleset -->
-    <rule ref="PHPCompatibility">
-        <!-- WP supports down to 7.0 : https://wordpress.org/about/requirements/ -->
-        <config name="testVersion" value="7.0-"/>
-    </rule>
+	<!-- Run against the PHPCompatibility ruleset -->
+	<rule ref="PHPCompatibility">
+		<!-- WP supports down to 7.0 : https://wordpress.org/about/requirements/ -->
+		<config name="testVersion" value="7.0-"/>
+	</rule>
 
-    <config name="minimum_wp_version" value="6.2"/>
+	<config name="minimum_wp_version" value="6.2"/>
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress.WP.I18n">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,50 +3,70 @@
 	<description>Accessibility Checker Wordpress Coding Standards</description>
 
 	<!-- Scan all files in directory -->
-    <file>.</file>
+	<file>.</file>
 
-    <!-- Folders to exclude -->
-    <exclude-pattern>./dist/</exclude-pattern>
-    <exclude-pattern>./vendor/</exclude-pattern>
-    <exclude-pattern>./node_modules/</exclude-pattern>
-    <exclude-pattern>./.wp-env/</exclude-pattern>
-    <exclude-pattern>./simple_html_dom.php</exclude-pattern>
-    <exclude-pattern>./update-composer-config.php</exclude-pattern>
+	<!-- Folders to exclude -->
+	<exclude-pattern>./dist/</exclude-pattern>
+	<exclude-pattern>./vendor/</exclude-pattern>
+	<exclude-pattern>./node_modules/</exclude-pattern>
+	<exclude-pattern>./.wp-env/</exclude-pattern>
+	<exclude-pattern>./simple_html_dom.php</exclude-pattern>
+	<exclude-pattern>./update-composer-config.php</exclude-pattern>
 
-    <!-- Scan only PHP files -->
-    <arg name="extensions" value="php"/>
+	<!-- Scan only PHP files -->
+	<arg name="extensions" value="php"/>
 
-    <!-- Show colors in console -->
-    <arg value="-colors"/>
+	<!-- Show colors in console -->
+	<arg value="-colors"/>
 
-    <!-- Show progress, show the error codes for each message (source). -->
-    <arg value="sp"/>
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="sp"/>
 
-    <!-- Include the WordPress-Extra standard. -->
-    <rule ref="WordPress-Extra" />
+	<!-- Include the WordPress-Extra standard. -->
+	<rule ref="WordPress-Extra" />
 
-    <!-- Let's also check that everything is properly documented. -->
-    <rule ref="WordPress-Docs"/>
+	<!-- Let's also check that everything is properly documented. -->
+	<rule ref="WordPress-Docs"/>
 
-    <!-- Add in some extra rules from other standards. -->
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
-    <rule ref="Generic.Commenting.Todo"/>
+	<!-- Add in some extra rules from other standards. -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.Commenting.Todo"/>
 
-    <!-- Add the WordPress-VIP-Go standard -->
-    <rule ref="WordPress-VIP-Go"/>
+	<!-- Add the WordPress-VIP-Go standard -->
+	<rule ref="WordPress-VIP-Go"/>
 
-    <!-- Run against the PHPCompatibility ruleset -->
-    <rule ref="PHPCompatibility">
-        <!-- WP supports down to 5.6.2 : https://wordpress.org/about/requirements/ -->
-        <config name="testVersion" value="5.6-"/>
-    </rule>
+	<config name="testVersion" value="7.0-"/>
 
-    <config name="minimum_supported_wp_version" value="5.0.0"/>
+	<rule ref="PHPCompatibilityWP">
+		<include-pattern>*\.php$</include-pattern>
+	</rule>
 
-    <!--
-    Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
-    See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
-    -->
-    <ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="accessibility-checker"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Run against the PHPCompatibility ruleset -->
+	<rule ref="PHPCompatibility">
+		<!-- WP supports down to 7.0 : https://wordpress.org/about/requirements/ -->
+		<config name="testVersion" value="7.0-"/>
+	</rule>
+
+	<!-- The %i placeholder is supported in WP since v6.2. -->
+	<rule ref="WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder">
+		<severity>1</severity>
+	</rule>
+
+	<config name="minimum_supported_wp_version" value="6.2.0"/>
+
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -123,10 +123,4 @@
 
 	<config name="minimum_supported_wp_version" value="6.2.0"/>
 
-	<!--
-	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
-	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
-	-->
-	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
-
 </ruleset>

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,11 +16,9 @@ if ( true === boolval( $delete_data ) ) {
 
 	// drop database.
 	global $wpdb;
-	$table_name = $wpdb->prefix . 'accessibility_checker';
-	$sql        = "DROP TABLE IF EXISTS $table_name";
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for table drop in uninstall script, caching not required for one time operation.
-	$wpdb->query( $sql );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Using direct query for table drop in uninstall script, caching not required for one time operation.
+	$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $wpdb->prefix . 'accessibility_checker' ) );
 
 	// delete options.
 	$options = array(


### PR DESCRIPTION
## What this PR does:
 
* The `%i` placeholder can be used for table-names, and allows us to properly prepare SQL queries.
* Strict comparisons (`===`/`!==` instead of `==`/`!=`) should be used where possible.
* Single-use variables should be avoided. Doing `$sql = 'foo'; $wpdb->query( $sql )` is bad practice and we should prefer `$wpdb->query( 'foo' );` - especially if the `$sql` variable is only used once. There's no reason to fill the PHP memory with things like that, and it makes the codes easier to read and understand.
* There were a few instances where the wrong textdomain was used in strings, so they were not translatable. I added an extra rule in `phpcs.xml` to catch these in the future, and fixed the instances where there was an issue. The textdomains that were used where `accessibility-checker` (correct), `accessibility_checker` (changed to `accessibility-checker`) and `edac` (changed to `accessibility-checker`).

## Process:

* I went through all the `phpcs:ignore` statements in the code and reviewed them. If it was possible to remove the rule ignores, and fix the code instead, this was done (for example by using the `%i` placeholder to properly prepare SQL statements).
* I added the default WP phpcs rules to the `phpcs.xml` file.
* I ran `vendor/bin/phpcs` and fixed any issues reported by that
* I commented out (locally - not committed) the `<rule ref="WordPress-VIP-Go"/>` line in `phpcs.xml`. The VIP rules disable some of the WP default rules for code-quality.
* With the VIP rules disabled, I ran `phpcbf` to automatically fix some of the simple stuff like spaces at the ends of lines, indentation etc. After that, I ran `phpcs` again and fixed the remaining issues.