### PR TITLE
Deprecate the `edac_check_plugin_active` function

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -144,6 +144,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/classes/class-edac-frontend
 /**
  * Import Resources
  */
+require_once plugin_dir_path( __FILE__ ) . 'includes/deprecated.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/activation.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/deactivation.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/helper-functions.php';
@@ -188,7 +189,7 @@ add_action( 'pre_get_posts', 'edac_show_draft_posts' );
 add_action( 'template_redirect', 'edac_before_page_render' );
 add_action( 'admin_init', 'edac_process_actions' );
 add_action( 'edac_download_sysinfo', 'edac_tools_sysinfo_download' );
-if ( edac_check_plugin_active( 'oxygen/functions.php' ) ) {
+if ( is_plugin_active( 'oxygen/functions.php' ) ) {
 	add_action( 'added_post_meta', 'edac_oxygen_builder_save_post', 10, 4 );
 	add_action( 'updated_post_meta', 'edac_oxygen_builder_save_post', 10, 4 );
 }

--- a/includes/classes/class-admin-notices.php
+++ b/includes/classes/class-admin-notices.php
@@ -56,7 +56,7 @@ class Admin_Notices {
 	public function edac_black_friday_notice() {
 
 		// check if accessibility checker pro is active.
-		$pro = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' );
+		$pro = is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' );
 		if ( $pro ) {
 			return;
 		}
@@ -145,7 +145,7 @@ class Admin_Notices {
 		define( 'EDAC_GAAD_NOTICE_END_DATE', '2023-05-24' );
 
 		// Check if Accessibility Checker Pro is active.
-		$pro = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' );
+		$pro = is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' );
 		if ( $pro ) {
 			return;
 		}

--- a/includes/classes/class-welcome-page.php
+++ b/includes/classes/class-welcome-page.php
@@ -30,7 +30,7 @@ class Welcome_Page {
 
 		<div id="edac_welcome_page_summary">
 
-			<?php if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) : ?>
+			<?php if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) : ?>
 				<section>
 					<div class="edac-cols edac-cols-header">
 						<div class="edac-cols-left">

--- a/includes/classes/class-widgets.php
+++ b/includes/classes/class-widgets.php
@@ -28,7 +28,7 @@ class Widgets {
 		if ( Settings::get_scannable_post_types() && Settings::get_scannable_post_statuses() ) {
 
 			$pro_modal_html = '';
-			if ( ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ||
+			if ( ( ! is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ||
 			false === EDAC_KEY_VALID ) &&
 			true !== boolval( get_user_meta( get_current_user_id(), 'edac_dashboard_cta_dismissed', true ) )
 			) {
@@ -45,7 +45,7 @@ class Widgets {
 			</div>';
 			}
 
-			if ( ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' !== $pro_modal_html ) {
+			if ( ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) || '' !== $pro_modal_html ) {
 
 				$html .= '
 			<div class="edac-summary edac-modal-container edac-hidden">';
@@ -179,7 +179,7 @@ class Widgets {
 							</tr>';
 
 				}
-			} elseif ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
+			} elseif ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
 
 				$html .= '
 						<tr >
@@ -224,7 +224,7 @@ class Widgets {
 		<div class="edac-buttons-container edac-mt-3 edac-mb-3">
 		';
 
-		if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
+		if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
 			$html .= '
 			<a class="button edac-mr-1" href="/wp-admin/admin.php?page=accessibility_checker">' . __( 'See More Reports', 'accessibility-checker' ) . '</a>';
 		}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Functions that have been deprecated and should not be used.
+ * They are still kept here for backwards-compatibility.
+ * 
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Alias of the is_plugin_active() function.
+ * 
+ * @deprecated 1.6.11
+ *
+ * @param string $plugin_slug The plugin slug.
+ * @return bool
+ */
+function edac_check_plugin_active( $plugin_slug ) {
+	_deprecated_function( __FUNCTION__, '1.6.11', 'is_plugin_active()' );
+	return is_plugin_active( $plugin_slug );
+}

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -74,7 +74,7 @@ function edac_enqueue_scripts( $mode = '' ) {
 		return;
 	}
 
-	$pro = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true;
+	$pro = is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true;
 
 	$headers = array(
 		'Content-Type' => 'application/json',

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -88,21 +88,6 @@ function edac_check_plugin_installed( $plugin_slug ) {
 }
 
 /**
- * Check if plugin is installed
- *
- * @param string $plugin_slug Slug of the plugin.
- *
- * @return bool
- */
-function edac_check_plugin_active( $plugin_slug ) {
-	if ( is_plugin_active( $plugin_slug ) ) {
-		return true;
-	}
-
-	return false;
-}
-
-/**
  * Convert cardinal number into ordinal number
  *
  * @param int $number Number to make ordinal.

--- a/includes/system-info.php
+++ b/includes/system-info.php
@@ -152,7 +152,7 @@ function edac_tools_sysinfo_get() {
 	$return .= 'Warning Count:            ' . edac_get_warning_count() . "\n";
 	$return .= 'DB Table Count:           ' . edac_database_table_count( 'accessibility_checker' ) . "\n";
 
-	if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) {
+	if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) ) {
 
 		$return   .= "\n" . '-- Accessibility Checker Pro Configuration' . "\n\n";
 		$return   .= 'Version:                  ' . EDACP_VERSION . "\n";

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -289,7 +289,7 @@ function edac_get_content( $post ) {
 	}
 
 	// http authorization.
-	if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true && $username && $password ) {
+	if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID === true && $username && $password ) {
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- This is a valid use case for base64_encode.
 		$context_opts['http']['header'] = 'Authorization: Basic ' . base64_encode( "$username:$password" );
 	}
@@ -362,7 +362,7 @@ function edac_get_content( $post ) {
 	}
 
 	// check for restricted access plugin.
-	if ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && edac_check_plugin_active( 'restricted-site-access/restricted_site_access.php' ) ) {
+	if ( ! is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && is_plugin_active( 'restricted-site-access/restricted_site_access.php' ) ) {
 		$content['html'] = false;
 	}
 

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -15,7 +15,7 @@
 			<div class="edac-welcome-header-left">
 				<h1 class="edac-welcome-title">
 					<?php
-					if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) === true && EDAC_KEY_VALID === true ) {
+					if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) === true && EDAC_KEY_VALID === true ) {
 						$welcome_title = __( 'Accessibility Checker Pro', 'accessibility-checker' );
 						$version       = EDACP_VERSION;
 					} else {
@@ -93,7 +93,7 @@
 			<h2><?php esc_html_e( 'Support Information', 'accessibility-checker' ); ?></h2>
 			<div class="edac-flex-container">
 		<?php
-		if ( edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
+		if ( is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID ) {
 			?>
 				<div class="edac-flex-item edac-flex-item-33 edac-background-light">
 					<h3><?php esc_html_e( 'Plugin Support', 'accessibility-checker' ); ?></h3>
@@ -149,7 +149,7 @@
 	</div>
 
 	<?php
-	if ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || ! EDAC_KEY_VALID ) {
+	if ( ! is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || ! EDAC_KEY_VALID ) {
 		echo '<div class="edac-cols-right edac-welcome-aside">
 			<div class="edac-has-cta">';
 	} else {
@@ -157,7 +157,7 @@
 			<div>';
 	}
 
-	if ( ! edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || ! EDAC_KEY_VALID ) {
+	if ( ! is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) || ! EDAC_KEY_VALID ) {
 		?>
 		<div class="edac-pro-callout edac-mt-3 edac-mb-3">
 			<img class="edac-pro-callout-icon" src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/edac-emblem.png" alt="<?php esc_attr_e( 'Equalize Digital Logo', 'accessibility-checker' ); ?>">


### PR DESCRIPTION
The `edac_check_plugin_active` function is a simple alias of the `is_plugin_active` function.
This PR deprecates the function by doing the following:
* Added a new `includes/deprecated.php` file and included it.
* Moved the `edac_check_plugin_active` function there, simplified it, and added a `_deprecated_function` call inside it to warn developers that the function was deprecated in v1.6.10 (we can tweak the version number depending on when this PR gets merged and what the next version will be)
* Replaced all calls to `edac_check_plugin_active` with `is_plugin_active`