### PR TITLE
Remove calls to add_option and replaces it with update_option where appropriate

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -253,11 +253,7 @@ function edac_update_database() {
 	// Update database version option.
 	$option_name = 'edac_db_version';
 	$new_value   = EDAC_DB_VERSION;
-	if ( get_option( $option_name ) !== false ) {
-		update_option( $option_name, $new_value );
-	} else {
-		add_option( $option_name, $new_value );
-	}
+	update_option( $option_name, $new_value );
 }
 
 /**
@@ -1069,19 +1065,12 @@ function edac_anww_update_post_meta() {
 
 	$option_name = 'edac_anww_update_post_meta';
 
-	if ( get_option( $option_name ) === false && EDAC_ANWW_ACTIVE === true ) {
-
-		add_option( $option_name, true );
-
-		edac_update_post_meta( 'link_blank' );
-
-	} elseif ( get_option( $option_name ) === true && EDAC_ANWW_ACTIVE === false ) {
-
+	if ( get_option( $option_name ) === false && EDAC_ANWW_ACTIVE ) {
+		update_option( $option_name, true );
+	} elseif ( get_option( $option_name ) === true && ! EDAC_ANWW_ACTIVE ) {
 		delete_option( $option_name );
-
-		edac_update_post_meta( 'link_blank' );
-
 	}
+	edac_update_post_meta( 'link_blank' );
 }
 
 /**

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -12,9 +12,9 @@
  */
 function edac_activation() {
 	// set options.
-	add_option( 'edac_activation_date', gmdate( 'Y-m-d H:i:s' ) );
-	add_option( 'edac_post_types', array( 'post', 'page' ) );
-	add_option( 'edac_simplified_summary_position', 'after' );
+	update_option( 'edac_activation_date', gmdate( 'Y-m-d H:i:s' ) );
+	update_option( 'edac_post_types', array( 'post', 'page' ) );
+	update_option( 'edac_simplified_summary_position', 'after' );
 
 	// Sanitize the input.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required.

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -112,11 +112,10 @@ function edac_validate( $post_ID, $post, $action ) {
 	do_action( 'edac_after_get_content', $post_ID, $content, $action );
 
 	if ( ! $content['html'] ) {
-		add_option( 'edac_password_protected', true );
+		update_option( 'edac_password_protected', true );
 		return;
-	} else {
-		delete_option( 'edac_password_protected' );
 	}
+	delete_option( 'edac_password_protected' );
 
 	// set record check flag on previous error records.
 	edac_remove_corrected_posts( $post_ID, $post->post_type, $pre = 1, 'php' );


### PR DESCRIPTION
Calling `add_option` is in most cases unnecessary. In this PR we're just cleaning up these calls.