### PR TITLE
Remove unnecessary `has_filter()` calls

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -1237,10 +1237,7 @@ function edac_details_ajax() {
 	$rules = array_merge( $error_rules, $warning_rules, $passed_rules );
 
 	if ( $rules ) {
-		$ignore_permission = true;
-		if ( has_filter( 'edac_ignore_permission' ) ) {
-			$ignore_permission = apply_filters( 'edac_ignore_permission', $ignore_permission );
-		}
+		$ignore_permission = apply_filters( 'edac_ignore_permission', true );
 		foreach ( $rules as $rule ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
 			$results        = $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment, ignre_global FROM %i where postid = %d and rule = %s and siteid = %d', $table_name, $postid, $rule['slug'], $siteid ), ARRAY_A );
@@ -1459,9 +1456,7 @@ function edac_readability_ajax() {
 		}
 	}
 
-	if ( has_filter( 'edac_filter_readability_content' ) ) {
-		$content = apply_filters( 'edac_filter_readability_content', $content, $post_id );
-	}
+	$content = apply_filters( 'edac_filter_readability_content', $content, $post_id );
 	$content = wp_filter_nohtml_kses( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );
 
@@ -1656,12 +1651,10 @@ function edac_get_simplified_summary( $post = null ) {
  */
 function edac_simplified_summary_markup( $post ) {
 	$simplified_summary         = get_post_meta( $post, '_edac_simplified_summary', true ) ? get_post_meta( $post, '_edac_simplified_summary', true ) : '';
-	$simplified_summary_heading = 'Simplified Summary';
-
-	// filter title.
-	if ( has_filter( 'edac_filter_simplified_summary_heading' ) ) {
-		$simplified_summary_heading = apply_filters( 'edac_filter_simplified_summary_heading', $simplified_summary_heading );
-	}
+	$simplified_summary_heading = apply_filters(
+		'edac_filter_simplified_summary_heading',
+		esc_html__( 'Simplified Summary', 'accessibility-checker' )
+	);
 
 	if ( $simplified_summary ) {
 		return '<div class="edac-simplified-summary"><h2>' . wp_kses_post( $simplified_summary_heading ) . '</h2><p>' . wp_kses_post( $simplified_summary ) . '</p></div>';

--- a/includes/classes/class-admin-notices.php
+++ b/includes/classes/class-admin-notices.php
@@ -324,13 +324,18 @@ class Admin_Notices {
 	 * @return string
 	 */
 	public function edac_password_protected_notice_text() {
-		$notice = 'Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or <a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank" aria-label="upgrade to accessibility checker pro, opens in a new window">upgrade to pro</a>. Scan results may be stored from a previous scan.';
-
-		if ( has_filter( 'edac_filter_password_protected_notice_text' ) ) {
-			$notice = apply_filters( 'edac_filter_password_protected_notice_text', $notice );
-		}
-
-		return $notice;
+		return apply_filters(
+			'edac_filter_password_protected_notice_text',
+			sprintf(
+				// translators: %s is the link to upgrade to pro, with "upgrade to pro" as the anchor text.
+				esc_html__( 'Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or %s. Scan results may be stored from a previous scan.', 'accessibility-checker' ),
+				sprintf(
+					'<a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank" aria-label="%1$s">%2$s</a>',
+					esc_attr__( 'Upgrade to accessibility checker pro. Opens in a new window.', 'accessibility-checker' ),
+					esc_html__( 'upgrade to pro', 'accessibility-checker' )
+				)
+			)
+		);
 	}
 
 	/**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -182,10 +182,7 @@ function edac_is_gutenberg_active() {
 	$gutenberg    = false;
 	$block_editor = false;
 
-	if ( has_filter( 'replace_editor', 'gutenberg_init' ) ) {
-		// Gutenberg is installed and activated.
-		$gutenberg = true;
-	}
+	$gutenberg = has_filter( 'replace_editor', 'gutenberg_init' );
 
 	if ( version_compare( $GLOBALS['wp_version'], '5.0-beta', '>' ) ) {
 		// Block editor.
@@ -249,13 +246,7 @@ function edac_custom_post_types() {
  * @return array
  */
 function edac_post_types() {
-
-	$post_types = array( 'post', 'page' );
-
-	// filter post types.
-	if ( has_filter( 'edac_filter_post_types' ) ) {
-		$post_types = apply_filters( 'edac_filter_post_types', $post_types );
-	}
+	$post_types = apply_filters( 'edac_filter_post_types', array( 'post', 'page' ) );
 
 	// remove duplicates.
 	$post_types = array_unique( $post_types );

--- a/includes/insert.php
+++ b/includes/insert.php
@@ -88,9 +88,7 @@ function edac_insert_rule_data( $post, $rule, $ruletype, $rule_obj ) {
 	if ( ! $results ) {
 
 		// filter post types.
-		if ( has_filter( 'edac_filter_insert_rule_data' ) ) {
-			$rule_data = apply_filters( 'edac_filter_insert_rule_data', $rule_data );
-		}
+		$rule_data = apply_filters( 'edac_filter_insert_rule_data', $rule_data );
 
 		// insert.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Using direct query for adding data to database.

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -49,10 +49,7 @@ function edac_add_options_page() {
 	}
 
 	// settings panel filter.
-	$settings_capability = 'manage_options';
-	if ( has_filter( 'edac_filter_settings_capability' ) ) {
-		$settings_capability = apply_filters( 'edac_filter_settings_capability', $settings_capability );
-	}
+	$settings_capability = apply_filters( 'edac_filter_settings_capability', 'manage_options' );
 
 	add_submenu_page(
 		'accessibility_checker',

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -5,23 +5,22 @@
  * @package Accessibility_Checker
  */
 
-// set up tab items.
-$settings_tab_items = array(
+// set up tab items and filter them.
+$settings_tab_items = apply_filters(
+	'edac_filter_settings_tab_items',
 	array(
-		'slug'  => '',
-		'label' => esc_html__( 'General', 'accessibility-checker' ),
-		'order' => 1,
-	),
-	array(
-		'slug'  => 'system_info',
-		'label' => esc_html__( 'System Info', 'accessibility-checker' ),
-		'order' => 4,
-	),
+		array(
+			'slug'  => '',
+			'label' => esc_html__( 'General', 'accessibility-checker' ),
+			'order' => 1,
+		),
+		array(
+			'slug'  => 'system_info',
+			'label' => esc_html__( 'System Info', 'accessibility-checker' ),
+			'order' => 4,
+		),
+	)
 );
-// filter settings tab items.
-if ( has_filter( 'edac_filter_settings_tab_items' ) ) {
-	$settings_tab_items = apply_filters( 'edac_filter_settings_tab_items', $settings_tab_items );
-}
 
 // sort settings tab items.
 if ( is_array( $settings_tab_items ) ) {


### PR DESCRIPTION
There's no need to check if `has_filter` before applying filters.
This PR removes the cases where `has_filter()` was not required.