### PR TITLE
Fix/admin notice constructor #395

### DIFF
--- a/includes/classes/class-admin-notices.php
+++ b/includes/classes/class-admin-notices.php
@@ -16,6 +16,14 @@ class Admin_Notices {
 	 * Initialize the class and set its properties.
 	 */
 	public function __construct() {
+	}
+	
+	/**
+	 * Initialize class hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'in_admin_header', array( $this, 'edac_remove_admin_notices' ), 1000 );
 		add_action( 'admin_notices', array( $this, 'edac_black_friday_notice' ) );
 		add_action( 'wp_ajax_edac_black_friday_notice_ajax', array( $this, 'edac_black_friday_notice_ajax' ) );
@@ -383,4 +391,5 @@ class Admin_Notices {
 	}
 }
 
-new Admin_Notices();
+$admin_notices = new \EDAC\Admin_Notices();
+$admin_notices->init_hooks();

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -11,8 +11,16 @@ use EDAC\Admin_Notices;
  */
 class EDACAdminNoticesTest extends WP_UnitTestCase {
 	
-	private $admin_notices; // Instance of the Admin_Notices class.
+	/**
+	 * Instance of the Admin_Notices class.
+	 *
+	 * @var Admin_Notices $admin_notices.
+	 */
+	private $admin_notices;
 	
+	/**
+	 * Set up the test fixture.
+	 */
 	protected function setUp(): void {
 		$this->admin_notices = new Admin_Notices();
 	}

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -68,7 +68,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '🎉 Get 30% off Accessibility Checker Pro in honor of Global Accessibility Awareness Day! 🎉', $message );
 		$this->assertStringContainsString( 'Use coupon code GAAD23 from May 18th-May 25th to get access to full-site scanning and other pro features at a special discount.', $message );
 		$this->assertStringContainsString( 'https://my.equalizedigital.com/support/pre-sale-questions/?utm_source=accessibility-checker&#038;utm_medium=software&#038;utm_campaign=GAAD23', $message );
-		$this->assertStringContainsString( 'https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23', $message );
+		$this->assertStringContainsString( 'https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&#038;utm_medium=software&#038;utm_campaign=GAAD23', $message );
 	}
 
 	/**

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -10,27 +10,93 @@ use EDAC\Admin_Notices;
  * Admin Notices test case.
  */
 class EDACAdminNoticesTest extends WP_UnitTestCase {
-    
-    private $admin_notices;
+	
+	private $admin_notices;
 
-    protected function setUp(): void {
-        $this->admin_notices = new Admin_Notices();
-    }
+	protected function setUp(): void {
+		$this->admin_notices = new Admin_Notices();
+	}
 
-    public function test_edac_get_black_friday_message_exists() {
-        $this->assertTrue(
-            method_exists( $this->admin_notices, 'edac_get_black_friday_message'),
-            'Class does not have method edac_get_black_friday_message'
-        );
-    }
+	/**
+	 * Test that the edac_get_black_friday_message function exists.
+	 */
+	public function test_edac_get_black_friday_message_exists() {
+		$this->assertTrue(
+			method_exists( $this->admin_notices, 'edac_get_black_friday_message'),
+			'Class does not have method edac_get_black_friday_message'
+		);
+	}
 
-    public function test_edac_get_black_friday_message_returns_string() {
-        $this->assertIsString( $this->admin_notices->edac_get_black_friday_message() );
-    }
+	/**
+	 * Test that the edac_get_black_friday_message function returns a string.
+	 */
+	public function test_edac_get_black_friday_message_returns_string() {
+		$this->assertIsString( $this->admin_notices->edac_get_black_friday_message() );
+	}
 
-    public function test_edac_get_black_friday_message_contains_promo_message() {
-        $message = $this->admin_notices->edac_get_black_friday_message();
-        $this->assertStringContainsString( 'Black Friday special!', $message );
-        $this->assertStringContainsString( 'Upgrade to a paid version of Accessibility Checker', $message );
-    }
+	/**
+	 * Test that the edac_get_black_friday_message function contains the expected promotional message.
+	 */
+	public function test_edac_get_black_friday_message_contains_promo_message() {
+		$message = $this->admin_notices->edac_get_black_friday_message();
+		$this->assertStringContainsString( 'Black Friday special!', $message );
+		$this->assertStringContainsString( 'Upgrade to a paid version of Accessibility Checker', $message );
+	}
+
+	/**
+	 * Test that the edac_get_gaad_promo_message function exists.
+	 */
+	public function test_edac_get_gaad_promo_message_exists() {
+		$this->assertTrue(
+			method_exists($this->admin_notices, 'edac_get_gaad_promo_message'),
+			'Class does not have method edac_get_gaad_promo_message'
+		);
+	}
+
+	/**
+	 * Test that the edac_get_gaad_promo_message function returns a string.
+	 */
+	public function test_edac_get_gaad_promo_message_returns_string() {
+		$this->assertIsString($this->admin_notices->edac_get_gaad_promo_message());
+	}
+
+	/**
+	 * Test that the edac_get_gaad_promo_message function contains the expected promotional message.
+	 */
+	public function test_edac_get_gaad_promo_message_contains_promo_message() {
+		$message = $this->admin_notices->edac_get_gaad_promo_message();
+		$this->assertStringContainsString( '🎉 Get 30% off Accessibility Checker Pro in honor of Global Accessibility Awareness Day! 🎉', $message );
+		$this->assertStringContainsString( 'Use coupon code GAAD23 from May 18th-May 25th to get access to full-site scanning and other pro features at a special discount.', $message );
+		$this->assertStringContainsString( 'https://my.equalizedigital.com/support/pre-sale-questions/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23', $message );
+		$this->assertStringContainsString( 'https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23', $message );
+	}
+
+	/**
+	 * Test that the edac_password_protected_notice_text function exists.
+	 */
+	public function test_edac_password_protected_notice_text_exists() {
+		$this->assertTrue(
+			method_exists( $this->admin_notices, 'edac_password_protected_notice_text'),
+			'Class does not have method edac_password_protected_notice_text'
+		);
+	}
+
+	/**
+	 * Test that the edac_password_protected_notice_text function returns a string.
+	 */
+	public function test_edac_password_protected_notice_text_returns_string() {
+		$this->assertIsString( $this->admin_notices->edac_password_protected_notice_text() );
+	}
+
+	/**
+	 * Test that the edac_password_protected_notice_text function contains the expected notice message.
+	 */
+	public function test_edac_password_protected_notice_text_contains_notice_message() {
+		$message = $this->admin_notices->edac_password_protected_notice_text();
+		$this->assertStringContainsString( 'Whoops! It looks like your website is currently password protected.', $message );
+		$this->assertStringContainsString( 'The free version of Accessibility Checker can only scan live websites.', $message );
+		$this->assertStringContainsString( 'To scan this website for accessibility problems either remove the password protection or upgrade to pro.', $message );
+		$this->assertStringContainsString( 'Scan results may be stored from a previous scan.', $message );
+	}
+
 }

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class SampleTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Sample test case.
+ */
+class EDACAdminNoticesTest extends WP_UnitTestCase {
+    
+    private $admin_notices;
+
+    protected function setUp(): void {
+        $this->admin_notices = new Admin_Notices();
+    }
+
+    public function test_edac_get_black_friday_message_exists() {
+        $this->assertTrue(
+            method_exists( $this->admin_notices, 'edac_get_black_friday_message'),
+            'Class does not have method edac_get_black_friday_message'
+        );
+    }
+
+    public function test_edac_get_black_friday_message_returns_string() {
+        $this->assertIsString( $this->admin_notices->edac_get_black_friday_message() );
+    }
+
+    public function test_edac_get_black_friday_message_contains_promo_message() {
+        $message = $this->admin_notices->edac_get_black_friday_message();
+        $this->assertStringContainsString( 'Black Friday special!', $message );
+        $this->assertStringContainsString( 'Upgrade to a paid version of Accessibility Checker', $message );
+    }
+}

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * Class SampleTest
+ * Class EDACAdminNoticesTest
  *
  * @package Accessibility_Checker
  */
 
+use EDAC\Admin_Notices;
 /**
- * Sample test case.
+ * Admin Notices test case.
  */
 class EDACAdminNoticesTest extends WP_UnitTestCase {
     

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -67,7 +67,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 		$message = $this->admin_notices->edac_get_gaad_promo_message();
 		$this->assertStringContainsString( '🎉 Get 30% off Accessibility Checker Pro in honor of Global Accessibility Awareness Day! 🎉', $message );
 		$this->assertStringContainsString( 'Use coupon code GAAD23 from May 18th-May 25th to get access to full-site scanning and other pro features at a special discount.', $message );
-		$this->assertStringContainsString( 'https://my.equalizedigital.com/support/pre-sale-questions/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23', $message );
+		$this->assertStringContainsString( 'https://my.equalizedigital.com/support/pre-sale-questions/?utm_source=accessibility-checker&#038;utm_medium=software&#038;utm_campaign=GAAD23', $message );
 		$this->assertStringContainsString( 'https://equalizedigital.com/accessibility-checker/pricing/?utm_source=accessibility-checker&utm_medium=software&utm_campaign=GAAD23', $message );
 	}
 
@@ -95,8 +95,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 		$message = $this->admin_notices->edac_password_protected_notice_text();
 		$this->assertStringContainsString( 'Whoops! It looks like your website is currently password protected.', $message );
 		$this->assertStringContainsString( 'The free version of Accessibility Checker can only scan live websites.', $message );
-		$this->assertStringContainsString( 'To scan this website for accessibility problems either remove the password protection or upgrade to pro.', $message );
+		$this->assertStringContainsString( 'To scan this website for accessibility problems either remove the password protection or <a href="https://equalizedigital.com/accessibility-checker/pricing/" target="_blank" aria-label="Upgrade to accessibility checker pro. Opens in a new window.">upgrade to pro</a>.', $message );
 		$this->assertStringContainsString( 'Scan results may be stored from a previous scan.', $message );
 	}
-
 }

--- a/tests/phpunit/test-admin_notices.php
+++ b/tests/phpunit/test-admin_notices.php
@@ -11,8 +11,8 @@ use EDAC\Admin_Notices;
  */
 class EDACAdminNoticesTest extends WP_UnitTestCase {
 	
-	private $admin_notices;
-
+	private $admin_notices; // Instance of the Admin_Notices class.
+	
 	protected function setUp(): void {
 		$this->admin_notices = new Admin_Notices();
 	}
@@ -22,7 +22,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 	 */
 	public function test_edac_get_black_friday_message_exists() {
 		$this->assertTrue(
-			method_exists( $this->admin_notices, 'edac_get_black_friday_message'),
+			method_exists( $this->admin_notices, 'edac_get_black_friday_message' ),
 			'Class does not have method edac_get_black_friday_message'
 		);
 	}
@@ -48,7 +48,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 	 */
 	public function test_edac_get_gaad_promo_message_exists() {
 		$this->assertTrue(
-			method_exists($this->admin_notices, 'edac_get_gaad_promo_message'),
+			method_exists( $this->admin_notices, 'edac_get_gaad_promo_message' ),
 			'Class does not have method edac_get_gaad_promo_message'
 		);
 	}
@@ -57,7 +57,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 	 * Test that the edac_get_gaad_promo_message function returns a string.
 	 */
 	public function test_edac_get_gaad_promo_message_returns_string() {
-		$this->assertIsString($this->admin_notices->edac_get_gaad_promo_message());
+		$this->assertIsString( $this->admin_notices->edac_get_gaad_promo_message() );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class EDACAdminNoticesTest extends WP_UnitTestCase {
 	 */
 	public function test_edac_password_protected_notice_text_exists() {
 		$this->assertTrue(
-			method_exists( $this->admin_notices, 'edac_password_protected_notice_text'),
+			method_exists( $this->admin_notices, 'edac_password_protected_notice_text' ),
 			'Class does not have method edac_password_protected_notice_text'
 		);
 	}


### PR DESCRIPTION
This PR removes hooks from the constructor of `EDAC\Admin_Notices` and adds basic unit tests.

- Added `init_hooks` method to the `EDAC\Admin_Notices` class.
- Moved hooks out of the constructor
- Created `test-admin_notices.php` unit test that tests for returned strings and expected messages.

#395