### PR TITLE
Avoid setting a `$plugin_check` global variable

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -26,8 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 // Check for WordPress Playground.
 require_once plugin_dir_path( __FILE__ ) . 'includes/classes/class-playground-check.php';
-$plugin_check = new EDAC\Playground_Check();
-if ( ! $plugin_check->should_load ) {
+if ( ! ( new EDAC\Playground_Check() )->should_load ) {
 	return;
 }
 


### PR DESCRIPTION
When adding a variable directly in an included file, it becomes accessible to all of WP.
So this:
```php
$foo = 'bar';
```
is like this:
```php
global $foo;
$foo = 'bar';
```

Unless that's what we want to do, we should avoid doing it because it might override some other global variable set by another plugin/theme/WP.