### PR TITLE
Refactor the `edac_ordinal` function

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -90,11 +90,12 @@ function edac_check_plugin_installed( $plugin_slug ) {
 /**
  * Convert cardinal number into ordinal number
  *
- * @param int $number Number to make ordinal.
+ * @param int|string $number Number to make ordinal.
  * @return string
  */
 function edac_ordinal( $number ) {
-	$ends = array( 'th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th' );
+	$number = (int) $number;
+	$ends   = array( 'th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th' );
 	if ( ( ( $number % 100 ) >= 11 ) && ( ( $number % 100 ) <= 13 ) ) {
 		return $number . 'th';
 	}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -94,12 +94,12 @@ function edac_check_plugin_installed( $plugin_slug ) {
  * @return string
  */
 function edac_ordinal( $number ) {
-	$number = (int) $number;
-	$ends   = array( 'th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th' );
-	if ( ( ( $number % 100 ) >= 11 ) && ( ( $number % 100 ) <= 13 ) ) {
-		return $number . 'th';
-	}
-	return $number . $ends[ $number % 10 ];
+	return (
+		new NumberFormatter(
+			get_locale(),
+			NumberFormatter::ORDINAL
+		)
+	)->format( (int) $number );
 }
 
 /**

--- a/tests/phpunit/helper-functions/test-edac_ordinal.php
+++ b/tests/phpunit/helper-functions/test-edac_ordinal.php
@@ -17,9 +17,27 @@ class EDACOrdinal extends WP_UnitTestCase {
 	 * 
 	 * @param int|string $numeric_value The number we want to convert to ordinal.
 	 * @param string     $ordinal_value The ordinal number that should be returned.
+	 * @param string     $locale        The locale to use.
 	 */
-	public function test_edac_ordinal( $numeric_value, $ordinal_value ) {
+	public function test_edac_ordinal( $numeric_value, $ordinal_value, $locale ) {
+
+		// A filter to bypass the locale.
+		$filter_locale = function () use ( $locale ) {
+			return $locale;
+		};
+
+		// If the locale is not `en_US`, we need to filter it.
+		if ( 'en_US' !== $locale ) {
+			add_filter( 'locale', $filter_locale );
+		}
+
+		// The actual test.
 		$this->assertSame( $ordinal_value, edac_ordinal( $numeric_value ) );
+
+		// Remove the filter if it was added.
+		if ( 'en_US' !== $locale ) {
+			remove_filter( 'locale', $filter_locale );
+		}
 	}
 
 	/**
@@ -27,57 +45,93 @@ class EDACOrdinal extends WP_UnitTestCase {
 	 */
 	public function edac_ordinal_data() {
 		return array(
-			'integer 1'      => array(
+
+			// Set of tests for the default, `en_US` locale.
+			'integer 1, en_US'      => array(
 				'numeric_value' => 1,
 				'ordinal_value' => '1st',
+				'locale'        => 'en_US',
 			),
-			'string 1'       => array(
+			'string 1, en_US'       => array(
 				'numeric_value' => '1',
 				'ordinal_value' => '1st',
+				'locale'        => 'en_US',
 			),
-			'integer 2'      => array(
+			'integer 2, en_US'      => array(
 				'numeric_value' => 2,
 				'ordinal_value' => '2nd',
+				'locale'        => 'en_US',
 			),
-			'integer 3'      => array(
+			'integer 3, en_US'      => array(
 				'numeric_value' => 3,
 				'ordinal_value' => '3rd',
+				'locale'        => 'en_US',
 			),
-			'integer 4'      => array(
+			'integer 4, en_US'      => array(
 				'numeric_value' => 4,
 				'ordinal_value' => '4th',
+				'locale'        => 'en_US',
 			),
-			'integer 5'      => array(
+			'integer 5, en_US'      => array(
 				'numeric_value' => 5,
 				'ordinal_value' => '5th',
+				'locale'        => 'en_US',
 			),
-			'integer 101'    => array(
+			'integer 101, en_US'    => array(
 				'numeric_value' => 101,
 				'ordinal_value' => '101st',
+				'locale'        => 'en_US',
 			),
-			'integer 102'    => array(
+			'integer 102, en_US'    => array(
 				'numeric_value' => 102,
 				'ordinal_value' => '102nd',
+				'locale'        => 'en_US',
 			),
-			'integer 103'    => array(
+			'integer 103, en_US'    => array(
 				'numeric_value' => 103,
 				'ordinal_value' => '103rd',
+				'locale'        => 'en_US',
 			),
-			'integer 104'    => array(
+			'integer 104, en_US'    => array(
 				'numeric_value' => 104,
 				'ordinal_value' => '104th',
+				'locale'        => 'en_US',
 			),
-			'integer 99701'  => array(
+			'integer 99701, en_US'  => array(
 				'numeric_value' => 99701,
-				'ordinal_value' => '99701st',
+				'ordinal_value' => '99,701st',
+				'locale'        => 'en_US',
 			),
-			'invalid string' => array(
+			'invalid string, en_US' => array(
 				'numeric_value' => 'foo',
 				'ordinal_value' => '0th',
+				'locale'        => 'en_US',
 			),
-			'float'          => array(
+			'float, en_US'          => array(
 				'numeric_value' => 1.1,
 				'ordinal_value' => '1st',
+				'locale'        => 'en_US',
+			),
+
+			// Tests for the `fr_FR` locale.
+			'integer 1, fr_FR'      => array(
+				'numeric_value' => 1,
+				'ordinal_value' => '1er',
+				'locale'        => 'fr_FR',
+			),
+
+			// Tests for the `ar` locale.
+			'integer 1, ar'         => array(
+				'numeric_value' => 1,
+				'ordinal_value' => '١.',
+				'locale'        => 'ar',
+			),
+
+			// Tests for the `el_GR` locale.
+			'integer 1, el_GR'      => array(
+				'numeric_value' => 1,
+				'ordinal_value' => '1.',
+				'locale'        => 'el_GR',
 			),
 		);
 	}

--- a/tests/phpunit/helper-functions/test-edac_ordinal.php
+++ b/tests/phpunit/helper-functions/test-edac_ordinal.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Class EDACOrdinal
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Sample test case.
+ */
+class EDACOrdinal extends WP_UnitTestCase {
+
+	/**
+	 * Tests the edac_ordinal function.
+	 * 
+	 * @dataProvider edac_ordinal_data
+	 * 
+	 * @param int|string $numeric_value The number we want to convert to ordinal.
+	 * @param string     $ordinal_value The ordinal number that should be returned.
+	 */
+	public function test_edac_ordinal( $numeric_value, $ordinal_value ) {
+		$this->assertSame( $ordinal_value, edac_ordinal( $numeric_value ) );
+	}
+
+	/**
+	 * Data provider for test_edac_ordinal.
+	 */
+	public function edac_ordinal_data() {
+		return array(
+			'integer 1'      => array(
+				'numeric_value' => 1,
+				'ordinal_value' => '1st',
+			),
+			'string 1'       => array(
+				'numeric_value' => '1',
+				'ordinal_value' => '1st',
+			),
+			'integer 2'      => array(
+				'numeric_value' => 2,
+				'ordinal_value' => '2nd',
+			),
+			'integer 3'      => array(
+				'numeric_value' => 3,
+				'ordinal_value' => '3rd',
+			),
+			'integer 4'      => array(
+				'numeric_value' => 4,
+				'ordinal_value' => '4th',
+			),
+			'integer 5'      => array(
+				'numeric_value' => 5,
+				'ordinal_value' => '5th',
+			),
+			'integer 101'    => array(
+				'numeric_value' => 101,
+				'ordinal_value' => '101st',
+			),
+			'integer 102'    => array(
+				'numeric_value' => 102,
+				'ordinal_value' => '102nd',
+			),
+			'integer 103'    => array(
+				'numeric_value' => 103,
+				'ordinal_value' => '103rd',
+			),
+			'integer 104'    => array(
+				'numeric_value' => 104,
+				'ordinal_value' => '104th',
+			),
+			'integer 99701'  => array(
+				'numeric_value' => 99701,
+				'ordinal_value' => '99701st',
+			),
+			'invalid string' => array(
+				'numeric_value' => 'foo',
+				'ordinal_value' => '0th',
+			),
+			'float'          => array(
+				'numeric_value' => 1.1,
+				'ordinal_value' => '1st',
+			),
+		);
+	}
+}


### PR DESCRIPTION
The `edac_ordinal` function was using hardcoded logic to determine the ordinal format of numbers.
This presented the following challenges:
* Ordinals were only valid for the `en_US` locale
* Even in the `en_US` locale, big numbers were not properly formatted. For example it should be `99,701st` and not `99701st`
* There were no safeguards in case the input was improper (an invalid string, a float and so on)

This PR removed the hardcoded logic and now uses PHP's `NumberFormatter`, passing the WP locale to it, and typecasting the input to an integer.

I also added a lot of tests for this function, accounting for invalid inputs, different locales etc.