### PR TITLE
EDAC\Helpers was renamed to EDAC\Admin\Helpers

### DIFF
--- a/admin/class-issues-query.php
+++ b/admin/class-issues-query.php
@@ -7,7 +7,7 @@
 
 namespace EDAC;
 
-use EDAC\Helpers;
+use EDAC\Admin\Helpers;
 use EDAC\Admin\Settings;
 
 /**

--- a/admin/class-rest-api.php
+++ b/admin/class-rest-api.php
@@ -9,7 +9,7 @@ namespace EDAC;
 
 use EDAC\Scans_Stats;
 use EDAC\Admin\Settings;
-use EDAC\Helpers;
+use EDAC\Admin\Helpers;
 
 
 /**

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -265,7 +265,7 @@ function edac_get_content( $post ) {
 		$parsed_url = wp_parse_url( home_url() );
 
 		if ( isset( $parsed_url['host'] ) ) {
-			$is_local_loopback = \EDAC\Helpers::is_domain_loopback( $parsed_url['host'] );
+			$is_local_loopback = \EDAC\Admin\Helpers::is_domain_loopback( $parsed_url['host'] );
 			update_option( 'edac_local_loopback', $is_local_loopback );
 		}
 	}


### PR DESCRIPTION
The `EDAC\Helpers` class was recently renamed to `EDAC\Admin\Helpers`. However, there were still a few instances where we called `EDAC\Helpers`, and the result was a fatal error: `PHP Fatal error:  Uncaught Error: Class "EDAC\Helpers" not found`.

This PR renames the remaining instances of `EDAC\Helpers`