### PR TITLE
Remove unnecessary calls to add_post_meta

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -231,7 +231,7 @@ function edac_include_rules_files() {
 	}
 	foreach ( $rules as $rule ) {
 		if ( ( array_key_exists( 'ruleset', $rule ) && 'php' === $rule['ruleset'] )
-			|| ( ! array_key_exists( 'ruleset', $rule ) && $rule['slug'] ) 
+			|| ( ! array_key_exists( 'ruleset', $rule ) && $rule['slug'] )
 		) {
 			require_once plugin_dir_path( __FILE__ ) . 'includes/rules/' . $rule['slug'] . '.php';
 		}
@@ -384,9 +384,7 @@ function edac_summary( $post_id ) {
 		$content_length = $issue_density_array[0][1];
 		$issue_density  = edac_get_issue_density( $issue_count, $element_count, $content_length );
 
-		if ( ! add_post_meta( $post_id, '_edac_issue_density', $issue_density, true ) ) {
-			update_post_meta( $post_id, '_edac_issue_density', $issue_density );
-		}
+		update_post_meta( $post_id, '_edac_issue_density', $issue_density );
 	} else {
 		delete_post_meta( $post_id, '_edac_issue_density' );
 	}

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -685,9 +685,7 @@ class Ajax {
 		$post_id = intval( $_REQUEST['post_id'] );
 		$summary = sanitize_text_field( $_REQUEST['summary'] );
 
-		if ( ! add_post_meta( $post_id, '_edac_simplified_summary', $summary, true ) ) {
-			update_post_meta( $post_id, '_edac_simplified_summary', $summary );
-		}
+		update_post_meta( $post_id, '_edac_simplified_summary', $summary );
 
 		$simplified_summary = get_post_meta( $post_id, '_edac_simplified_summary', $single = true );
 
@@ -708,7 +706,7 @@ class Ajax {
 	 */
 	public function dismiss_welcome_cta() {
 
-		update_user_meta( get_current_user_id(), 'edac_welcome_cta_dismissed', true ); 
+		update_user_meta( get_current_user_id(), 'edac_welcome_cta_dismissed', true );
 
 		wp_send_json( 'success' );
 	}

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -165,7 +165,7 @@ function edac_validate( $post_ID, $post, $action ) {
 	edac_remove_corrected_posts( $post_ID, $post->post_type, $pre = 2, 'php' );
 
 	// set post meta checked.
-	add_post_meta( $post_ID, '_edac_post_checked', true, true );
+	update_post_meta( $post_ID, '_edac_post_checked', true );
 
 	do_action( 'edac_after_validate', $post_ID, $action );
 }


### PR DESCRIPTION
From the documentation of the [`update_post_meta`](https://developer.wordpress.org/reference/functions/update_post_meta/) function:

> If the meta field for the post does not exist, it will be added and its ID returned.
> 
> Can be used in place of [add_post_meta()](https://developer.wordpress.org/reference/functions/add_post_meta/) .

This PR removes calls to `add_post_meta` and uses `update_post_meta` where appropriate.
This will also ensure that post-meta will properly get updated (if the post-meta already exists, `add_post_meta` does not update the value)