### PR TITLE
The `edac_log` function does not exist

### DIFF
--- a/includes/validate.php
+++ b/includes/validate.php
@@ -153,12 +153,12 @@ function edac_validate( $post_ID, $post, $action ) {
 			}
 		}
 		if ( EDAC_DEBUG === true ) {
-			edac_log( $rule_performance_results );
+			edacp_log( $rule_performance_results );
 		}
 	}
 	if ( EDAC_DEBUG === true ) {
 		$time_elapsed_secs = microtime( true ) - $all_rules_process_time;
-		edac_log( 'rules validate time: ' . $time_elapsed_secs );
+		edacp_log( 'rules validate time: ' . $time_elapsed_secs );
 	}
 
 	// remove corrected records.


### PR DESCRIPTION
I noticed a couple of calls to an `edac_log` function. However, that function does not exist anywhere.
I found `edacp_log` - and I _assume_ that is the one we wanted to use, so I renamed the calls to the right function.