### PR TITLE
Fix docblock types & add an extra condition

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -307,7 +307,7 @@ function edac_process_actions() {
  * @param boolean $strip_rn strip rn.
  * @param string  $default_br_text default br text.
  * @param string  $default_span_text default span text.
- * @return object
+ * @return object|false
  */
 function edac_str_get_html(
 	$str,

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -15,7 +15,7 @@
 function edac_compare_strings( $string1, $string2 ) {
 	/**
 	 * Prepare strings for our comparison.
-	 * 
+	 *
 	 * @param string $content String to prepare.
 	 * @return string
 	 */
@@ -307,7 +307,7 @@ function edac_process_actions() {
  * @param boolean $strip_rn strip rn.
  * @param string  $default_br_text default br text.
  * @param string  $default_span_text default span text.
- * @return string
+ * @return object
  */
 function edac_str_get_html(
 	$str,

--- a/includes/rules/broken_aria_reference.php
+++ b/includes/rules/broken_aria_reference.php
@@ -37,8 +37,8 @@ function edac_rule_broken_aria_reference( $content, $post ) { // phpcs:ignore --
 /**
  * Checks whether has all referenced elements
  *
- * @param string $element the element.
- * @param string $dom the document.
+ * @param object $element the element.
+ * @param object $dom the document.
  * @param string $attr attribute.
  * @return bool
  */

--- a/includes/rules/missing_transcript.php
+++ b/includes/rules/missing_transcript.php
@@ -18,8 +18,9 @@ function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore -- $c
 		return array();
 	}
 
-	$dom    = edac_str_get_html( $post->post_content );
-	$errors = array();
+	$dom      = edac_str_get_html( $post->post_content );
+	$errors   = array();
+	$elements = array();
 	if ( $dom ) {
 		$elements = $dom->find_media_embeds( true );
 	}

--- a/includes/rules/missing_transcript.php
+++ b/includes/rules/missing_transcript.php
@@ -18,9 +18,11 @@ function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore -- $c
 		return array();
 	}
 
-	$dom      = edac_str_get_html( $post->post_content );
-	$errors   = array();
-	$elements = $dom->find_media_embeds( true );
+	$dom    = edac_str_get_html( $post->post_content );
+	$errors = array();
+	if ( $dom ) {
+		$elements = $dom->find_media_embeds( true );
+	}
 
 	$dom->convert_tag_to_marker( array( 'img', 'iframe', 'audio', 'video', '.is-type-video' ) );
 	foreach ( $elements as $element ) {


### PR DESCRIPTION
This PR changes some errors in docblock param & return types.
Additionally, the `edac_str_get_html` function can return either an object or false, so a condition was added to ensure we don't call methods on a false variable.