### PR TITLE
JS Coding Standards fixes - 2nd pass

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,13 @@
 {
-    "extends": [ "plugin:@wordpress/eslint-plugin/recommended" ]
+	"extends": [ "plugin:@wordpress/eslint-plugin/esnext" ],
+	"env": {
+		"browser": true,
+		"node": false
+	},
+	"globals": {
+		"wp": true,
+		"jQuery": true,
+		"edac_script_vars": true,
+		"ajaxurl": true
+	}
 }

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,4 +1,8 @@
 /* eslint-disable no-unused-vars */
+
+// eslint-disable-next-line camelcase
+const edacScriptVars = edac_script_vars;
+
 ( function() {
 	'use strict';
 
@@ -84,8 +88,7 @@
 		 * @param {Function} callback - Callback function to run after ajax is complete
 		 */
 		function edacSummaryAjax( callback = null ) {
-			// eslint-disable-next-line camelcase
-			const postID = edac_script_vars.postID;
+			const postID = edacScriptVars.postID;
 
 			if ( postID === null ) {
 				return;
@@ -97,8 +100,7 @@
 				data: {
 					action: 'edac_summary_ajax',
 					post_id: postID,
-					// eslint-disable-next-line camelcase
-					nonce: edac_script_vars.nonce,
+					nonce: edacScriptVars.nonce,
 				},
 			} ).done( function( response ) {
 				if ( true === response.success ) {
@@ -134,8 +136,7 @@
 		 * Ajax Details
 		 */
 		function edacDetailsAjax() {
-			// eslint-disable-next-line camelcase
-			const postID = edac_script_vars.postID;
+			const postID = edacScriptVars.postID;
 
 			if ( postID === null ) {
 				return;
@@ -147,8 +148,7 @@
 				data: {
 					action: 'edac_details_ajax',
 					post_id: postID,
-					// eslint-disable-next-line camelcase
-					nonce: edac_script_vars.nonce,
+					nonce: edacScriptVars.nonce,
 				},
 			} ).done( function( response ) {
 				if ( true === response.success ) {
@@ -211,8 +211,7 @@
 		 * Ajax Readability
 		 */
 		function edacReadabilityAjax() {
-			// eslint-disable-next-line camelcase
-			const postID = edac_script_vars.postID;
+			const postID = edacScriptVars.postID;
 
 			if ( postID === null ) {
 				return;
@@ -224,8 +223,7 @@
 				data: {
 					action: 'edac_readability_ajax',
 					post_id: postID,
-					// eslint-disable-next-line camelcase
-					nonce: edac_script_vars.nonce,
+					nonce: edacScriptVars.nonce,
 				},
 			} ).done( function( response ) {
 				if ( true === response.success ) {
@@ -248,8 +246,7 @@
 									action: 'edac_update_simplified_summary',
 									post_id: postID,
 									summary,
-									// eslint-disable-next-line camelcase
-									nonce: edac_script_vars.nonce,
+									nonce: edacScriptVars.nonce,
 								},
 							} ).done( function( doneResponse ) {
 								if ( true === doneResponse.success ) {
@@ -327,8 +324,7 @@
 							comment,
 							ignore_action: ignoreAction,
 							ignore_type: ignoreType,
-							// eslint-disable-next-line camelcase
-							nonce: edac_script_vars.nonce,
+							nonce: edacScriptVars.nonce,
 						},
 					} ).done( function( response ) {
 						if ( true === response.success ) {
@@ -510,8 +506,7 @@
 				data: {
 					action: 'edac_review_notice_ajax',
 					review_action: reviewAction,
-					// eslint-disable-next-line camelcase
-					nonce: edac_script_vars.nonce,
+					nonce: edacScriptVars.nonce,
 				},
 			} ).done( function( response ) {
 				if ( true === response.success ) {
@@ -542,8 +537,7 @@
 				method: 'GET',
 				data: {
 					action: 'edac_password_protected_notice_ajax',
-					// eslint-disable-next-line camelcase
-					nonce: edac_script_vars.nonce,
+					nonce: edacScriptVars.nonce,
 				},
 			} ).done( function( response ) {
 				if ( true === response.success ) {
@@ -581,8 +575,7 @@
 				method: 'GET',
 				data: {
 					action: functionName,
-					// eslint-disable-next-line camelcase
-					nonce: edac_script_vars.nonce,
+					nonce: edacScriptVars.nonce,
 				},
 			} ).done( function( response ) {
 				if ( true === response.success ) {
@@ -674,8 +667,7 @@ window.addEventListener( 'load', function() {
 				}
 
 				postData(
-					// eslint-disable-next-line camelcase
-					edac_script_vars.edacApiUrl + '/clear-cached-scans-stats'
+					edacScriptVars.edacApiUrl + '/clear-cached-scans-stats'
 				).then( ( data ) => {
 					if ( data.success ) {
 						if ( container ) {
@@ -694,8 +686,7 @@ window.addEventListener( 'load', function() {
 
 // Fill the dashboard widget
 const fillDashboardWidget = () => {
-	// eslint-disable-next-line camelcase
-	getData( edac_script_vars.edacApiUrl + '/scans-stats' )
+	getData( edacScriptVars.edacApiUrl + '/scans-stats' )
 		.then( ( data ) => {
 			if ( data.success ) {
 				// Set passed %
@@ -847,8 +838,7 @@ const fillDashboardWidget = () => {
 			//TODO:
 		} );
 
-	// eslint-disable-next-line camelcase
-	getData( edac_script_vars.edacApiUrl + '/scans-stats-by-post-types' )
+	getData( edacScriptVars.edacApiUrl + '/scans-stats-by-post-types' )
 		.then( ( data ) => {
 			if ( data.success ) {
 				Object.entries( data.stats ).forEach( ( [ key, value ] ) => {
@@ -955,8 +945,7 @@ const getData = async ( url = '', data = {} ) => {
 	const response = await fetch( url, {
 		method: 'GET',
 		headers: {
-			// eslint-disable-next-line camelcase
-			'X-WP-Nonce': edac_script_vars.restNonce,
+			'X-WP-Nonce': edacScriptVars.restNonce,
 		},
 	} );
 	return response.json();
@@ -966,8 +955,7 @@ const postData = async ( url = '', data = {} ) => {
 	const response = await fetch( url, {
 		method: 'POST',
 		headers: {
-			// eslint-disable-next-line camelcase
-			'X-WP-Nonce': edac_script_vars.restNonce,
+			'X-WP-Nonce': edacScriptVars.restNonce,
 		},
 		body: JSON.stringify( data ),
 	} );

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,22 +1,21 @@
 /* eslint-disable no-unused-vars */
-/* global edac_script_vars, ajaxurl, jQuery */
-( function ( $ ) {
+( function() {
 	'use strict';
 
-	$( function () {
+	jQuery( function() {
 		// Accessibility Statement disable
-		$(
+		jQuery(
 			'input[type=checkbox][name=edac_add_footer_accessibility_statement]'
-		).on( 'change', function () {
+		).on( 'change', function() {
 			if ( this.checked ) {
-				$(
+				jQuery(
 					'input[type=checkbox][name=edac_include_accessibility_statement_link]'
 				).prop( 'disabled', false );
 			} else {
-				$(
+				jQuery(
 					'input[type=checkbox][name=edac_include_accessibility_statement_link]'
 				).prop( 'disabled', true );
-				$(
+				jQuery(
 					'input[type=checkbox][name=edac_include_accessibility_statement_link]'
 				).prop( 'checked', false );
 			}
@@ -25,25 +24,25 @@
 
 		// Show Simplified Summary code on options page
 		if (
-			$(
+			jQuery(
 				'input[type=radio][name=edac_simplified_summary_position]:checked'
 			).val() === 'none'
 		) {
-			$( '#ac-simplified-summary-option-code' ).show();
+			jQuery( '#ac-simplified-summary-option-code' ).show();
 		}
-		$( 'input[type=radio][name=edac_simplified_summary_position]' ).on(
+		jQuery( 'input[type=radio][name=edac_simplified_summary_position]' ).on(
 			'load',
-			function () {
+			function() {
 				if ( this.value === 'none' ) {
-					$( '#ac-simplified-summary-option-code' ).show();
+					jQuery( '#ac-simplified-summary-option-code' ).show();
 				} else {
-					$( '#ac-simplified-summary-option-code' ).hide();
+					jQuery( '#ac-simplified-summary-option-code' ).hide();
 				}
 			}
 		);
 	} );
 
-	$( window ).on( 'load', function () {
+	jQuery( window ).on( 'load', function() {
 		/**
 		 * Tabs
 		 */
@@ -52,31 +51,31 @@
 		const refreshSummaryAndReadability = () => {
 			edacSummaryAjax( () => {
 				edacReadabilityAjax();
-				$( '.edac-panel' ).removeClass( 'edac-panel-loading' );
+				jQuery( '.edac-panel' ).removeClass( 'edac-panel-loading' );
 			} );
 		};
 
-		$( '.edac-tab' ).click( function ( e ) {
+		jQuery( '.edac-tab' ).click( function( e ) {
 			e.preventDefault();
-			const id = $( 'a', this ).attr( 'href' );
+			const id = jQuery( 'a', this ).attr( 'href' );
 
-			$( '.edac-panel' ).hide();
-			$( '.edac-panel' ).removeClass( 'active' );
-			$( '.edac-tab a' )
+			jQuery( '.edac-panel' ).hide();
+			jQuery( '.edac-panel' ).removeClass( 'active' );
+			jQuery( '.edac-tab a' )
 				.removeClass( 'active' )
 				.attr( 'aria-current', false );
-			$( id ).show();
-			$( id ).addClass( 'active' );
-			$( 'a', this ).addClass( 'active' ).attr( 'aria-current', true );
+			jQuery( id ).show();
+			jQuery( id ).addClass( 'active' );
+			jQuery( 'a', this ).addClass( 'active' ).attr( 'aria-current', true );
 		} );
 
 		// Details Tab on click Ajax
-		$( '.edac-tab-details' ).click( function () {
+		jQuery( '.edac-tab-details' ).click( function() {
 			edacDetailsAjax();
 		} );
 
 		// Summary Tab on click Ajax
-		$( '.edac-tab-summary' ).click( function () {
+		jQuery( '.edac-tab-summary' ).click( function() {
 			refreshSummaryAndReadability();
 		} );
 
@@ -92,7 +91,7 @@
 				return;
 			}
 
-			$.ajax( {
+			jQuery.ajax( {
 				url: ajaxurl,
 				method: 'GET',
 				data: {
@@ -101,14 +100,14 @@
 					// eslint-disable-next-line camelcase
 					nonce: edac_script_vars.nonce,
 				},
-			} ).done( function ( response ) {
+			} ).done( function( response ) {
 				if ( true === response.success ) {
-					const responseJSON = $.parseJSON( response.data );
+					const responseJSON = jQuery.parseJSON( response.data );
 
 					/*
           if(responseJSON.password_protected && edacGutenbergActive()){
             wp.data.dispatch('core/notices').createInfoNotice(
-              responseJSON.password_protected, 
+              responseJSON.password_protected,
               {
                 id: 'edac-password-protected-error',
                 type: 'default', //default, or snackbar
@@ -119,7 +118,7 @@
           }
           */
 
-					$( '.edac-summary' ).html( responseJSON.content );
+					jQuery( '.edac-summary' ).html( responseJSON.content );
 
 					if ( typeof callback === 'function' ) {
 						callback();
@@ -142,7 +141,7 @@
 				return;
 			}
 
-			$.ajax( {
+			jQuery.ajax( {
 				url: ajaxurl,
 				method: 'GET',
 				data: {
@@ -151,51 +150,51 @@
 					// eslint-disable-next-line camelcase
 					nonce: edac_script_vars.nonce,
 				},
-			} ).done( function ( response ) {
+			} ).done( function( response ) {
 				if ( true === response.success ) {
-					const responseJSON = $.parseJSON( response.data );
+					const responseJSON = jQuery.parseJSON( response.data );
 
-					$( '.edac-details' ).html( responseJSON );
+					jQuery( '.edac-details' ).html( responseJSON );
 
 					// Rule on click
-					$( '.edac-details-rule-title' ).click( function () {
-						//$('.edac-details-rule-records').slideUp();
-						if ( $( this ).hasClass( 'active' ) ) {
-							$( this ).next().slideUp();
-							$( this ).removeClass( 'active' );
+					jQuery( '.edac-details-rule-title' ).click( function() {
+						// jQuery('.edac-details-rule-records').slideUp();
+						if ( jQuery( this ).hasClass( 'active' ) ) {
+							jQuery( this ).next().slideUp();
+							jQuery( this ).removeClass( 'active' );
 						} else {
-							$( this ).next().slideDown();
-							$( this ).addClass( 'active' );
+							jQuery( this ).next().slideDown();
+							jQuery( this ).addClass( 'active' );
 						}
 					} );
 
 					// Title arrow button on click
-					$( '.edac-details-rule-title-arrow' ).click(
-						function ( e ) {
+					jQuery( '.edac-details-rule-title-arrow' ).click(
+						function( e ) {
 							e.preventDefault();
 							if (
-								$( this ).attr( 'aria-expanded' ) === 'true'
+								jQuery( this ).attr( 'aria-expanded' ) === 'true'
 							) {
-								$( this ).attr( 'aria-expanded', 'false' );
+								jQuery( this ).attr( 'aria-expanded', 'false' );
 							} else {
-								$( this ).attr( 'aria-expanded', 'true' );
+								jQuery( this ).attr( 'aria-expanded', 'true' );
 							}
 						}
 					);
 
 					// Ignore on click
-					$(
+					jQuery(
 						'.edac-details-rule-records-record-actions-ignore'
-					).click( function ( e ) {
+					).click( function( e ) {
 						e.preventDefault();
-						$( this )
+						jQuery( this )
 							.parent()
 							.next( '.edac-details-rule-records-record-ignore' )
 							.slideToggle();
-						if ( $( this ).attr( 'aria-expanded' ) === 'true' ) {
-							$( this ).attr( 'aria-expanded', 'false' );
+						if ( jQuery( this ).attr( 'aria-expanded' ) === 'true' ) {
+							jQuery( this ).attr( 'aria-expanded', 'false' );
 						} else {
-							$( this ).attr( 'aria-expanded', 'true' );
+							jQuery( this ).attr( 'aria-expanded', 'true' );
 						}
 					} );
 
@@ -219,7 +218,7 @@
 				return;
 			}
 
-			$.ajax( {
+			jQuery.ajax( {
 				url: ajaxurl,
 				method: 'GET',
 				data: {
@@ -228,21 +227,21 @@
 					// eslint-disable-next-line camelcase
 					nonce: edac_script_vars.nonce,
 				},
-			} ).done( function ( response ) {
+			} ).done( function( response ) {
 				if ( true === response.success ) {
-					const responseJSON = $.parseJSON( response.data );
+					const responseJSON = jQuery.parseJSON( response.data );
 
-					$( '.edac-readability' ).html( responseJSON );
+					jQuery( '.edac-readability' ).html( responseJSON );
 
 					// Simplified Summary on click
-					$( '.edac-readability-simplified-summary' ).submit(
-						function ( event ) {
+					jQuery( '.edac-readability-simplified-summary' ).submit(
+						function( event ) {
 							event.preventDefault();
 
 							// var postID = wp.data.select("core/editor").getCurrentPostId();
-							const summary = $( '#edac-readability-text' ).val();
+							const summary = jQuery( '#edac-readability-text' ).val();
 
-							$.ajax( {
+							jQuery.ajax( {
 								url: ajaxurl,
 								method: 'GET',
 								data: {
@@ -252,9 +251,9 @@
 									// eslint-disable-next-line camelcase
 									nonce: edac_script_vars.nonce,
 								},
-							} ).done( function ( doneResponse ) {
+							} ).done( function( doneResponse ) {
 								if ( true === doneResponse.success ) {
-									const doneResponseJSON = $.parseJSON(
+									const doneResponseJSON = jQuery.parseJSON(
 										doneResponse.data
 									);
 
@@ -280,21 +279,21 @@
 			const editPost = wp.data.select( 'core/edit-post' );
 			let lastIsSaving = false;
 
-			wp.data.subscribe( function () {
+			wp.data.subscribe( function() {
 				const isSaving = editPost.isSavingMetaBoxes();
 				if ( isSaving ) {
-					$( '.edac-panel' ).addClass( 'edac-panel-loading' );
+					jQuery( '.edac-panel' ).addClass( 'edac-panel-loading' );
 				}
 				if ( isSaving !== lastIsSaving && ! isSaving ) {
 					lastIsSaving = isSaving;
 
 					// reset to first meta box tab
-					$( '.edac-panel' ).hide();
-					$( '.edac-panel' ).removeClass( 'active' );
-					$( '.edac-tab a' ).removeClass( 'active' );
-					$( '#edac-summary' ).show();
-					$( '#edac-summary' ).addClass( 'active' );
-					$( '.edac-tab:first-child a' ).addClass( 'active' );
+					jQuery( '.edac-panel' ).hide();
+					jQuery( '.edac-panel' ).removeClass( 'active' );
+					jQuery( '.edac-tab a' ).removeClass( 'active' );
+					jQuery( '#edac-summary' ).show();
+					jQuery( '#edac-summary' ).addClass( 'active' );
+					jQuery( '.edac-tab:first-child a' ).addClass( 'active' );
 
 					edacDetailsAjax();
 					refreshSummaryAndReadability();
@@ -307,19 +306,19 @@
 		 * Ignore Submit on click
 		 */
 		function ignoreSubmit() {
-			$( '.edac-details-rule-records-record-ignore-submit' ).click(
-				function ( e ) {
+			jQuery( '.edac-details-rule-records-record-ignore-submit' ).click(
+				function( e ) {
 					e.preventDefault();
 
-					const ids = [ $( this ).attr( 'data-id' ) ];
-					const ignoreAction = $( this ).attr( 'data-action' );
-					const ignoreType = $( this ).attr( 'data-type' );
-					const comment = $(
+					const ids = [ jQuery( this ).attr( 'data-id' ) ];
+					const ignoreAction = jQuery( this ).attr( 'data-action' );
+					const ignoreType = jQuery( this ).attr( 'data-type' );
+					const comment = jQuery(
 						'.edac-details-rule-records-record-ignore-comment',
-						$( this ).parent()
+						jQuery( this ).parent()
 					).val();
 
-					$.ajax( {
+					jQuery.ajax( {
 						url: ajaxurl,
 						method: 'GET',
 						data: {
@@ -331,9 +330,9 @@
 							// eslint-disable-next-line camelcase
 							nonce: edac_script_vars.nonce,
 						},
-					} ).done( function ( response ) {
+					} ).done( function( response ) {
 						if ( true === response.success ) {
-							const data = $.parseJSON( response.data );
+							const data = jQuery.parseJSON( response.data );
 
 							const record =
 								'#edac-details-rule-records-record-' +
@@ -355,56 +354,56 @@
 								? '<strong>Date:</strong> ' + data.date
 								: '';
 
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-submit'
 							).attr( 'data-action', doneIgnoreAction );
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-comment'
 							).attr( 'disabled', doneCommentDisabled );
 							if ( data.action !== 'enable' ) {
-								$(
+								jQuery(
 									record +
 										' .edac-details-rule-records-record-ignore-comment'
 								).val( '' );
 							}
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-actions-ignore'
 							).toggleClass( 'active' );
-							$(
+							jQuery(
 								".edac-details-rule-records-record-actions-ignore[data-id='" +
 									ids[ 0 ] +
 									"']"
 							).toggleClass( 'active' ); // pro
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-actions-ignore-label'
 							).html( doneActionsIgnoreLabel );
-							$(
+							jQuery(
 								".edac-details-rule-records-record-actions-ignore[data-id='" +
 									ids[ 0 ] +
 									"'] .edac-details-rule-records-record-actions-ignore-label"
 							).html( doneActionsIgnoreLabel ); // pro
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-submit-label'
 							).html( ignoreSubmitLabel );
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-info-user'
 							).html( username );
-							$(
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-info-date'
 							).html( date );
 
 							// Update rule count
 							const rule =
-								$( record ).parents( '.edac-details-rule' );
+								jQuery( record ).parents( '.edac-details-rule' );
 							let count = parseInt(
-								$( '.edac-details-rule-count', rule ).html()
+								jQuery( '.edac-details-rule-count', rule ).html()
 							);
 							if ( data.action === 'enable' ) {
 								count--;
@@ -412,21 +411,21 @@
 								count++;
 							}
 							if ( count === 0 ) {
-								$(
+								jQuery(
 									'.edac-details-rule-count',
 									rule
 								).removeClass( 'active' );
 							} else {
-								$( '.edac-details-rule-count', rule ).addClass(
+								jQuery( '.edac-details-rule-count', rule ).addClass(
 									'active'
 								);
 							}
 							count.toString();
-							$( '.edac-details-rule-count', rule ).html( count );
+							jQuery( '.edac-details-rule-count', rule ).html( count );
 
 							// Update ignore rule count
 							let countIgnore = parseInt(
-								$(
+								jQuery(
 									'.edac-details-rule-count-ignore',
 									rule
 								).html()
@@ -438,27 +437,27 @@
 								countIgnore--;
 							}
 							if ( countIgnore === 0 ) {
-								$(
+								jQuery(
 									'.edac-details-rule-count-ignore',
 									rule
 								).hide();
 							} else {
-								$(
+								jQuery(
 									'.edac-details-rule-count-ignore',
 									rule
 								).show();
 							}
 							countIgnore.toString();
-							$( '.edac-details-rule-count-ignore', rule ).html(
+							jQuery( '.edac-details-rule-count-ignore', rule ).html(
 								countIgnore + ' Ignored Items'
 							);
 
 							// refresh page on ignore or unignore in pro
 							if (
-								$( 'body' ).hasClass(
+								jQuery( 'body' ).hasClass(
 									'accessibility-checker_page_accessibility_checker_issues'
 								) ||
-								$( 'body' ).hasClass(
+								jQuery( 'body' ).hasClass(
 									'accessibility-checker_page_accessibility_checker_ignored'
 								)
 							) {
@@ -479,8 +478,9 @@
 		 */
 		function edacGutenbergActive() {
 			// return false if widgets page
-			if ( document.body.classList.contains( 'widgets-php' ) )
+			if ( document.body.classList.contains( 'widgets-php' ) ) {
 				return false;
+			}
 
 			// check if block editor page
 			return document.body.classList.contains( 'block-editor-page' );
@@ -489,22 +489,22 @@
 		/**
 		 * Review Notice Ajax
 		 */
-		if ( $( '.edac-review-notice' ).length ) {
-			$( '.edac-review-notice-review' ).on( 'click', function () {
+		if ( jQuery( '.edac-review-notice' ).length ) {
+			jQuery( '.edac-review-notice-review' ).on( 'click', function() {
 				edacReviewNoticeAjax( 'stop', true );
 			} );
 
-			$( '.edac-review-notice-remind' ).on( 'click', function () {
+			jQuery( '.edac-review-notice-remind' ).on( 'click', function() {
 				edacReviewNoticeAjax( 'pause', false );
 			} );
 
-			$( '.edac-review-notice-dismiss' ).on( 'click', function () {
+			jQuery( '.edac-review-notice-dismiss' ).on( 'click', function() {
 				edacReviewNoticeAjax( 'stop', false );
 			} );
 		}
 
 		function edacReviewNoticeAjax( reviewAction, redirect ) {
-			$.ajax( {
+			jQuery.ajax( {
 				url: ajaxurl,
 				method: 'GET',
 				data: {
@@ -513,10 +513,10 @@
 					// eslint-disable-next-line camelcase
 					nonce: edac_script_vars.nonce,
 				},
-			} ).done( function ( response ) {
+			} ).done( function( response ) {
 				if ( true === response.success ) {
-					const responseJSON = $.parseJSON( response.data );
-					$( '.edac-review-notice' ).fadeOut();
+					const responseJSON = jQuery.parseJSON( response.data );
+					jQuery( '.edac-review-notice' ).fadeOut();
 					if ( redirect ) {
 						window.location.href =
 							'https://wordpress.org/support/plugin/accessibility-checker/reviews/#new-post';
@@ -530,14 +530,14 @@
 		/**
 		 * Password Protected Notice Ajax
 		 */
-		if ( $( '.edac_password_protected_notice' ).length ) {
-			$( '.edac_password_protected_notice' ).on( 'click', function () {
+		if ( jQuery( '.edac_password_protected_notice' ).length ) {
+			jQuery( '.edac_password_protected_notice' ).on( 'click', function() {
 				edacPasswordProtectedNoticeAjax();
 			} );
 		}
 
 		function edacPasswordProtectedNoticeAjax() {
-			$.ajax( {
+			jQuery.ajax( {
 				url: ajaxurl,
 				method: 'GET',
 				data: {
@@ -545,9 +545,9 @@
 					// eslint-disable-next-line camelcase
 					nonce: edac_script_vars.nonce,
 				},
-			} ).done( function ( response ) {
+			} ).done( function( response ) {
 				if ( true === response.success ) {
-					const responseJSON = $.parseJSON( response.data );
+					const responseJSON = jQuery.parseJSON( response.data );
 				} else {
 					//console.log(response);
 				}
@@ -557,8 +557,8 @@
 		/**
 		 * GAAD Notice Ajax
 		 */
-		if ( $( '.edac_gaad_notice' ).length ) {
-			$( '.edac_gaad_notice .notice-dismiss' ).on( 'click', function () {
+		if ( jQuery( '.edac_gaad_notice' ).length ) {
+			jQuery( '.edac_gaad_notice .notice-dismiss' ).on( 'click', function() {
 				edacGaadNoticeAjax( 'edac_gaad_notice_ajax' );
 			} );
 		}
@@ -566,17 +566,17 @@
 		/**
 		 * Black Friday Notice Ajax
 		 */
-		if ( $( '.edac_black_friday_notice' ).length ) {
-			$( '.edac_black_friday_notice .notice-dismiss' ).on(
+		if ( jQuery( '.edac_black_friday_notice' ).length ) {
+			jQuery( '.edac_black_friday_notice .notice-dismiss' ).on(
 				'click',
-				function () {
+				function() {
 					edacGaadNoticeAjax( 'edac_black_friday_notice_ajax' );
 				}
 			);
 		}
 
 		function edacGaadNoticeAjax( functionName = null ) {
-			$.ajax( {
+			jQuery.ajax( {
 				url: ajaxurl,
 				method: 'GET',
 				data: {
@@ -584,32 +584,32 @@
 					// eslint-disable-next-line camelcase
 					nonce: edac_script_vars.nonce,
 				},
-			} ).done( function ( response ) {
+			} ).done( function( response ) {
 				if ( true === response.success ) {
-					const responseJSON = $.parseJSON( response.data );
+					const responseJSON = jQuery.parseJSON( response.data );
 				} else {
 					//console.log(response);
 				}
 			} );
 		}
 
-		if ( $( '.edac-summary' ).length ) {
+		if ( jQuery( '.edac-summary' ).length ) {
 			refreshSummaryAndReadability();
 		}
-		if ( $( '.edac-details' ).length ) {
+		if ( jQuery( '.edac-details' ).length ) {
 			edacDetailsAjax();
 			ignoreSubmit();
 		}
-		if ( $( '.edac-details-rule-records-record-ignore' ).length ) {
+		if ( jQuery( '.edac-details-rule-records-record-ignore' ).length ) {
 			ignoreSubmit();
 		}
-		if ( $( '.edac-readability' ).length ) {
+		if ( jQuery( '.edac-readability' ).length ) {
 			refreshSummaryAndReadability();
 		}
 
-		$( '#dismiss_welcome_cta' ).on( 'click', function () {
+		jQuery( '#dismiss_welcome_cta' ).on( 'click', function() {
 			// AJAX request to handle button click
-			$.ajax( {
+			jQuery.ajax( {
 				type: 'POST',
 				url: ajaxurl,
 				data: {
@@ -618,7 +618,7 @@
 				success( response ) {
 					if ( response === 'success' ) {
 						// Hide the CTA on button click
-						$( '#edac_welcome_page_summary' ).hide();
+						jQuery( '#edac_welcome_page_summary' ).hide();
 					}
 				},
 			} );
@@ -636,7 +636,7 @@
 
 			document.querySelector( '.edac-summary' ).remove();
 
-			$.ajax( {
+			jQuery.ajax( {
 				type: 'POST',
 				url: ajaxurl,
 				data: {
@@ -654,9 +654,9 @@
 			);
 		}
 	} );
-} )( jQuery );
+}( jQuery ) );
 
-window.addEventListener( 'load', function () {
+window.addEventListener( 'load', function() {
 	if ( this.document.querySelector( '.edac-widget .edac-summary' ) ) {
 		fillDashboardWidget();
 	}
@@ -665,7 +665,7 @@ window.addEventListener( 'load', function () {
 	if ( this.document.querySelector( '#edac_clear_cached_stats' ) ) {
 		this.document
 			.querySelector( '#edac_clear_cached_stats' )
-			.addEventListener( 'click', function () {
+			.addEventListener( 'click', function() {
 				const container = document.querySelector(
 					'#edac_welcome_page_summary .edac-welcome-grid-container'
 				);
@@ -739,7 +739,7 @@ const fillDashboardWidget = () => {
       const mins_to_exp = Math.round((expires_at - Math.floor(now / 1000))/60);
       const cache_hit = data.stats.cache_hit;
       if(completedAtEl && completedAt){
-        completedAtEl.textContent = completedAt; 
+        completedAtEl.textContent = completedAt;
         completedAtEl.setAttribute('data-edac-cache-hit', cache_hit);
         completedAtEl.setAttribute('data-edac-cache-mins-to-expiration', mins_to_exp + ' minutes');
       }
@@ -911,7 +911,7 @@ function edacTimestampToLocal() {
 
 	const elements = document.querySelectorAll( '.edac-timestamp-to-local' );
 
-	elements.forEach( function ( element ) {
+	elements.forEach( function( element ) {
 		if ( /^[0-9]+$/.test( element.textContent ) ) {
 			//if only numbers
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -12,7 +12,9 @@ const DEBUG_ENABLED = false;
 let SCAN_INTERVAL_IN_SECONDS = 30;
 
 // eslint-disable-next-line camelcase
-if ( edac_script_vars.mode === 'full-scan' ) {
+const edacScriptVars = edac_script_vars;
+
+if ( edacScriptVars.mode === 'full-scan' ) {
 	SCAN_INTERVAL_IN_SECONDS = 3;
 }
 
@@ -176,21 +178,13 @@ class AccessibilityCheckerHighlight {
 	/**
 	 * This function makes an AJAX call to the server to retrieve the list of issues.
 	 *
-	 * Note: This function assumes that `edac_script_vars` is a global variable containing necessary data.
+	 * Note: This function assumes that `edacScriptVars` is a global variable containing necessary data.
 	 */
 	highlightAjax() {
 		const self = this;
 		return new Promise( function( resolve, reject ) {
 			const xhr = new XMLHttpRequest();
-			const url =
-				// eslint-disable-next-line camelcase
-				edac_script_vars.ajaxurl +
-				'?action=edac_frontend_highlight_ajax&post_id=' +
-				// eslint-disable-next-line camelcase
-				edac_script_vars.postID +
-				'&nonce=' +
-				// eslint-disable-next-line camelcase
-				edac_script_vars.nonce;
+			const url = `${ edacScriptVars.ajaxurl }?action=edac_frontend_highlight_ajax&post_id=${ edacScriptVars.postID }&nonce=${ edacScriptVars.nonce }`;
 
 			self.showWait( true );
 
@@ -222,7 +216,7 @@ class AccessibilityCheckerHighlight {
 				} else {
 					self.showWait( false );
 
-					info( 'Request failed.  Returned status of ' + xhr.status );
+					info( `Request failed. Returned status of ${ xhr.status }` );
 
 					reject( {
 						status: xhr.status,
@@ -286,8 +280,7 @@ class AccessibilityCheckerHighlight {
 	addTooltip( element, value ) {
 		// Create the tooltip.
 		const tooltip = document.createElement( 'button' );
-		tooltip.classList =
-			'edac-highlight-btn edac-highlight-btn-' + value.rule_type;
+		tooltip.classList = `edac-highlight-btn edac-highlight-btn-${ value.rule_type }`;
 		tooltip.ariaLabel = value.rule_title;
 		tooltip.ariaExpanded = 'false';
 		//tooltip.ariaControls = 'edac-highlight-tooltip-' + value.id;
@@ -663,9 +656,7 @@ class AccessibilityCheckerHighlight {
 			let content = '';
 
 			// Get the index and total
-			content += ` <div class="edac-highlight-panel-description-index">${
-				this.currentButtonIndex + 1
-			} of ${ this.issues.length }</div>`;
+			content += ` <div class="edac-highlight-panel-description-index">${ this.currentButtonIndex + 1 } of ${ this.issues.length }</div>`;
 
 			// Get the status of the issue
 			if ( this.currentIssueStatus ) {
@@ -682,15 +673,14 @@ class AccessibilityCheckerHighlight {
 			content += `<button class="edac-highlight-panel-description-code-button" aria-expanded="false" aria-controls="edac-highlight-panel-description-code">Show Code</button>`;
 
 			// title and content
-			descriptionTitle.innerHTML =
-				matchingObj.rule_title +
-				' <span class="edac-highlight-panel-description-type edac-highlight-panel-description-type-' +
-				matchingObj.rule_type +
-				'" aria-label=" Issue type: ' +
-				matchingObj.rule_type +
-				'"> ' +
-				matchingObj.rule_type +
-				'</span>';
+			descriptionTitle.innerHTML = `
+				${ matchingObj.rule_title }
+				<span
+					class="edac-highlight-panel-description-type edac-highlight-panel-description-type-${ matchingObj.rule_type }"
+					aria-label="Issue type: ${ matchingObj.rule_type }"
+				>
+					${ matchingObj.rule_type }
+				</span>`;
 
 			// content
 			descriptionContent.innerHTML = content;
@@ -755,8 +745,8 @@ class AccessibilityCheckerHighlight {
 			link.rel = 'stylesheet';
 			link.id = 'edac-app-css';
 			link.type = 'text/css';
-			// eslint-disable-next-line camelcase, no-unused-expressions
-			( link.href = edac_script_vars.appCssUrl ), ( link.media = 'all' );
+			// eslint-disable-next-line no-unused-expressions
+			( link.href = edacScriptVars.appCssUrl ), ( link.media = 'all' );
 			document.head.appendChild( link );
 		}
 
@@ -904,26 +894,15 @@ class AccessibilityCheckerHighlight {
 		if ( errorCount > 0 || warningCount > 0 || ignoredCount > 0 ) {
 			textContent = '';
 			if ( errorCount >= 0 ) {
-				textContent +=
-					errorCount +
-					' error' +
-					( errorCount === 1 ? '' : 's' ) +
-					', ';
+				textContent += errorCount === 1 ? ' error' : ' errors';
 			}
 			if ( warningCount >= 0 ) {
-				textContent +=
-					warningCount +
-					' warning' +
-					( warningCount === 1 ? '' : 's' ) +
-					', ';
+				textContent += warningCount === 1 ? ' warning' : ' warnings';
 			}
 			if ( ignoredCount >= 0 ) {
-				textContent +=
-					'and ' +
-					ignoredCount +
-					' ignored issue' +
-					( ignoredCount === 1 ? '' : 's' ) +
-					' detected.';
+				textContent += ignoredCount === 1
+					? 'and 1 ignored issue detected.'
+					: `and ${ ignoredCount } ignored issues detected.`;
 			} else {
 				// Remove the trailing comma and add "detected."
 				textContent = textContent.slice( 0, -2 ) + ' detected.';
@@ -940,31 +919,26 @@ if ( window.top._scheduledScanRunning === undefined ) {
 }
 
 async function checkApi() {
-	// eslint-disable-next-line camelcase
-	if ( edac_script_vars.edacHeaders.Authorization === 'None' ) {
+	if ( edacScriptVars.edacHeaders.Authorization === 'None' ) {
 		return 401;
 	}
 
-	// eslint-disable-next-line camelcase
-	const response = await fetch( edac_script_vars.edacApiUrl + '/test', {
+	const response = await fetch( edacScriptVars.edacApiUrl + '/test', {
 		method: 'POST',
-		// eslint-disable-next-line camelcase
-		headers: edac_script_vars.edacHeaders,
+		headers: edacScriptVars.edacHeaders,
 	} );
 
 	return response.status;
 }
 
 async function postData( url = '', data = {} ) {
-	// eslint-disable-next-line camelcase
-	if ( edac_script_vars.edacHeaders.Authorization === 'None' ) {
+	if ( edacScriptVars.edacHeaders.Authorization === 'None' ) {
 		return;
 	}
 
 	return await fetch( url, {
 		method: 'POST',
-		// eslint-disable-next-line camelcase
-		headers: edac_script_vars.edacHeaders,
+		headers: edacScriptVars.edacHeaders,
 		body: JSON.stringify( data ),
 	} )
 		.then( ( res ) => {
@@ -976,15 +950,13 @@ async function postData( url = '', data = {} ) {
 }
 
 async function getData( url = '' ) {
-	// eslint-disable-next-line camelcase
-	if ( edac_script_vars.edacHeaders.Authorization === 'None' ) {
+	if ( edacScriptVars.edacHeaders.Authorization === 'None' ) {
 		return {};
 	}
 
 	return await fetch( url, {
 		method: 'GET',
-		// eslint-disable-next-line camelcase
-		headers: edac_script_vars.edacHeaders,
+		headers: edacScriptVars.edacHeaders,
 	} )
 		.then( ( res ) => {
 			return res.json();
@@ -1003,10 +975,10 @@ function info( message ) {
 function debug( message ) {
 	if ( DEBUG_ENABLED ) {
 		if ( window.location.href !== window.top.location.href ) {
-			console.debug( 'DEBUG [ ' + window.location.href + ' ]' );
+			console.debug( `DEBUG [ ${ window.location.href } ]` );
 		}
 		if ( typeof message !== 'object' ) {
-			console.debug( 'DEBUG: ' + message );
+			console.debug( `DEBUG: ${ message }` );
 		} else {
 			console.debug( message );
 		}
@@ -1018,8 +990,7 @@ function saveScanResults( postId, violations, scheduled = false ) {
 	checkApi()
 		.then( ( status ) => {
 			if ( status >= 400 ) {
-				// eslint-disable-next-line camelcase
-				if ( status === 401 && edac_script_vars.edacpApiUrl === '' ) {
+				if ( status === 401 && edacScriptVars.edacpApiUrl === '' ) {
 					showNotice( {
 						msg: ' Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or {link}. Scan results may be stored from a previous scan.',
 						type: 'warning',
@@ -1031,11 +1002,7 @@ function saveScanResults( postId, violations, scheduled = false ) {
 					debug(
 						'Error: Password protected scans are not supported in the free version.'
 					);
-				} else if (
-					status === 401 &&
-					// eslint-disable-next-line camelcase
-					edac_script_vars.edacpApiUrl !== ''
-				) {
+				} else if ( status === 401 && edacScriptVars.edacpApiUrl !== '' ) {
 					showNotice( {
 						msg: 'Whoops! It looks like your website is currently password protected. To scan this website for accessibility problems {link}.',
 						type: 'warning',
@@ -1056,30 +1023,21 @@ function saveScanResults( postId, violations, scheduled = false ) {
 						closeOthers: true,
 					} );
 
-					debug(
-						'Error: Cannot connect to API. Status code is: ' +
-							status
-					);
+					debug( `Error: Cannot connect to API. Status code is: ${ status }` );
 				}
 			} else {
-				info( 'Saving ' + postId + ': started' );
+				info( `Saving ${ postId }: started` );
 
 				// Api is fine so we can send the scan results.
-				postData(
-					// eslint-disable-next-line camelcase
-					edac_script_vars.edacApiUrl +
-						'/post-scan-results/' +
-						postId,
-					{
-						violations,
-					}
-				).then( ( data ) => {
+				postData( `${ edacScriptVars.edacApiUrl }/post-scan-results/${ postId }`, {
+					violations,
+				} ).then( ( data ) => {
 					debug( data );
 
-					info( 'Saving ' + postId + ': done' );
+					info( `Saving ${ postId }: done` );
 
 					if ( ! data.success ) {
-						info( 'Saving ' + postId + ': error' );
+						info( `Saving ${ postId }: error` );
 
 						showNotice( {
 							msg: 'Whoops! It looks like there was a problem updating. Please try again.',
@@ -1096,7 +1054,7 @@ function saveScanResults( postId, violations, scheduled = false ) {
 			}
 		} )
 		.catch( ( error ) => {
-			info( 'Saving ' + postId + ': error' );
+			info( `Saving ${ postId }: error` );
 
 			debug( error );
 			showNotice( {
@@ -1110,8 +1068,7 @@ function saveScanResults( postId, violations, scheduled = false ) {
 window.addEventListener(
 	'message',
 	( e ) => {
-		// eslint-disable-next-line camelcase
-		if ( e.origin !== edac_script_vars.edacUrl ) {
+		if ( e.origin !== edacScriptVars.edacUrl ) {
 			return;
 		}
 
@@ -1154,10 +1111,10 @@ window.addEventListener(
 				// back to the top window so we can use that cookie to authenticate the rest post.
 				// See: https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/
 
-				info( 'Scan ' + postId + ': started' );
+				info( `Scan ${ postId }: started` );
 
 				scan().then( ( results ) => {
-					info( 'Scan ' + postId + ': done' );
+					info( `Scan ${ postId }: done` );
 
 					const violations = JSON.parse(
 						JSON.stringify( results.violations )
@@ -1183,11 +1140,11 @@ window.addEventListener(
 
 				window.top._scheduledScanRunning = true;
 
-				info( 'Scheduled scan: started ' + postId );
+				info( `Scheduled scan: started ${ postId }` );
 				debug( '_scheduledScanRunning: true' );
 
 				scan().then( ( results ) => {
-					info( 'Scheduled scan: done ' + postId );
+					info( `Scheduled scan: done ${ postId }` );
 
 					const violations = JSON.parse(
 						JSON.stringify( results.violations )
@@ -1209,12 +1166,10 @@ window.addEventListener(
 );
 
 window.addEventListener( 'DOMContentLoaded', () => {
-	// eslint-disable-next-line camelcase
-	debug( 'We are loading the app in ' + edac_script_vars.mode + ' mode.' );
+	debug( `We are loading the app in ${ edacScriptVars.mode } mode.` );
 
 	if ( JS_SCAN_ENABLED ) {
-		// eslint-disable-next-line camelcase
-		if ( edac_script_vars.mode === 'editor-scan' ) {
+		if ( edacScriptVars.mode === 'editor-scan' ) {
 			debug( 'App is loading from within the editor.' );
 
 			// We are loading the app from within the editor (rather than the page preview).
@@ -1223,8 +1178,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			// loaded in the iframe to: 1) run the js scan, 2) post the results.
 			const iframe = document.createElement( 'iframe' );
 			iframe.setAttribute( 'id', 'edac_scanner' );
-			// eslint-disable-next-line camelcase
-			iframe.setAttribute( 'src', edac_script_vars.scanUrl );
+			iframe.setAttribute( 'src', edacScriptVars.scanUrl );
 			iframe.style.width = window.screen.width + 'px';
 			iframe.style.height = window.screen.height + 'px';
 			iframe.style.position = 'absolute';
@@ -1238,8 +1192,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 				window.postMessage( {
 					sender: 'edac_start_scan',
 					message: {
-						// eslint-disable-next-line camelcase
-						postId: edac_script_vars.postID,
+						postId: edacScriptVars.postID,
 					},
 				} );
 			} );
@@ -1257,8 +1210,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 						checkApi().then( ( status ) => {
 							if (
 								status === 401 &&
-								// eslint-disable-next-line camelcase
-								edac_script_vars.edacpApiUrl === ''
+								edacScriptVars.edacpApiUrl === ''
 							) {
 								showNotice( {
 									msg: ' Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or {link}. Scan results may be stored from a previous scan.',
@@ -1272,16 +1224,8 @@ window.addEventListener( 'DOMContentLoaded', () => {
 									'Password protected scans are not supported on the free version.'
 								);
 							} else {
-								debug(
-									'Loading scan iframe: ' +
-										// eslint-disable-next-line camelcase
-										edac_script_vars.scanUrl
-								);
-								iframe.setAttribute(
-									'src',
-									// eslint-disable-next-line camelcase
-									edac_script_vars.scanUrl
-								);
+								debug( `Loading scan iframe: ${ edacScriptVars.scanUrl }` );
+								iframe.setAttribute( 'src', edacScriptVars.scanUrl );
 							}
 						} );
 					}
@@ -1292,12 +1236,8 @@ window.addEventListener( 'DOMContentLoaded', () => {
 		}
 
 		if (
-			// eslint-disable-next-line camelcase
-			( edac_script_vars.mode === 'editor-scan' &&
-				// eslint-disable-next-line camelcase
-				edac_script_vars.edacpApiUrl !== '' ) || //&& edac_script_vars.pendingFullScan) ||
-			// eslint-disable-next-line camelcase
-			edac_script_vars.mode === 'full-scan'
+			( edacScriptVars.mode === 'editor-scan' && edacScriptVars.edacpApiUrl !== '' ) ||
+			edacScriptVars.mode === 'full-scan'
 		) {
 			debug(
 				'App is loading either from the editor page or from the scheduled full scan page.'
@@ -1340,17 +1280,11 @@ window.addEventListener( 'DOMContentLoaded', () => {
 					debug( 'Polling to see if there are any scans pending.' );
 
 					// Poll to see if there are any scans pending.
-					getData(
-						// eslint-disable-next-line camelcase
-						edac_script_vars.edacpApiUrl + '/scheduled-scan-url'
-					).then( ( data ) => {
+					getData( `${ edacScriptVars.edacpApiUrl }/scheduled-scan-url` ).then( ( data ) => {
 						if ( data.code !== 'rest_no_route' ) {
 							if ( data.data !== undefined ) {
 								if ( data.data.scanUrl !== undefined ) {
-									info(
-										'A post needs scanning: ' +
-											data.data.scanUrl
-									);
+									info( `A post needs scanning: ${ data.data.scanUrl }` );
 									debug( data );
 
 									//set the data so we can pass it to the onload handler
@@ -1364,12 +1298,8 @@ window.addEventListener( 'DOMContentLoaded', () => {
 								}
 							}
 						} else {
-							info(
-								'There was a problem connecting to the API.'
-							);
-
+							info( 'There was a problem connecting to the API.' );
 							window.top._scheduledScanRunning = false;
-
 							debug( '_scheduledScanRunning: false' );
 						}
 					} );
@@ -1379,8 +1309,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			}, SCAN_INTERVAL_IN_SECONDS * 1000 );
 		}
 	}
-	// eslint-disable-next-line camelcase
-	if ( edac_script_vars.mode === 'ui' && edac_script_vars.active ) {
+	if ( edacScriptVars.mode === 'ui' && edacScriptVars.active ) {
 		// We are loading the app in a normal page preview so show the user the ui
 		new AccessibilityCheckerHighlight();
 	}
@@ -1450,13 +1379,7 @@ if ( window.top === window && window._showNotice === undefined ) {
 			if ( settings.url ) {
 				msg = msg.replace(
 					'{link}',
-					'<a href="' +
-						settings.url +
-						'" target="_blank" arial-label="' +
-						settings.label +
-						'">' +
-						settings.label +
-						'</a>'
+					`<a href="${ settings.url }" target="_blank" arial-label="${ settings.label }">${ settings.label }</a>`
 				);
 			} else {
 				msg = msg.replace( '{link}', '' );

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-/* global edac_script_vars, DOMParser, XMLHttpRequest */
 import { computePosition, autoUpdate } from '@floating-ui/dom';
 import { createFocusTrap } from 'focus-trap';
 import { isFocusable } from 'tabbable';
@@ -181,7 +180,7 @@ class AccessibilityCheckerHighlight {
 	 */
 	highlightAjax() {
 		const self = this;
-		return new Promise( function ( resolve, reject ) {
+		return new Promise( function( resolve, reject ) {
 			const xhr = new XMLHttpRequest();
 			const url =
 				// eslint-disable-next-line camelcase
@@ -197,7 +196,7 @@ class AccessibilityCheckerHighlight {
 
 			xhr.open( 'GET', url );
 
-			xhr.onload = function () {
+			xhr.onload = function() {
 				if ( xhr.status === 200 ) {
 					self.showWait( false );
 
@@ -232,7 +231,7 @@ class AccessibilityCheckerHighlight {
 				}
 			};
 
-			xhr.onerror = function () {
+			xhr.onerror = function() {
 				self.showWait( false );
 
 				reject( {
@@ -307,7 +306,7 @@ class AccessibilityCheckerHighlight {
 		// Add the tooltip to the page.
 		document.body.append( tooltip );
 
-		const updatePosition = function () {
+		const updatePosition = function() {
 			computePosition( element, tooltip, {
 				placement: 'top-start',
 				middleware: [],
@@ -571,7 +570,7 @@ class AccessibilityCheckerHighlight {
 				this.issues = json;
 
 				json.forEach(
-					function ( value, index ) {
+					function( value, index ) {
 						const element = this.findElement( value, index );
 						if ( element !== null ) {
 							this.issues[ index ].element = element;
@@ -770,11 +769,11 @@ class AccessibilityCheckerHighlight {
 		const elementsWithStyle = document.querySelectorAll(
 			'*[style]:not([class^="edac"])'
 		);
-		elementsWithStyle.forEach( function ( element ) {
+		elementsWithStyle.forEach( function( element ) {
 			element.removeAttribute( 'style' );
 		} );
 
-		this.originalCss = this.originalCss.filter( function ( element ) {
+		this.originalCss = this.originalCss.filter( function( element ) {
 			if (
 				element.id === 'edac-app-css' ||
 				element.id === 'dashicons-css'
@@ -785,7 +784,7 @@ class AccessibilityCheckerHighlight {
 		} );
 
 		document.head.dataset.css = this.originalCss;
-		this.originalCss.forEach( function ( element ) {
+		this.originalCss.forEach( function( element ) {
 			element.remove();
 		} );
 
@@ -801,7 +800,7 @@ class AccessibilityCheckerHighlight {
 	 * This function enables all styles on the page.
 	 */
 	enableStyles() {
-		this.originalCss.forEach( function ( element ) {
+		this.originalCss.forEach( function( element ) {
 			if ( element.tagName === 'STYLE' ) {
 				document.head.appendChild( element.cloneNode( true ) );
 			} else {
@@ -1112,7 +1111,9 @@ window.addEventListener(
 	'message',
 	( e ) => {
 		// eslint-disable-next-line camelcase
-		if ( e.origin !== edac_script_vars.edacUrl ) return;
+		if ( e.origin !== edac_script_vars.edacUrl ) {
+			return;
+		}
 
 		if ( window === window.top ) {
 			//There has been a request to start a scan. Pass the message to the scanner's window.
@@ -1230,7 +1231,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			iframe.style.left = '-' + window.screen.width + 'px';
 			document.body.append( iframe );
 
-			iframe.addEventListener( 'load', function () {
+			iframe.addEventListener( 'load', function() {
 				debug( 'Scan iframe loaded.' );
 
 				// The frame has loaded the preview page, so post the message that fires the iframe scan and save.
@@ -1314,7 +1315,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			iframeScheduledScanner.style.left =
 				'-' + window.screen.width + 'px';
 
-			const onLoadIframeScheduledScanner = function ( e ) {
+			const onLoadIframeScheduledScanner = function( e ) {
 				debug( 'Loading scheduled scan iframe: done' );
 
 				const data = e.currentTarget.data;
@@ -1393,7 +1394,7 @@ if ( window.top === window && window._showNotice === undefined ) {
 	link.media = 'screen,print';
 	document.getElementsByTagName( 'head' )[ 0 ].appendChild( link );
 
-	window._showNotice = function ( options ) {
+	window._showNotice = function( options ) {
 		const settings = Object.assign(
 			{},
 			{
@@ -1436,7 +1437,7 @@ if ( window.top === window && window._showNotice === undefined ) {
 					} );
 			}
 
-			setTimeout( function () {
+			setTimeout( function() {
 				wp.data
 					.dispatch( 'core/notices' )
 					.createNotice( settings.type, msg, o );

--- a/src/app/scanner/index.js
+++ b/src/app/scanner/index.js
@@ -89,11 +89,13 @@ export async function scan( options = { configOptions: {}, runOptions: {} } ) {
 			} );
 
 			//Sort the violations by order they appear in the document
-			violations.sort( function ( a, b ) {
+			violations.sort( function( a, b ) {
 				a = document.querySelector( a.selector );
 				b = document.querySelector( b.selector );
 
-				if ( a === b ) return 0;
+				if ( a === b ) {
+					return 0;
+				}
 				// eslint-disable-next-line no-bitwise
 				if ( a.compareDocumentPosition( b ) & 2 ) {
 					// b comes before a

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* global require, __dirname, module */
 const webpack = require( 'webpack' ); // to access built-in plugins
 const path = require( 'path' );
 const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );


### PR DESCRIPTION
In #424 we fixed the important stuff in JS.
This PR is a 2nd pass, doing the following changes:
* Changed `@wordpress/eslint-plugin/recommended` to `@wordpress/eslint-plugin/esnext` in our ESLint configuration
* Added global variables in the ESLint config so we don't need to define them per-file/line
* Fixed new reported issues
* Replaced `edac_script_vars` with `edacScriptVars` where possible (defined it as a const in the beginning of files with `const edacScriptVars = edac_script_vars;`). This allowed us to get rid of many eslint-disable lines.
* In some places changed concatenation from using `+` to using backticks. This made some things easier to read, and for printed text it will make i18n easier at a later date (right now, text in JS is not translatable, but we can change that in a follow-up PR)