### PR TITLE
Simplified Summary Unit Tests

### DIFF
--- a/tests/phpunit/test-simplified_summary.php
+++ b/tests/phpunit/test-simplified_summary.php
@@ -35,17 +35,6 @@ class EDACSimplifiedSummaryTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tear down the test fixture.
-	 * 
-	 * Cleans up the testing environment after each test.
-	 *
-	 * @return void
-	 */
-	public function tearDown(): void {
-		parent::tearDown();
-	}
-
-	/**
 	 * Tests output of simplified_summary_markup with a summary.
 	 * 
 	 * Verifies that the correct HTML markup is returned when a post 
@@ -75,7 +64,6 @@ class EDACSimplifiedSummaryTest extends WP_UnitTestCase {
 	public function test_simplified_summary_markup_without_summary() {
 		$post_id = self::factory()->post->create();
 
-		// Test that simplified_summary_markup returns an empty string
 		$output = $this->simplified_summary->simplified_summary_markup( $post_id );
 		$this->assertEmpty( $output );
 	}

--- a/tests/phpunit/test-simplified_summary.php
+++ b/tests/phpunit/test-simplified_summary.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Class EDACSimplifiedSummaryTest
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Inc\Simplified_Summary;
+
+/**
+ * Simplified_Summary test case.
+ */
+class EDACSimplifiedSummaryTest extends WP_UnitTestCase {
+	
+	/**
+	 * Instance of the Simplified_Summary class.
+	 * 
+	 * Holds an instance of the Simplified_Summary class
+	 * which is used to test its methods.
+	 *
+	 * @var Admin_Notices $simplified_summary.
+	 */
+	private $simplified_summary;
+
+	/**
+	 * Set up the test fixture.
+	 * 
+	 * Initializes the testing environment before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->simplified_summary = new Simplified_Summary();
+	}
+
+	/**
+	 * Tear down the test fixture.
+	 * 
+	 * Cleans up the testing environment after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests output of simplified_summary_markup with a summary.
+	 * 
+	 * Verifies that the correct HTML markup is returned when a post 
+	 * has a simplified summary.
+	 *
+	 * @return void
+	 */
+	public function test_simplified_summary_markup_with_summary() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, '_edac_simplified_summary', 'This is a simplified summary.' );
+
+		$output = $this->simplified_summary->simplified_summary_markup( $post_id );
+		$this->assertStringContainsString( '<div class="edac-simplified-summary">', $output );
+		$this->assertStringContainsString( '<h2>Simplified Summary</h2>', $output );
+		$this->assertStringContainsString( '<p>This is a simplified summary.</p>', $output );
+		$this->assertStringContainsString( '</div>', $output );
+	}
+
+	/**
+	 * Tests output of simplified_summary_markup without a summary.
+	 * 
+	 * Ensures that an empty string is returned when a post does not
+	 * have a simplified summary.
+	 *
+	 * @return void
+	 */
+	public function test_simplified_summary_markup_without_summary() {
+		$post_id = self::factory()->post->create();
+
+		// Test that simplified_summary_markup returns an empty string
+		$output = $this->simplified_summary->simplified_summary_markup( $post_id );
+		$this->assertEmpty( $output );
+	}
+}


### PR DESCRIPTION
This PR adds unit tests that test the output of the simplified_summary_markup with and without a summary.