### PR TITLE
Hotfix - basic auth fix

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -835,7 +835,7 @@ function edac_summary_ajax() {
 
 	// password check.
 	if (
-		!(
+		! (
 			EDAC_KEY_VALID === true &&
 			edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' )
 		) &&

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -834,7 +834,13 @@ function edac_summary_ajax() {
 	$html['content'] = '';
 
 	// password check.
-	if ( boolval( get_option( 'edac_password_protected' ) ) === true ) {
+	if (
+		!(
+			EDAC_KEY_VALID === true &&
+			edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' )
+		) &&
+		\EDAC\Helpers::is_basic_auth() 
+	) {
 		$admin_notices              = new \EDAC\Admin_Notices();
 		$notice_text                = $admin_notices->edac_password_protected_notice_text();
 		$html['password_protected'] = $notice_text;

--- a/includes/classes/class-helpers.php
+++ b/includes/classes/class-helpers.php
@@ -207,4 +207,41 @@ class Helpers {
 	
 		return false;
 	}
+
+	/**
+	 * Determine if this site is using basic auth.
+	 *
+	 * @return boolean
+	 */
+	public static function is_basic_auth() {
+		
+		$key = 'edac_auth_type';
+
+		$status = get_transient( $key );
+
+		$status = false;
+
+		if ( false === $status ) {
+
+			//phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			$response = wp_remote_get( home_url() );
+			if ( ! is_wp_error( $response ) ) {
+				$code = wp_remote_retrieve_response_code( $response );
+		
+				if ( 401 === $code || 403 === $code ) {
+					$status = 'basic';
+				}
+			}
+			
+			// cache results for up to 30 seconds.
+			set_transient( $key, $status, 30 );
+
+		}
+
+		if ( 'basic' === $status ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -84,6 +84,7 @@ function edac_admin_enqueue_scripts() {
 					'postID'      => $post_id,
 					'edacUrl'     => esc_url_raw( get_site_url() ),
 					'edacHeaders' => $headers,
+					'basicAuth'   => true === $pro ? false : EDAC\Helpers::is_basic_auth(),
 					'edacApiUrl'  => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
 					'baseurl'     => plugin_dir_url( __DIR__ ),
 					'active'      => $active,

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -80,7 +80,6 @@ function edac_display_options_page() {
 
 	// force edac_auth_type to reset in case user updates auth options.
 	delete_transient( 'edac_auth_type' );
-
 }
 
 /**

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -77,6 +77,10 @@ function edac_display_welcome_page() {
  */
 function edac_display_options_page() {
 	include_once plugin_dir_path( __DIR__ ) . 'partials/settings-page.php';
+
+	// force edac_auth_type to reset in case user updates auth options.
+	delete_transient( 'edac_auth_type' );
+
 }
 
 /**

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -112,6 +112,7 @@ function edac_validate( $post_ID, $post, $action ) {
 	do_action( 'edac_after_get_content', $post_ID, $content, $action );
 
 	if ( ! $content['html'] ) {
+		delete_transient( 'edac_auth_type' );
 		add_option( 'edac_password_protected', true );
 		return;
 	} else {

--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -5,11 +5,12 @@ import { showNotice } from './../common/helpers';
 
 const API_URL = edac_editor_app.edacApiUrl;
 
+
 let HEADERS;
-if (typeof (edacp_full_site_scan_app) === 'undefined') {
+if (typeof (edacpFullSiteScanApp) === 'undefined') {
 	HEADERS = edac_editor_app.edacHeaders;
 } else {
-	HEADERS = edacp_full_site_scan_app.edacpHeaders;
+	HEADERS = edacpFullSiteScanApp.edacpHeaders;
 }
 
 

--- a/src/editorApp/index.js
+++ b/src/editorApp/index.js
@@ -1,102 +1,73 @@
-import { settings }  from './settings';
-import { info, debug } from './helpers';
-import { showNotice } from './../common/helpers';
+import { settings } from './settings';
 import { init as initCheckPage } from './checkPage';
+import { showNotice } from './../common/helpers';
+
 
 
 window.addEventListener('DOMContentLoaded', () => {
 
 	const SCANNABLE_POST_TYPE = edac_editor_app.active;
-			
-	if(SCANNABLE_POST_TYPE && settings.JS_SCAN_ENABLED){
 
+	if (SCANNABLE_POST_TYPE && settings.JS_SCAN_ENABLED) {
 
-		if(edac_editor_app.pro === '1'){
-	
-			// Use checkApi from pro instead.
-			setTimeout(function(){
+		if (edac_editor_app.pro === '1' || edac_editor_app.basicAuth !== '1') {
+
+			setTimeout(function () {
 				initCheckPage();
 			}, 250); // Allow page load to fire before init, otherwise we'll have to wait for iframe to load.
 
 		} else {
 
-			const API_URL = edac_editor_app.edacApiUrl;
-			const HEADERS = edac_editor_app.edacHeaders;
-			
-	
-			const checkApi = async () => {
-				try {
-				  const response = await fetch(API_URL + '/test', {
-					method: "POST",
-					headers: HEADERS
-				  });
-			  
-				  return response.status;
-				} catch (error) {
-				  return 401; // Default status for error
-				}
-			};
-	
 
-			checkApi().then((status) => {
+			//Listen for dispatches from the wp data store so we can trap the update/publish event
+			let saving = false;
+			let autosaving = false;
 
-				if (status > 400) {
-		
-					if (status == 401) {
-		
-						showNotice({
-							msg: 'Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or follow the link below to upgrade to Accessibility Checker Pro.',
-							type: 'warning',
-							url: 'https://equalizedigital.com/accessibility-checker/pricing/',
-							label: 'Upgrade',
-							closeOthers: true
-						});
-		
-					} else {
-						showNotice({
-							msg: 'Whoops! It looks like there was a problem connecting to the WordPress REST API which is required by Accessibility Checker. Follow the link below for more information:',
-							type: 'warning',
-							url: 'https://developer.wordpress.org/rest-api/frequently-asked-questions',
-							label: 'Rest API',
-							closeOthers: true
-						});
-	
-						debug('Error: Cannot connect to API. Status code is: ' + status);
-		
+
+			if (wp.data !== undefined && wp.data.subscribe !== undefined) {
+				wp.data.subscribe(() => {
+
+					
+					if (wp.data.select('core/editor').isAutosavingPost()) {
+						autosaving = true;
 					}
-				} else {
 
-					setTimeout(function(){
-						initCheckPage();
-					}, 250); // Allow page load to fire before init, otherwise we'll have to wait for iframe to load.
-			
-				}
-			
-			}).catch((error) => {
-			
-				
-				showNotice({
-					msg: 'Whoops! It looks like there was a problem connecting to the WordPress REST API which is required by Accessibility Checker. Follow the link below for more information:',
-					type: 'warning',
-					url: 'https://developer.wordpress.org/rest-api/frequently-asked-questions',
-					label: 'Rest API',
-					closeOthers: true
+					// Rescan the page if user saves post
+					if (wp.data.select('core/editor').isSavingPost()) {
+					
+						saving = true;
+					} else {
+						if (saving) {
+							saving = false;
+
+							if (edac_editor_app.pro !== '1' || edac_editor_app.basicAuth === '1') {
+								showNotice({
+									msg: 'Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or follow the link below to upgrade to Accessibility Checker Pro.',
+									type: 'warning',
+									url: 'https://equalizedigital.com/accessibility-checker/pricing/',
+									label: 'Upgrade',
+									closeOthers: true
+								});
+						
+							}
+						
+						}
+					}
+
 				});
 
-				debug(error);
-				
-			});
-		
+			} else {
+				debug("Gutenberg is not enabled.");
+			}
 
 
 		
-
-
 		}
-	
 
-	
+
 	}
+
+
 });
 
 


### PR DESCRIPTION
 This PR:

- Bugfix: changes misnamed js variable from edacp_full_site_scan_app to edacpFullSiteScanApp
- Adds EDAC\Helpers\is_basic_auth()
- replaces get_option( 'edac_password_protected') checks with EDAC\Helpers\is_basic_auth() 
- Adds basicAuth to js edac_editor_app
- Adds auth warning to editor page when user saves a post in free on a site that requires auth