### PR TITLE
Bugfix: Classic editor conflict

### DIFF
--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -158,7 +158,10 @@ export const init = () => {
 	if (wp.data !== undefined && wp.data.subscribe !== undefined) {
 		wp.data.subscribe(() => {
 
-			
+			if(wp.data.select('core/editor') === undefined) {
+				return;
+			}
+
 			if (wp.data.select('core/editor').isAutosavingPost()) {
 				autosaving = true;
 			}


### PR DESCRIPTION
The PR:
- Exits the listener for editor saves when core/editor is not defined

Before fix:
- <img width="1065" alt="Screenshot 2024-01-12 at 1 36 40 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/c05707cb-11c2-4a0c-b07f-bba4b5456088">
- <img width="657" alt="Screenshot 2024-01-12 at 1 36 55 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/86300ee6-6485-4483-9c1e-6d4d4ce7e58a">

After fix:
- No core/editor related console errors
- <img width="629" alt="Screenshot 2024-01-12 at 1 37 26 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/c52cc255-11f3-499a-a5d1-fb420c9cba28">
