### PR TITLE
Hotfix/basic auth fix

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -835,7 +835,7 @@ function edac_summary_ajax() {
 
 	// password check.
 	if (
-		!(
+		! (
 			EDAC_KEY_VALID === true &&
 			edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' )
 		) &&

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -835,11 +835,7 @@ function edac_summary_ajax() {
 
 	// password check.
 	if (
-		! (
-			EDAC_KEY_VALID === true &&
-			edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' )
-		) &&
-		\EDAC\Helpers::is_basic_auth() 
+		get_option( 'edac_password_protected', false )
 	) {
 		$admin_notices              = new \EDAC\Admin_Notices();
 		$notice_text                = $admin_notices->edac_password_protected_notice_text();

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.7.1
+ * Version:           1.7.1-beta.7
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -45,7 +45,7 @@ if ( is_admin() && file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.p
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.7.1' );
+	define( 'EDAC_VERSION', '1.7.1-beta.7' );
 }
 
 // Current database version.
@@ -835,7 +835,7 @@ function edac_summary_ajax() {
 
 	// password check.
 	if (
-		get_option( 'edac_password_protected', false )
+		(bool) get_option( 'edac_password_protected', false )
 	) {
 		$admin_notices              = new \EDAC\Admin_Notices();
 		$notice_text                = $admin_notices->edac_password_protected_notice_text();

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,16 @@
     "prefer-stable": true,
     "repositories": [
         {
-          "type": "vcs",
-          "url": "https://github.com/equalizedigital/accessibility-checker-wp-env"
+            "type": "vcs",
+            "url": "https://github.com/equalizedigital/accessibility-checker-wp-env"
         }
-      ],
+    ],
     "require-dev": {
         "automattic/vipwpcs": "^3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
         "phpcompatibility/php-compatibility": "*",
-        "php-parallel-lint/php-parallel-lint": "^1.3"
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "equalizedigital/accessibility-checker-wp-env": "*"
     },
     "require": {
         "cbschuld/browser.php": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "981cc16881daa866df30c80aec17e34a",
+    "content-hash": "36328aa3065e60c85418e6198e600470",
     "packages": [
         {
             "name": "cbschuld/browser.php",
@@ -399,6 +399,37 @@
             "time": "2022-02-04T12:51:07+00:00"
         },
         {
+            "name": "equalizedigital/accessibility-checker-wp-env",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/equalizedigital/accessibility-checker-wp-env.git",
+                "reference": "fd3a97365c258749692fbb900b90e9129deb4a15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/equalizedigital/accessibility-checker-wp-env/zipball/fd3a97365c258749692fbb900b90e9129deb4a15",
+                "reference": "fd3a97365c258749692fbb900b90e9129deb4a15",
+                "shasum": ""
+            },
+            "type": "library",
+            "license": [
+                "GPLv2 or later"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Boone",
+                    "email": "matt@boone.dev"
+                }
+            ],
+            "description": "This package is a customized version of wp-env used for development and testing of Accessibility Checker, Accessibility Checker Pro and Accessibility Checker Audit History.",
+            "support": {
+                "source": "https://github.com/equalizedigital/accessibility-checker-wp-env/tree/v1.0.0",
+                "issues": "https://github.com/equalizedigital/accessibility-checker-wp-env/issues"
+            },
+            "time": "2023-10-23T23:58:23+00:00"
+        },
+        {
             "name": "php-parallel-lint/php-parallel-lint",
             "version": "v1.3.2",
             "source": {
@@ -519,29 +550,29 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.1.2",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.8",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -576,35 +607,50 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-09-20T22:06:18+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
-                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/908247bc65010c7b7541a9551e002db12e9dae70",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -649,9 +695,24 @@
             "support": {
                 "docs": "https://phpcsutils.com/",
                 "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
-            "time": "2023-07-16T21:39:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T14:50:00+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -713,16 +774,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -732,11 +793,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -751,22 +812,45 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/classes/class-helpers.php
+++ b/includes/classes/class-helpers.php
@@ -208,40 +208,4 @@ class Helpers {
 		return false;
 	}
 
-	/**
-	 * Determine if this site is using basic auth.
-	 *
-	 * @return boolean
-	 */
-	public static function is_basic_auth() {
-		
-		$key = 'edac_auth_type';
-
-		$status = get_transient( $key );
-
-		$status = false;
-
-		if ( false === $status ) {
-
-			//phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
-			$response = wp_remote_get( home_url() );
-			if ( ! is_wp_error( $response ) ) {
-				$code = wp_remote_retrieve_response_code( $response );
-		
-				if ( 401 === $code || 403 === $code ) {
-					$status = 'basic';
-				}
-			}
-			
-			// cache results for up to 30 seconds.
-			set_transient( $key, $status, 30 );
-
-		}
-
-		if ( 'basic' === $status ) {
-			return true;
-		}
-
-		return false;
-	}
 }

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -81,7 +81,7 @@ function edac_admin_enqueue_scripts() {
 					'baseurl'    => plugin_dir_url( __DIR__ ),
 					'active'     => $active,
 					'pro'        => $pro,
-					'authOk'     => false === get_option( 'edac_password_protected', false ),
+					'authOk'     => false === (bool) get_option( 'edac_password_protected', false ),
 					'debug'      => $debug,
 					'scanUrl'    => get_preview_post_link(
 						$post_id, 

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -81,7 +81,7 @@ function edac_admin_enqueue_scripts() {
 					'baseurl'    => plugin_dir_url( __DIR__ ),
 					'active'     => $active,
 					'pro'        => $pro,
-					'authOk'     => get_option( 'edac_password_protected', false ),
+					'authOk'     => false === get_option( 'edac_password_protected', false ),
 					'debug'      => $debug,
 					'scanUrl'    => get_preview_post_link(
 						$post_id, 

--- a/includes/enqueue-scripts.php
+++ b/includes/enqueue-scripts.php
@@ -57,12 +57,6 @@ function edac_admin_enqueue_scripts() {
 				$active = false;
 			}
 
-			$headers = array(
-				'Content-Type'  => 'application/json',
-				'X-WP-Nonce'    => wp_create_nonce( 'wp_rest' ),
-				'Authorization' => 'None',
-			
-			);
 	
 			$pro = edac_check_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID;
 	
@@ -81,16 +75,15 @@ function edac_admin_enqueue_scripts() {
 				'edac-editor-app',
 				'edac_editor_app',
 				array(
-					'postID'      => $post_id,
-					'edacUrl'     => esc_url_raw( get_site_url() ),
-					'edacHeaders' => $headers,
-					'basicAuth'   => true === $pro ? false : EDAC\Helpers::is_basic_auth(),
-					'edacApiUrl'  => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
-					'baseurl'     => plugin_dir_url( __DIR__ ),
-					'active'      => $active,
-					'pro'         => $pro,
-					'debug'       => $debug,
-					'scanUrl'     => get_preview_post_link(
+					'postID'     => $post_id,
+					'edacUrl'    => esc_url_raw( get_site_url() ),
+					'edacApiUrl' => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
+					'baseurl'    => plugin_dir_url( __DIR__ ),
+					'active'     => $active,
+					'pro'        => $pro,
+					'authOk'     => get_option( 'edac_password_protected', false ),
+					'debug'      => $debug,
+					'scanUrl'    => get_preview_post_link(
 						$post_id, 
 						array( 'edac_pageScanner' => 1 )
 					),

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -77,9 +77,6 @@ function edac_display_welcome_page() {
  */
 function edac_display_options_page() {
 	include_once plugin_dir_path( __DIR__ ) . 'partials/settings-page.php';
-
-	// force edac_auth_type to reset in case user updates auth options.
-	delete_transient( 'edac_auth_type' );
 }
 
 /**

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -80,7 +80,6 @@ function edac_display_options_page() {
 
 	// force edac_auth_type to reset in case user updates auth options.
 	delete_transient( 'edac_auth_type' );
-
 }
 
 /**

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -111,8 +111,10 @@ function edac_validate( $post_ID, $post, $action ) {
 	$content = edac_get_content( $post );
 	do_action( 'edac_after_get_content', $post_ID, $content, $action );
 
+	// TODO:
+	error_log( $content['html'] );
+
 	if ( ! $content['html'] ) {
-		delete_transient( 'edac_auth_type' );
 		add_option( 'edac_password_protected', true );
 		return;
 	} else {
@@ -357,9 +359,8 @@ function edac_get_content( $post ) {
 			// will not be followed, so $content['html] will be false.
 			$merged_context_opts = array_merge( $default_context_opts, $context_opts );
 			$context             = stream_context_create( $merged_context_opts );
-			
-			$dom             = file_get_html( $url, false, $context );      
-			$content['html'] = edac_remove_elements(
+			$dom                 = file_get_html( $url, false, $context );   
+			$content['html']     = edac_remove_elements(
 				$dom, 
 				array(
 					'#wpadminbar',            // wp admin bar.

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -112,10 +112,10 @@ function edac_validate( $post_ID, $post, $action ) {
 	do_action( 'edac_after_get_content', $post_ID, $content, $action );
 
 	if ( ! $content['html'] ) {
-		add_option( 'edac_password_protected', true );
+		update_option( 'edac_password_protected', true );
 		return;
 	} else {
-		delete_option( 'edac_password_protected' );
+		update_option( 'edac_password_protected', false );
 	}
 
 	// set record check flag on previous error records.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@floating-ui/dom": "^1.2.9",
         "@wordpress/env": "*",
         "@wordpress/scripts": "^26.5.0",
-        "axe-core": "^4.7.2",
+        "axe-core": "^4.8.2",
         "babel-loader": "^9.1.2",
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^6.8.1",

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -840,7 +840,8 @@ const getData = async (url = "", data = {}) => {
   const response = await fetch(url, {
     method: "GET",
     headers: {
-      'X-WP-Nonce': edac_script_vars.restNonce
+      'X-WP-Nonce': edac_script_vars.restNonce,
+      'Content-Type': 'application/json'
     }
   });
   return response.json();
@@ -854,7 +855,8 @@ const postData = async (url = "", data = {}) => {
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      'X-WP-Nonce': edac_script_vars.restNonce
+      'X-WP-Nonce': edac_script_vars.restNonce,
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(data),
   });

--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -1,8 +1,6 @@
 import { info, debug } from './helpers';
 import { showNotice } from './../common/helpers';
 
-
-
 const API_URL = edac_editor_app.edacApiUrl;
 
 const postData = async (url = "", data = {}) => {
@@ -10,6 +8,10 @@ const postData = async (url = "", data = {}) => {
 
 	return await fetch(url, {
 		method: "POST",
+		headers: {
+			'X-WP-Nonce': edac_script_vars.restNonce,
+			'Content-Type': 'application/json'
+		},	  
 		body: JSON.stringify(data),
 	}).then((res) => {
 		return res.json();
@@ -18,19 +20,6 @@ const postData = async (url = "", data = {}) => {
 	});
 
 }
-
-const getData = async (url = "") => {
-
-	return await fetch(url, {
-		method: "GET",
-	}).then((res) => {
-		return res.json();
-	}).catch(() => {
-		return {};
-	});
-
-}
-
 
 
 const saveScanResults = (postId, violations) => {

--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -5,21 +5,11 @@ import { showNotice } from './../common/helpers';
 
 const API_URL = edac_editor_app.edacApiUrl;
 
-
-let HEADERS;
-if (typeof (edacpFullSiteScanApp) === 'undefined') {
-	HEADERS = edac_editor_app.edacHeaders;
-} else {
-	HEADERS = edacpFullSiteScanApp.edacpHeaders;
-}
-
-
 const postData = async (url = "", data = {}) => {
 
 
 	return await fetch(url, {
 		method: "POST",
-		headers: HEADERS,
 		body: JSON.stringify(data),
 	}).then((res) => {
 		return res.json();
@@ -33,7 +23,6 @@ const getData = async (url = "") => {
 
 	return await fetch(url, {
 		method: "GET",
-		headers: HEADERS
 	}).then((res) => {
 		return res.json();
 	}).catch(() => {

--- a/src/editorApp/index.js
+++ b/src/editorApp/index.js
@@ -1,7 +1,5 @@
 import { settings } from './settings';
 import { init as initCheckPage } from './checkPage';
-import { showNotice } from './../common/helpers';
-
 
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -10,58 +8,12 @@ window.addEventListener('DOMContentLoaded', () => {
 
 	if (SCANNABLE_POST_TYPE && settings.JS_SCAN_ENABLED) {
 
-		if (edac_editor_app.pro === '1' || edac_editor_app.basicAuth !== '1') {
+		if (edac_editor_app.authOk === '1' ) {
 
 			setTimeout(function () {
 				initCheckPage();
 			}, 250); // Allow page load to fire before init, otherwise we'll have to wait for iframe to load.
-
-		} else {
-
-
-			//Listen for dispatches from the wp data store so we can trap the update/publish event
-			let saving = false;
-			let autosaving = false;
-
-
-			if (wp.data !== undefined && wp.data.subscribe !== undefined) {
-				wp.data.subscribe(() => {
-
-					
-					if (wp.data.select('core/editor').isAutosavingPost()) {
-						autosaving = true;
-					}
-
-					// Rescan the page if user saves post
-					if (wp.data.select('core/editor').isSavingPost()) {
-					
-						saving = true;
-					} else {
-						if (saving) {
-							saving = false;
-
-							if (edac_editor_app.pro !== '1' || edac_editor_app.basicAuth === '1') {
-								showNotice({
-									msg: 'Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or follow the link below to upgrade to Accessibility Checker Pro.',
-									type: 'warning',
-									url: 'https://equalizedigital.com/accessibility-checker/pricing/',
-									label: 'Upgrade',
-									closeOthers: true
-								});
-						
-							}
-						
-						}
-					}
-
-				});
-
-			} else {
-				debug("Gutenberg is not enabled.");
-			}
-
-
-		
+	
 		}
 
 

--- a/update-composer-config.php
+++ b/update-composer-config.php
@@ -18,7 +18,7 @@ if ( 'true' === $env ) {
 } else {
 	// Not running in GitHub Actions, assuming local environment.
 	// Add your local specific packages.
-	$composer_config['require-dev']['equalizedigital/accessibility-checker-wp-env'] = '1.0.0';
+	$composer_config['require-dev']['equalizedigital/accessibility-checker-wp-env'] = '*';
 }
 
 file_put_contents( $composer_json_path, json_encode( $composer_config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );


### PR DESCRIPTION
This PR:
- Removes setting authorization header in rest calls because browser caches that auth and uses for all requests going forward (not just rest).
- Updates composer to pull the most recent version of equalizedigital/accessibility-checker-wp-env.
