### PR TITLE
Hotfix for incorrect heading order issue

### DIFF
--- a/includes/rules/incorrect_heading_order.php
+++ b/includes/rules/incorrect_heading_order.php
@@ -26,8 +26,8 @@ function edac_rule_incorrect_heading_order( $content, $post ) {
 	if ( $elements ) {
 		foreach ( $elements as $element ) {
 			$current = ( $element->hasAttribute( 'aria-level' ) )
-				? $element->getAttribute( 'aria-level' )
-				: str_replace( 'h', '', $element->tag );
+				? (int) $element->getAttribute( 'aria-level' )
+				: (int) str_replace( 'h', '', $element->tag );
 
 			// Only process the logic if $previous is set and $current is not equal to $previous.
 			if ( $previous && $current !== $previous ) {


### PR DESCRIPTION
This PR corrects false positives on the incorrect heading order rule.

See: 
https://equalizedigital.zendesk.com/agent/tickets/6229
https://equalizedigital.zendesk.com/agent/tickets/6226

Before:
<img width="551" alt="Screenshot 2024-02-06 at 5 32 05 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/b4ae566a-adbb-402d-9b91-321d0b3101a9">


After:
<img width="408" alt="Screenshot 2024-02-06 at 5 33 15 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/695220/e3764515-b5ed-4e89-a79c-d67e1d1595a7">
