### PR TITLE
Hotfix/class number formatter not found

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -271,16 +271,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.27",
+            "version": "2.1.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "16a1ab81559aabf14acb616141e801b32777f085"
+                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/16a1ab81559aabf14acb616141e801b32777f085",
-                "reference": "16a1ab81559aabf14acb616141e801b32777f085",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
+                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
                 "shasum": ""
             },
             "require": {
@@ -313,9 +313,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.27"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.28"
             },
-            "time": "2023-12-03T18:46:49+00:00"
+            "time": "2024-02-06T09:26:11+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -588,16 +588,16 @@
         },
         {
             "name": "equalizedigital/accessibility-checker-wp-env",
-            "version": "v1.0.6",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/equalizedigital/accessibility-checker-wp-env.git",
-                "reference": "9a4f397605def84e54e1dc7fdcf511568f22dad3"
+                "reference": "d643641a52a5364893f96c60acc072955d9ad198"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/equalizedigital/accessibility-checker-wp-env/zipball/9a4f397605def84e54e1dc7fdcf511568f22dad3",
-                "reference": "9a4f397605def84e54e1dc7fdcf511568f22dad3",
+                "url": "https://api.github.com/repos/equalizedigital/accessibility-checker-wp-env/zipball/d643641a52a5364893f96c60acc072955d9ad198",
+                "reference": "d643641a52a5364893f96c60acc072955d9ad198",
                 "shasum": ""
             },
             "type": "library",
@@ -612,10 +612,10 @@
             ],
             "description": "This package is a customized version of wp-env used for development and testing of Accessibility Checker, Accessibility Checker Pro and Accessibility Checker Audit History.",
             "support": {
-                "source": "https://github.com/equalizedigital/accessibility-checker-wp-env/tree/v1.0.6",
+                "source": "https://github.com/equalizedigital/accessibility-checker-wp-env/tree/v1.0.9",
                 "issues": "https://github.com/equalizedigital/accessibility-checker-wp-env/issues"
             },
-            "time": "2024-01-24T20:02:01+00:00"
+            "time": "2024-01-31T17:37:15+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -94,12 +94,40 @@ function edac_check_plugin_installed( $plugin_slug ) {
  * @return string
  */
 function edac_ordinal( $number ) {
-	return (
-		new NumberFormatter(
-			get_locale(),
-			NumberFormatter::ORDINAL
-		)
-	)->format( (int) $number );
+
+	$number = (int) $number;
+
+	if ( class_exists( 'NumberFormatter' ) ) {
+		return (
+			new NumberFormatter(
+				get_locale(),
+				NumberFormatter::ORDINAL
+			)
+		)->format( $number );
+	
+	} else {
+		if ( $number % 100 >= 11 && $number % 100 <= 13 ) {
+			$ordinal = $number . 'th';
+		} else {
+			// Regular rules for other numbers
+			switch ( $number % 10 ) {
+				case 1:
+					$ordinal = $number . 'st';
+					break;
+				case 2:
+					$ordinal = $number . 'nd';
+					break;
+				case 3:
+					$ordinal = $number . 'rd';
+					break;
+				default:
+					$ordinal = $number . 'th';
+					break;
+			}
+		}
+		return $ordinal;
+	
+	}
 }
 
 /**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -109,7 +109,6 @@ function edac_ordinal( $number ) {
 		if ( $number % 100 >= 11 && $number % 100 <= 13 ) {
 			$ordinal = $number . 'th';
 		} else {
-			// Regular rules for other numbers
 			switch ( $number % 10 ) {
 				case 1:
 					$ordinal = $number . 'st';


### PR DESCRIPTION
This PR adds fallback to determine ordinal when php intl extension is not installed.