### PR TITLE
Updated  missing transcript rule to skip certain types of links

### DIFF
--- a/includes/rules/missing_transcript.php
+++ b/includes/rules/missing_transcript.php
@@ -35,6 +35,17 @@ function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore -- $c
 	$linked_media = $dom->find_linked_media( true );
 
 	foreach ( $linked_media as $media_link ) {
+		$href = $media_link->href;
+
+		// Skip certain types of links.
+		if ( strpos( $href, 'mailto:' ) === 0 
+			|| strpos( $href, 'tel:' ) === 0 
+			|| strpos( $href, '#' ) === 0 
+			|| strpos( $href, 'javascript:' ) === 0
+		) {
+			continue;
+		}
+		
 		if ( ! $dom->text_around_element_contains( $media_link, __( 'transcript', 'accessibility-checker' ), 25 ) ) {
 			$errors[] = $media_link;
 		}


### PR DESCRIPTION
The PR fixes the issue with the missing transcript rule flagging false positives on `mailto:` links and other like types.

- Added conditional to skip certain types of links

Fixes #400