### PR TITLE
Simplified summary readability logic #482

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -75,13 +75,25 @@ class Ajax {
 		$summary                   = edac_summary( $post_id );
 		$simplified_summary_text   = '';
 		$simplified_summary_prompt = get_option( 'edac_simplified_summary_prompt' );
+		$simplified_summary        = get_post_meta( $post_id, '_edac_simplified_summary', true ) ? get_post_meta( $post_id, '_edac_simplified_summary', true ) : '';
+
+		$simplified_summary_grade = 0;
+		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
+			$text_statistics          = new \DaveChild\TextStatistics\TextStatistics();
+			$simplified_summary_grade = (int) floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
+		}
+		$simplified_summary_grade_failed = ( $simplified_summary_grade > 9 ) ? true : false;
 
 		$simplified_summary_text = esc_html__( 'A Simplified summary has not been included for this content.', 'accessibility-checker' );
 		if ( 'none' !== $simplified_summary_prompt ) {
 			if ( $summary['content_grade'] <= 9 ) {
 				$simplified_summary_text = esc_html__( 'Your content has a reading level at or below 9th grade and does not require a simplified summary.', 'accessibility-checker' );
 			} elseif ( $summary['simplified_summary'] ) {
-				$simplified_summary_text = esc_html__( 'A Simplified summary has been included for this content.', 'accessibility-checker' );
+				if ( $simplified_summary_grade_failed ) {
+					$simplified_summary_text = esc_html__( 'The reading level of the simplified summary is too high.', 'accessibility-checker' );
+				} else {
+					$simplified_summary_text = esc_html__( 'A simplified summary has been included for this content.', 'accessibility-checker' );
+				}
 			}
 		}
 
@@ -136,14 +148,14 @@ class Ajax {
 		<div class="edac-summary-readability">
 			<div class="edac-summary-readability-level">
 				<div><img src="' . EDAC_PLUGIN_URL . 'assets/images/readability icon navy.png" alt="" width="54"></div>
-				<div class="edac-panel-number' . ( ( (int) $summary['readability'] <= 9 || 'none' === $simplified_summary_prompt ) ? ' passed-text-color' : ' failed-text-color' ) . '">
+				<div class="edac-panel-number' . ( ( (int) $summary['content_grade'] <= 9 || 'none' === $simplified_summary_prompt ) ? ' passed-text-color' : ' failed-text-color' ) . '">
 					' . $summary['readability'] . '
 				</div>
 				<div class="edac-panel-number-label' . ( ( (int) $summary['readability'] <= 9 || 'none' === $simplified_summary_prompt ) ? ' passed-text-color' : ' failed-text-color' ) . '">Reading <br />Level</div>
 			</div>
 			<div class="edac-summary-readability-summary">
-				<div class="edac-summary-readability-summary-icon' . ( ( 'none' === $simplified_summary_prompt || $summary['simplified_summary'] || (int) $summary['readability'] <= 9 ) ? ' active' : '' ) . '"></div>
-				<div class="edac-summary-readability-summary-text' . ( ( 'none' === $simplified_summary_prompt || $summary['simplified_summary'] || (int) $summary['readability'] <= 9 ) ? ' active' : '' ) . '">' . $simplified_summary_text . '</div>
+				<div class="edac-summary-readability-summary-icon' . ( ( ( 'none' === $simplified_summary_prompt || $summary['simplified_summary'] || (int) $summary['content_grade'] <= 9 ) && ! $simplified_summary_grade_failed ) ? ' active' : '' ) . '"></div>
+				<div class="edac-summary-readability-summary-text' . ( ( ( 'none' === $simplified_summary_prompt || $summary['simplified_summary'] || (int) $summary['content_grade'] <= 9 ) && ! $simplified_summary_grade_failed ) ? ' active' : '' ) . '">' . $simplified_summary_text . '</div>
 			</div>
 		</div>
 		<div class="edac-summary-disclaimer"><small>* True accessibility requires manual testing in addition to automated scans. <a href="https://a11ychecker.com/help4280">Learn how to manually test for accessibility</a>.</small></div>
@@ -507,7 +519,7 @@ class Ajax {
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
 			$text_statistics          = new \DaveChild\TextStatistics\TextStatistics();
-			$simplified_summary_grade = edac_ordinal( floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) ) );
+			$simplified_summary_grade = (int) floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
 		}
 
 		$simplified_summary_grade_failed = ( $simplified_summary_grade > 9 ) ? true : false;
@@ -532,8 +544,8 @@ class Ajax {
 			if ( $simplified_summary && 'none' !== $simplified_summary_prompt ) {
 				$html .= '<li class="edac-readability-list-item edac-readability-summary-grade-level">
 					<span class="edac-readability-list-item-icon dashicons ' . ( ( $simplified_summary_grade_failed ) ? 'dashicons-no-alt' : 'dashicons-saved' ) . '"></span>
-					<p class="edac-readability-list-item-title">Simplified Summary Reading Grade Level: <strong class="' . ( ( $simplified_summary_grade_failed ) ? 'failed-text-color' : 'passed-text-color' ) . '">' . $simplified_summary_grade . '</strong></p>
-					<p class="edac-readability-list-item-description">Your simplified summary has a reading level ' . ( ( $simplified_summary_grade_failed > 9 ) ? 'higher' : 'lower' ) . ' than 9th grade.</p>
+					<p class="edac-readability-list-item-title">Simplified Summary Reading Grade Level: <strong class="' . ( ( $simplified_summary_grade_failed ) ? 'failed-text-color' : 'passed-text-color' ) . '">' . edac_ordinal( $simplified_summary_grade ) . '</strong></p>
+					<p class="edac-readability-list-item-description">Your simplified summary has a reading level ' . ( ( $simplified_summary_grade_failed ) ? 'higher' : 'lower' ) . ' than 9th grade.</p>
 				</li>';
 			}
 
@@ -661,7 +673,6 @@ class Ajax {
 	 *  - '-1' means that nonce could not be varified
 	 *  - '-2' means that the post ID was not specified
 	 *  - '-3' means that the summary was not specified
-	 *  - '-4' means that there isn't any summary to return
 	 */
 	public function simplified_summary() {
 
@@ -692,14 +703,8 @@ class Ajax {
 
 		update_post_meta( $post_id, '_edac_simplified_summary', $summary );
 
-		$simplified_summary = get_post_meta( $post_id, '_edac_simplified_summary', $single = true );
-
-		if ( ! $simplified_summary ) {
-
-			$error = new \WP_Error( '-4', 'No simplified summary to return' );
-			wp_send_json_error( $error );
-
-		}
+		$edac_simplified_summary = get_post_meta( $post_id, '_edac_simplified_summary', $single = true );
+		$simplified_summary      = $edac_simplified_summary ? $edac_simplified_summary : '';
 
 		wp_send_json_success( wp_json_encode( $simplified_summary ) );
 	}


### PR DESCRIPTION
This PR updates the simplified summary readability grade-level logic.

- Fixed issue with trying to compare the simplified summary ordinal value
- Removed `wp_send_json_error()` from `simplified_summary` Ajax function when the simplified summary is empty
- Added simplified summary grade-level, message, and icon logic to the `summary()` Ajax
- See functionality screenshots on issue: https://github.com/equalizedigital/accessibility-checker/issues/482#issuecomment-1933389399

Fixes: #482