### PR TITLE
Added value to simplified summary submit button #481

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -575,7 +575,7 @@ class Ajax {
 			<form action="/" class="edac-readability-simplified-summary">
 				<label for="edac-readability-text">Simplified Summary</label>
 				<textarea name="" id="edac-readability-text" cols="30" rows="10">' . $simplified_summary . '</textarea>
-				<input type="submit">
+				<input type="submit" value="Submit">
 			</form>';
 		}
 


### PR DESCRIPTION
This PR fixes the issue with the submit button text showing as `Submit Query` in Firefox.

Fixes: #481