### PR TITLE
Frontend Validate Class

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -139,7 +139,6 @@ add_action( 'admin_head', 'edac_post_on_load' );
 add_filter( 'save_post', 'edac_save_post', 10, 3 );
 add_action( 'wp_trash_post', 'edac_delete_post' );
 add_action( 'pre_get_posts', 'edac_show_draft_posts' );
-add_action( 'template_redirect', 'edac_before_page_render' );
 if ( is_plugin_active( 'oxygen/functions.php' ) ) {
 	add_action( 'added_post_meta', 'edac_oxygen_builder_save_post', 10, 4 );
 	add_action( 'updated_post_meta', 'edac_oxygen_builder_save_post', 10, 4 );
@@ -186,31 +185,6 @@ function edac_include_rules_files() {
 	}
 }
 edac_include_rules_files();
-
-/**
- * Code that needs to run before the page is rendered
- *
- * @return void
- */
-function edac_before_page_render() {
-
-	global $pagenow;
-
-	if ( 'index.php' === $pagenow && false === is_customize_preview() && current_user_can( 'edit_posts' ) ) {
-
-		// Check the page if it hasn't already been checked.
-		global $post;
-		$post_id = is_object( $post ) ? $post->ID : null;       
-		if ( null === $post_id ) {
-			return;
-		}
-
-		$checked = get_post_meta( $post->ID, '_edac_post_checked', true );
-		if ( ! $checked ) {
-			edac_validate( $post->ID, $post, $action = 'load' );
-		}
-	}
-}
 
 /**
  * Summary Data

--- a/includes/classes/class-frontend-validate.php
+++ b/includes/classes/class-frontend-validate.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Accessibility Checker plugin file.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Inc;
+
+/**
+ * A class that handles the validation of the page on the frontend.
+ *
+ * @since 1.9.0
+ */
+class Frontend_Validate {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Initialize WordPress hooks.
+	 *
+	 * @since 1.9.0
+	 */
+	public function init_hooks() {
+		add_action( 'template_redirect', array( $this, 'validate' ) );
+	}
+
+	/**
+	 * Validates the current post on the WordPress dashboard home under specific conditions.
+	 *
+	 * This function is triggered only when viewing the dashboard home ('index.php'), not in a customizer preview,
+	 * and if the current user has permissions to edit posts. It checks if the current post has been previously 
+	 * validated based on a specific post meta key ('_edac_post_checked'). If the post has not been validated, 
+	 * it initiates the validation process.
+	 *
+	 * @return void The function does not return a value. It triggers validation for an unvalidated post or does nothing.
+	 * @since 1.9.0
+	 */
+	public function validate() {
+
+		global $pagenow;
+
+		if ( 'index.php' === $pagenow && false === is_customize_preview() && current_user_can( 'edit_posts' ) ) {
+
+			global $post;
+			$post_id = is_object( $post ) ? $post->ID : null;       
+			if ( null === $post_id ) {
+				return;
+			}
+
+			$checked = get_post_meta( $post->ID, '_edac_post_checked', true );
+			if ( ! $checked ) {
+				edac_validate( $post->ID, $post, $action = 'load' );
+			}
+		}
+	}
+}

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -47,5 +47,8 @@ class Plugin {
 
 		$lazyload_filter = new Lazyload_Filter();
 		$lazyload_filter->init_hooks();
+
+		$frontend_validate = new Frontend_Validate();
+		$frontend_validate->init_hooks();
 	}
 }

--- a/tests/phpunit/test-frontend-validate.php
+++ b/tests/phpunit/test-frontend-validate.php
@@ -84,6 +84,6 @@ class EDACFrontendValidateTest extends WP_UnitTestCase {
 		$this->frontend_validate->validate();
 
 		// Assert that the edac_validate function was called.
-		$this->assertTrue( has_action( 'load', 'edac_validate' ) );
+		$this->assertIsNumeric( has_action( 'load', 'edac_validate' ) );
 	}
 }

--- a/tests/phpunit/test-frontend-validate.php
+++ b/tests/phpunit/test-frontend-validate.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Class EDACFrontendValidateTest
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Inc\Frontend_Validate;
+
+/**
+ * Frontend Validate test case.
+ */
+class EDACFrontendValidateTest extends WP_UnitTestCase {
+	
+	/**
+	 * Instance of the Frontend_Validate class.
+	 *
+	 * @var Frontend_Validate $frontend_validate.
+	 */
+	private $frontend_validate;
+
+	/**
+	 * Set up the test fixture.
+	 */
+	protected function setUp(): void {
+		$this->frontend_validate = new Frontend_Validate();
+	}
+
+	/**
+	 * Test that the validate function does not run validation when the current page is not index.php.
+	 */
+	public function test_validate_does_not_run_on_non_index_pages() {
+		// Set up a non-index page.
+		global $pagenow;
+		$pagenow = 'page.php';
+
+		// Call the validate function.
+		$this->frontend_validate->validate();
+
+		// Assert that the edac_validate function was not called.
+		$this->assertFalse( has_action( 'load', 'edac_validate' ) );
+	}
+
+	/**
+	 * Test that the validate function does not run validation when the customizer preview is active.
+	 */
+	public function test_validate_does_not_run_in_customizer_preview() {
+		// Set up the customizer preview.
+		set_theme_mod( 'is_customize_preview', true );
+
+		// Call the validate function.
+		$this->frontend_validate->validate();
+
+		// Assert that the edac_validate function was not called.
+		$this->assertFalse( has_action( 'load', 'edac_validate' ) );
+	}
+
+	/**
+	 * Test that the validate function does not run validation when the current user cannot edit posts.
+	 */
+	public function test_validate_does_not_run_for_non_editors() {
+		// Set up a user who cannot edit posts.
+		wp_set_current_user( 1 );
+
+		// Call the validate function.
+		$this->frontend_validate->validate();
+
+		// Assert that the edac_validate function was not called.
+		$this->assertFalse( has_action( 'load', 'edac_validate' ) );
+	}
+
+	/**
+	 * Test that the validate function runs validation when all conditions are met.
+	 */
+	public function test_validate_runs_when_conditions_are_met() {
+		// Set up conditions for validation to run.
+		global $pagenow;
+		$pagenow = 'index.php';
+		set_theme_mod( 'is_customize_preview', false );
+		wp_set_current_user( 1 );
+		add_action( 'load', 'edac_validate' );
+
+		// Call the validate function.
+		$this->frontend_validate->validate();
+
+		// Assert that the edac_validate function was called.
+		$this->assertTrue( has_action( 'load', 'edac_validate' ) );
+	}
+}


### PR DESCRIPTION
The PR refactors the edac_before_page_render into a new class with unit tests.

- Removed: edac_before_page_render functions from the main file
- Added: frontend validate class
- Added: frontend validate unit tests

Fixes: #472 