### PR TITLE
Improve aria-hidden warning rule to cover some valid use cases for adding it to elements

### DIFF
--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -32,14 +32,13 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 				}
 			}
 
-			$parent_node             = $element->parent();
-			$tags_for_further_checks = array(
-				'button',
-				'a',
-			);
+			$parent_node = $element->parent();
 			if (
 				$parent_node &&
-				in_array( strtolower( $parent_node->tag ), $tags_for_further_checks, true )
+				(
+					strtolower( $parent_node->tag ) === 'button' ||
+					strtolower( $parent_node->tag ) === 'a'
+				)
 			) {
 				if ( edac_rule_aria_hidden_valid_parentnode_condition_check( $parent_node, $element ) ) {
 					continue;

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -32,8 +32,15 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 				}
 			}
 
-			$parent_node = $element->parent();
-			if ( $parent_node && ( strtolower( $parent_node->tag ) === 'button' || strtolower( $parent_node->tag ) === 'a' ) ) {
+			$parent_node             = $element->parent();
+			$tags_for_further_checks = array(
+				'button',
+				'a',
+			);
+			if (
+				$parent_node &&
+				in_array( strtolower( $parent_node->tag ), $tags_for_further_checks, true )
+			) {
 				if ( edac_rule_aria_hidden_valid_parentnode_condition_check( $parent_node, $element ) ) {
 					continue;
 				}
@@ -109,7 +116,10 @@ function edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( array $
  */
 function edac_rule_aria_hidden_valid_parentnode_condition_check( object $parent_node, object $element ): bool {
 	// bail early if we don't have a parent node or an element node.
-	if ( ! $parent_node || ! $element ) {
+	if (
+		! $parent_node ||
+		! $element
+	) {
 		return false;
 	}
 

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -33,14 +33,17 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 			}
 
 			$parent_node = $element->parent();
-			if ( $parent_node && edac_rule_aria_hidden_valid_parentnode_condition_check( $parent_node, $element ) ) {
-				continue;
+			if ( $parent_node && ( strtolower( $parent_node->tag ) === 'button' || strtolower( $parent_node->tag ) === 'a' ) ) {
+				if ( edac_rule_aria_hidden_valid_parentnode_condition_check( $parent_node, $element ) ) {
+					continue;
+				}
+
+				$siblings = $parent_node->children();
+				if ( $siblings && edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( $siblings ) ) {
+					continue;
+				}
 			}
 
-			$siblings = $parent_node->children();
-			if ( $siblings && edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( $siblings ) ) {
-				continue;
-			}
 
 			$errors[] = $element;
 		}

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -37,11 +37,46 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 				continue;
 			}
 
+			$siblings = $parent_node->children();
+			if ( $siblings && edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( $siblings ) ) {
+				continue;
+			}
+
 			$errors[] = $element;
 		}
 	}
 
 	return $errors;
+}
+
+/**
+ * Check if the siblings are screen reader text elements.
+ *
+ * @param array $siblings Array of siblings.
+ * @return bool
+ */
+function edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( array $siblings ): bool {
+	$common_screen_reader_classes = array(
+		'screen-reader-text',
+		'sr-only',
+		'show-for-sr',
+		'visuallyhidden',
+		'visually-hidden',
+		'hidden-visually',
+		'invisible',
+		'accessibly-hidden',
+		'hide',
+		'hidden',
+	);
+
+	foreach ( $siblings as $sibling ) {
+		foreach ( $common_screen_reader_classes as $class ) {
+			if ( stristr( $sibling->getAttribute( 'class' ), $class ) ) {
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 /**

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -73,7 +73,7 @@ function edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( array $
 
 	foreach ( $siblings as $sibling ) {
 		foreach ( $common_screen_reader_classes as $class ) {
-			if ( stristr( $sibling->getAttribute( 'class' ), $class ) ) {
+			if ( strtolower( $sibling->getAttribute( 'class' ) ) === $class ) {
 				return true;
 			}
 		}

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -18,11 +18,18 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 	$errors   = array();
 	$elements = $dom->find( '[aria-hidden="true"]' );
 
+	$attributes_that_make_this_valid_hidden_use = array(
+		'class' => 'wp-block-spacer',
+		'role'  => 'presentation',
+	);
+
 	if ( $elements ) {
 		foreach ( $elements as $element ) {
 
-			if ( stristr( $element->getAttribute( 'class' ), 'wp-block-spacer' ) ) {
-				continue;
+			foreach ( $attributes_that_make_this_valid_hidden_use as $attribute => $value ) {
+				if ( stristr( $element->getAttribute( $attribute ), $value ) ) {
+					continue 2;
+				}
 			}
 
 			$errors[] = $element;

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -44,7 +44,6 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 				}
 			}
 
-
 			$errors[] = $element;
 		}
 	}

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -52,6 +52,8 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 /**
  * Check if the siblings are screen reader text elements.
  *
+ * @since 1.10.0
+ *
  * @param array $siblings Array of siblings.
  * @return bool
  */
@@ -81,6 +83,8 @@ function edac_rule_aria_hidden_siblings_are_screen_reader_text_elements( array $
 
 /**
  * Check if the parent has a valid situation to avoid flagging aria-hidden="true" warning.
+ *
+ * @since 1.10.0
  *
  * @param object $parent_node  The parent element.
  * @param object $element The element.

--- a/includes/rules/aria_hidden.php
+++ b/includes/rules/aria_hidden.php
@@ -32,9 +32,36 @@ function edac_rule_aria_hidden( $content, $post ) { // phpcs:ignore -- $post is 
 				}
 			}
 
+			$parent_node = $element->parent();
+			if ( $parent_node && edac_rule_aria_hidden_valid_parentnode_condition_check( $parent_node, $element ) ) {
+				continue;
+			}
+
 			$errors[] = $element;
 		}
 	}
 
 	return $errors;
+}
+
+/**
+ * Check if the parent has a valid situation to avoid flagging aria-hidden="true" warning.
+ *
+ * @param object $parent_node  The parent element.
+ * @param object $element The element.
+ *
+ * @return bool
+ */
+function edac_rule_aria_hidden_valid_parentnode_condition_check( object $parent_node, object $element ): bool {
+	// bail early if we don't have a parent node or an element node.
+	if ( ! $parent_node || ! $element ) {
+		return false;
+	}
+
+	// parent node with a non-empty aria-label makes the aria-hidden="true" likely valid.
+	if ( ! empty( $parent_node->getAttribute( 'aria-label' ) ) ) {
+		return true;
+	}
+
+	return false;
 }

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -7,6 +7,8 @@
 
 /**
  * Various different test cases and situations to be run against the aria-hidden rule.
+ *
+ * @group rules
  */
 class AriaHiddenTest extends WP_UnitTestCase {
 
@@ -92,6 +94,71 @@ class AriaHiddenTest extends WP_UnitTestCase {
 		$this->assertEmpty(
 			$this->get_errors_from_rule_check(
 				$this->get_test_markup( 'element_that_is_wp-block-spacer' )
+			)
+		);
+	}
+	/**
+	 * Tests that aria-hidden="true" is ignored when the element is flagged presentational.
+	 */
+	public function test_edac_rule_aria_hidden_skips_presentational() {
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'image_that_is_presentational' )
+			)
+		);
+	}
+
+	/**
+	 * Tests that aria-hidden="true" is allowed when the parent has an aria-label that is not empty.
+	 */
+	public function test_edac_rule_aria_hidden_allows_hidden_with_parent_that_has_label() {
+
+		$button_with_aria_label    = $this->get_test_markup( 'button_with_aria-label' );
+		$button_without_aria_label = preg_replace( '/aria-label="[^"]+"/', '', $button_with_aria_label );
+
+		$this->assertEmpty( $this->get_errors_from_rule_check( $button_with_aria_label ) );
+		$this->assertNotEmpty( $this->get_errors_from_rule_check( $button_without_aria_label ) );
+
+		$link_with_aria_label    = $this->get_test_markup( 'link_with_aria-label' );
+		$link_without_aria_label = preg_replace( '/aria-label="[^"]+"/', '', $button_with_aria_label );
+
+		$this->assertEmpty( $this->get_errors_from_rule_check( $link_with_aria_label ) );
+		$this->assertNotEmpty( $this->get_errors_from_rule_check( $link_without_aria_label ) );
+	}
+
+	/**
+	 * Tests that aria-hidden="true" is allowed when the parent has a screen reader text.
+	 */
+	public function test_edac_rule_aria_hidden_allows_hidden_with_parent_that_has_screen_reader_text() {
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'button_with_screen_reader_text' )
+			)
+		);
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'link_with_screen_reader_text' )
+			)
+		);
+	}
+
+	/**
+	 * Tests that aria-hidden="true" is allowed when the parent has visible text.
+	 */
+	public function test_edac_rule_aria_hidden_allows_hidden_with_parent_that_has_visible_text() {
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'button_with_visible_text' )
+			)
+		);
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'link_with_visible_text' )
 			)
 		);
 	}

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -60,6 +60,43 @@ class AriaHiddenTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the edac_rule_aria_hidden function detects aria-hidden="true".
+	 */
+	public function test_edac_rule_aria_hidden_finds_hidden() {
+
+		$errors = $this->get_errors_from_rule_check( $this->get_test_markup( 'element_with_aria-hidden' ) );
+		$this->assertNotEmpty( $errors );
+
+		// can handle single quotes.
+		$errors = $this->get_errors_from_rule_check( str_replace( '"', "'", $this->get_test_markup( 'element_with_aria-hidden' ) ) );
+		$this->assertNotEmpty( $errors );
+	}
+
+	/**
+	 * Tests the edac_rule_aria_hidden function doesn't detect an issue when aria-hidden="false".
+	 */
+	public function test_edac_rule_aria_hidden_skips_hidden_false() {
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'element_with_aria-hidden_false' )
+			)
+		);
+	}
+
+	/**
+	 * Tests that aria-hidden="true" is ignored when the element is a spacer block.
+	 */
+	public function test_edac_rule_aria_hidden_skips_spacer_block() {
+
+		$this->assertEmpty(
+			$this->get_errors_from_rule_check(
+				$this->get_test_markup( 'element_that_is_wp-block-spacer' )
+			)
+		);
+	}
+
+	/**
 	 * Wrapper to generate dom objects that match the shape of the object in the plugin.
 	 *
 	 * @param string $html_string HTML string.

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Tests the aria_hidden rule.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Various different test cases and situations to be run against the aria-hidden rule.
+ */
+class AriaHiddenTest extends WP_UnitTestCase {
+
+	/**
+	 * Collection of different markup to use for test cases.
+	 *
+	 * @param string $type a key to the array of markup fragments.
+	 * @return string
+	 */
+	private function get_test_markup( string $type = '' ): string {
+		$markup_fragments = array(
+			'element_with_aria-hidden'        => '<div aria-hidden="true"></div>',
+			'element_with_aria-hidden_false'  => '<div aria-hidden="false"></div>',
+			'element_that_is_wp-block-spacer' => '<div aria-hidden="true" class="wp-block-spacer"></div>',
+			'button_with_aria-label'          => <<<EOT
+				<button type="button" aria-haspopup="true" aria-label="Open menu" class="components-button wp-block-navigation__responsive-container-open" inert="true">
+				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
+				</button>
+			EOT,
+			'link_with_aria-label'            => <<<EOT
+				<a href="http://example.com" aria-label="label">
+					    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
+				</a>
+			EOT,
+			'link_with_screen_reader_text'    => <<<EOT
+				<a href="/about" >
+				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
+				<span class="sr-only">About Us</span>
+			EOT,
+			'button_with_screen_reader_text'  => <<<EOT
+				<button type="button" aria-haspopup="true" class="components-button wp-block-navigation__responsive-container-open" inert="true">
+				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
+				<span class="sr-only">Open menu</span>
+				</button>
+			EOT,
+			'link_with_visible_text'          => <<<EOT
+				<a href="/about" >
+				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
+				About Us
+				</a>
+			EOT,
+			'button_with_visible_text'        => <<<EOT
+				<button type="button" aria-haspopup="true" class="components-button wp-block-navigation__responsive-container-open" inert="true">
+				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
+				Menu
+				</button>
+			EOT,
+			'image_that_is_presentational'    => '<img src="http://example.com/image.jpg" aria-hidden="true" role="presentation" />',
+		);
+		return $markup_fragments[ $type ] ?? '';
+	}
+}

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -151,14 +151,34 @@ class AriaHiddenTest extends WP_UnitTestCase {
 	/**
 	 * Test elements with aria-label that are not links or buttons still error.
 	 */
-	public function test_parent_with_lable_that_is_not_link_or_button_errors() {
+	public function test_parent_with_label_that_is_not_link_or_button_errors() {
 
 		$test_elements = array( 'div', 'span', 'section' );
 		foreach ( $test_elements as $element ) {
 			$markup = "<$element aria-label='label'><div aria-hidden='true'></div></$element>";
-			$errors = $this->get_errors_from_rule_check( $markup );
+			$dom    = $this->get_DOM( $markup );
+			$errors = $this->get_errors_from_rule_check( $dom );
 			$this->assertNotEmpty( $errors );
 		}
+	}
+
+	/**
+	 * Test that parents with likely visible text pass.
+	 */
+	public function test_parent_with_likely_visible_text_passes() {
+		$link_dom     = $this->get_DOM( $this->get_test_markup( 'link_with_visible_text' ) );
+		$link_element = $link_dom->find( '[aria-hidden="true"]' );
+		$link_parent  = $link_element[0]->parent();
+		$this->assertNotEmpty( edac_rule_aria_hidden_strip_markup_and_return_text( $link_parent ) );
+
+		$button_dom     = $this->get_DOM( $this->get_test_markup( 'button_with_visible_text' ) );
+		$button_element = $button_dom->find( '[aria-hidden="true"]' );
+		$button_parent  = $button_element[0]->parent();
+		$this->assertNotEmpty( edac_rule_aria_hidden_strip_markup_and_return_text( $button_parent ) );
+
+		// pass the 2 doms through the rule check as well to validate the whole process.
+		$this->assertEmpty( $this->get_errors_from_rule_check( $link_dom ) );
+		$this->assertEmpty( $this->get_errors_from_rule_check( $button_dom ) );
 	}
 
 	/**

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -149,6 +149,19 @@ class AriaHiddenTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test elements with aria-label that are not links or buttons still error.
+	 */
+	public function test_parent_with_lable_that_is_not_link_or_button_errors() {
+
+		$test_elements = array( 'div', 'span', 'section' );
+		foreach ( $test_elements as $element ) {
+			$markup = "<$element aria-label='label'><div aria-hidden='true'></div></$element>";
+			$errors = $this->get_errors_from_rule_check( $markup );
+			$this->assertNotEmpty( $errors );
+		}
+	}
+
+	/**
 	 * Collection of different markup to use for test cases.
 	 *
 	 * @param string $type a key to the array of markup fragments.
@@ -156,43 +169,48 @@ class AriaHiddenTest extends WP_UnitTestCase {
 	 */
 	private function get_test_markup( string $type = '' ): string {
 		$markup_fragments = array(
-			'element_with_aria-hidden'        => '<div aria-hidden="true"></div>',
-			'element_with_aria-hidden_false'  => '<div aria-hidden="false"></div>',
-			'element_that_is_wp-block-spacer' => '<div aria-hidden="true" class="wp-block-spacer"></div>',
-			'button_with_aria-label'          => <<<EOT
+			'element_with_aria-hidden'          => '<div aria-hidden="true"></div>',
+			'element_with_aria-hidden_false'    => '<div aria-hidden="false"></div>',
+			'element_that_is_wp-block-spacer'   => '<div aria-hidden="true" class="wp-block-spacer"></div>',
+			'button_with_aria-label'            => <<<EOT
 				<button type="button" aria-haspopup="true" aria-label="Open menu" class="components-button wp-block-navigation__responsive-container-open" inert="true">
 				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
 				</button>
 			EOT,
-			'link_with_aria-label'            => <<<EOT
+			'link_with_aria-label'              => <<<EOT
 				<a href="http://example.com" aria-label="label">
 					    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
 				</a>
 			EOT,
-			'link_with_screen_reader_text'    => <<<EOT
+			'link_with_screen_reader_text'      => <<<EOT
 				<a href="/about" >
 				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
 				<span class="sr-only">About Us</span>
 			EOT,
-			'button_with_screen_reader_text'  => <<<EOT
+			'button_with_screen_reader_text'    => <<<EOT
 				<button type="button" aria-haspopup="true" class="components-button wp-block-navigation__responsive-container-open" inert="true">
 				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
 				<span class="sr-only">Open menu</span>
 				</button>
 			EOT,
-			'link_with_visible_text'          => <<<EOT
+			'link_with_visible_text'            => <<<EOT
 				<a href="/about" >
 				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
 				About Us
 				</a>
 			EOT,
-			'button_with_visible_text'        => <<<EOT
+			'button_with_visible_text'          => <<<EOT
 				<button type="button" aria-haspopup="true" class="components-button wp-block-navigation__responsive-container-open" inert="true">
 				    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect><rect x="4" y="15" width="16" height="1.5"></rect></svg>
 				Menu
 				</button>
 			EOT,
-			'image_that_is_presentational'    => '<img src="http://example.com/image.jpg" aria-hidden="true" role="presentation" />',
+			'element_with_aria_label_on_parent' => <<<EOT
+				<div aria-label="label">
+					<div aria-hidden="true"></div>
+				</div>
+			EOT,
+			'image_that_is_presentational'      => '<img src="http://example.com/image.jpg" aria-hidden="true" role="presentation" />',
 		);
 		return $markup_fragments[ $type ] ?? '';
 	}

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -158,7 +158,7 @@ class AriaHiddenTest extends WP_UnitTestCase {
 
 		$this->assertEmpty(
 			$this->get_errors_from_rule_check(
-				$this->get_test_markup( 'link_with_visible_text' )
+				$this->get_test_markup( 'element_with_aria_hidden' )
 			)
 		);
 	}
@@ -195,7 +195,7 @@ class AriaHiddenTest extends WP_UnitTestCase {
 	 * @param string $html_string HTML string.
 	 * @return array
 	 */
-	private function get_errors_from_rule_check( string $html_string = '' ) {
+	private function get_errors_from_rule_check( string $html_string = '' ): array {
 		$dom             = $this->get_DOM( $html_string );
 		$content['html'] = $dom;
 		$post            = $this->factory()->post->create_and_get();

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -170,23 +170,15 @@ class AriaHiddenTest extends WP_UnitTestCase {
 	 * @return EDAC_Dom
 	 */
 	private function get_DOM( string $html_string = '' ) {
-		$lowercase         = true;
-		$force_tags_closed = true;
-		$target_charset    = DEFAULT_TARGET_CHARSET;
-		$strip_rn          = true;
-		$default_br_text   = DEFAULT_BR_TEXT;
-		$default_span_text = DEFAULT_SPAN_TEXT;
-
-		$dom = new EDAC_Dom(
+		return new EDAC_Dom(
 			$html_string,
-			$lowercase,
-			$force_tags_closed,
-			$target_charset,
-			$strip_rn,
-			$default_br_text,
-			$default_span_text
+			true,
+			true,
+			DEFAULT_TARGET_CHARSET,
+			true,
+			DEFAULT_BR_TEXT,
+			DEFAULT_SPAN_TEXT
 		);
-		return $dom;
 	}
 
 	/**

--- a/tests/phpunit/includes/rules/AriaHiddenTest.php
+++ b/tests/phpunit/includes/rules/AriaHiddenTest.php
@@ -58,4 +58,44 @@ class AriaHiddenTest extends WP_UnitTestCase {
 		);
 		return $markup_fragments[ $type ] ?? '';
 	}
+
+	/**
+	 * Wrapper to generate dom objects that match the shape of the object in the plugin.
+	 *
+	 * @param string $html_string HTML string.
+	 * @return EDAC_Dom
+	 */
+	private function get_DOM( string $html_string = '' ) {
+		$lowercase         = true;
+		$force_tags_closed = true;
+		$target_charset    = DEFAULT_TARGET_CHARSET;
+		$strip_rn          = true;
+		$default_br_text   = DEFAULT_BR_TEXT;
+		$default_span_text = DEFAULT_SPAN_TEXT;
+
+		$dom = new EDAC_Dom(
+			$html_string,
+			$lowercase,
+			$force_tags_closed,
+			$target_charset,
+			$strip_rn,
+			$default_br_text,
+			$default_span_text
+		);
+		return $dom;
+	}
+
+	/**
+	 * Wrapper to produce $dom nodes and run the rule check.
+	 *
+	 * @param string $html_string HTML string.
+	 * @return array
+	 */
+	private function get_errors_from_rule_check( string $html_string = '' ) {
+		$dom             = $this->get_DOM( $html_string );
+		$content['html'] = $dom;
+		$post            = $this->factory()->post->create_and_get();
+
+		return edac_rule_aria_hidden( $content, $post );
+	}
 }


### PR DESCRIPTION
Right now, the aria-hidden rule flags a warning for every instance that it detects and tasks users with looking at each one and its context to determine whether it is valid. If they find it valid, they are instructed to ignore the issue.

This PR seeks to add some smarts to the checker so that it can try not to flag some instances as warnings when we can tell they are valid already.

It was pretty easy to detect items with labels on the parent, but screen reader text and visible text are a little more challenging and are still being worked through.

* Unit tests have been added to try to cover all the new functionality

Closes: #448 