### PR TITLE
Solve some unexpected situations with frontend highlighter when rules are filtered off

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.9.1
+ * Version:           1.9.2
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -41,7 +41,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.9.1' );
+	define( 'EDAC_VERSION', '1.9.2' );
 }
 
 // Current database version.

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -45,7 +45,8 @@ class Frontend_Highlight {
 		if ( ! $results ) {
 			return null;
 		}
-		return $results;
+
+		return Helpers::filter_results_to_only_active_rules( $results );
 	}
 
 	/**
@@ -76,8 +77,15 @@ class Frontend_Highlight {
 
 		$output = array();
 		foreach ( $results as $result ) {
-			$array     = array();
-			$rule      = edac_filter_by_value( $rules, 'slug', $result['rule'] );
+			$array = array();
+			$rule  = edac_filter_by_value( $rules, 'slug', $result['rule'] );
+
+			// When rules are filtered out, they are not in the rules array and this can be empty. Skip when the rule
+			// is empty to avoid php warnings and passing null values to the frontend highlighter.
+			if ( ! $rule ) {
+				continue;
+			}
+
 			$rule_type = ( true === (bool) $result['ignre'] ) ? 'ignored' : $rule[0]['rule_type'];
 
 			$array['rule_type']  = $rule_type;

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -188,4 +188,27 @@ class Helpers {
 
 		return false;
 	}
+
+	/**
+	 * Filter out inactive rules from the results returned.
+	 *
+	 * @param array $results The results to filter.
+	 */
+	public static function filter_results_to_only_active_rules( $results ): array {
+		// determine which rules are active.
+		$active_rule_slugs = array_map(
+			function ( $rule ) {
+				return $rule['slug'];
+			},
+			edac_register_rules()
+		);
+
+		// filter out inactive rules from the results returned.
+		foreach ( $results as $index => $result ) {
+			if ( ! in_array( $result['rule'], $active_rule_slugs, true ) ) {
+				unset( $results[ $index ] );
+			}
+		}
+		return $results;
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,14 @@
 === Equalize Digital Accessibility Checker - Audit Your Website for WCAG, ADA, and Section 508 Accessibility Errors ===
 Contributors: equalizedigital, alh0319, stevejonesdev
-Tags: accessibility, accessible, wcag, ada, WP accessibility, section 508, aoda, a11y, audit, readability, content analysis
+Tags: accessibility, accessible, wcag, ada, WP accessibility
 Requires at least: 6.2
 Tested up to: 6.4.3
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 
-Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance for WCAG compliance. No API or per page fees.
+Ensure your site's accessibility with a pre-publish audit. Get in-post WCAG compliance help without API or per-page fees.
 
 == Description ==
 
@@ -170,6 +170,12 @@ No, Accessibility Checker runs completely on your server and does not require yo
 8. Accessibility Checker Summary tab on a page with no accessibility error or warnings and an included simplified summary.
 
 == Changelog ==
+
+= 1.9.2 =
+* Fixed: filtered rules are not passed to the frontend highlighter, avoiding 'null' state issues
+* Updated: frontend highlighter buttons to be disabled until issues are confirmed
+* Updated: frontend highlighter buttons to show only after we know there are issues to display
+* Updated: frontend highlighter to not show buttons if none are returned
 
 = 1.9.1 =
 * Updated: `edac_include_rules_files to fire on init action to fix the `edac_filter_register_rules` filter timing

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -498,16 +498,13 @@ class AccessibilityCheckerHighlight {
 		this.panelControls.style.display = 'block';
 		this.panelToggle.style.display = 'none';
 
+		// previous and next buttons are disabled until we have issues to show.
+		this.nextButton.disabled = true;
+		this.previousButton.disabled = true;
+
 		// Get the issues for this page.
 		this.highlightAjax().then(
 			( json ) => {
-				if ( json.length === 0 ) {
-					this.nextButton.disabled = true;
-					this.previousButton.disabled = true;
-				} else {
-					this.nextButton.disabled = false;
-					this.previousButton.disabled = false;
-				}
 
 				this.issues = json;
 
@@ -790,6 +787,10 @@ class AccessibilityCheckerHighlight {
 		let textContent = 'No issues detected.';
 		if ( errorCount > 0 || warningCount > 0 || ignoredCount > 0 ) {
 			textContent = '';
+			// show buttons since we have issues.
+			this.nextButton.disabled = false;
+			this.previousButton.disabled = false;
+
 			if ( errorCount >= 0 ) {
 				textContent += errorCount + ' error' + ( errorCount === 1 ? '' : 's' ) + ', ';
 			}

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -165,7 +165,15 @@ class AccessibilityCheckerHighlight {
 							resolve( responseJson );
 						} else {
 							resolve(
-								responseJson.filter( ( item ) => ( item.id === self.urlParameter || item.rule_type !== 'ignored' ) )
+								responseJson.filter( ( item ) => {
+									// When rules are filtered off from php we can get null values for some properties
+									// here. This should be fixed upstream but handling it here as well for robustness.
+									if ( item.rule_type === null ) {
+										return false;
+									}
+
+									return ( item.id === self.urlParameter || item.rule_type !== 'ignored' );
+								} )
 							);
 						}
 					} else {


### PR DESCRIPTION
When someone filters out a certain rule after a page is scanned, the Ajax call still returns those rules to the highlighter in a 'null' state without any information. This PR seeks to not return null data to the highlighter so they are not shown on the frontend when inspecting the page issues.

* Prevent filtered out rule issues being passed down to the highlighter.
* Also disable the buttons in the highlighter until we know we have issues to display.

<details>
  <summary>Widget when loading doesn't show nav buttons anymore</summary>
  
![Screenshot from 2024-03-08 21-35-49](https://github.com/equalizedigital/accessibility-checker/assets/3902039/b7b9d4e4-7a2b-4bde-bcdf-f5c6ac4a550d)


</details>

<details>
  <summary>Show buttons only after we know there are issues to display</summary>
  
![Screenshot from 2024-03-08 21-36-08](https://github.com/equalizedigital/accessibility-checker/assets/3902039/372239a6-a0fa-4645-83db-094eee5b6d29)

</details>

<details>
  <summary>Show no buttons when no issues were returned from ajax call</summary>

![Screenshot from 2024-03-08 21-36-55](https://github.com/equalizedigital/accessibility-checker/assets/3902039/16a6c4dc-ec60-45e9-80b2-496b29fcd440)

</details>

Fixes #524 