### PR TITLE
Add a capability check for 'edit_posts' before outputting dashboard w…

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.9.2
+ * Version:           1.9.3
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -41,7 +41,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.9.2' );
+	define( 'EDAC_VERSION', '1.9.3' );
 }
 
 // Current database version.

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -252,10 +252,6 @@ class Admin_Notices {
 	 */
 	public function edac_review_notice() {
 
-		if ( ! Helpers::current_user_can_see_widget() ) {
-			return;
-		}
-
 		$option             = 'edac_review_notice';
 		$edac_review_notice = get_option( $option );
 

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -26,6 +26,21 @@ class Admin_Notices {
 	public function init_hooks() {
 
 		add_action( 'in_admin_header', array( $this, 'edac_remove_admin_notices' ), 1000 );
+		add_action( 'init', array( $this, 'hook_notices' ) );
+	}
+
+	/**
+	 * Hook Notices
+	 *
+	 * @since 1.9.3
+	 *
+	 * @return void
+	 */
+	public function hook_notices() {
+		if ( ! Helpers::current_user_can_see_widgets_and_notices() ) {
+			return;
+		}
+
 		add_action( 'admin_notices', array( $this, 'edac_black_friday_notice' ) );
 		add_action( 'wp_ajax_edac_black_friday_notice_ajax', array( $this, 'edac_black_friday_notice_ajax' ) );
 		add_action( 'admin_notices', array( $this, 'edac_gaad_notice' ) );

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -17,13 +17,14 @@ class Admin_Notices {
 	 */
 	public function __construct() {
 	}
-	
+
 	/**
 	 * Initialize class hooks.
 	 *
 	 * @return void
 	 */
 	public function init_hooks() {
+
 		add_action( 'in_admin_header', array( $this, 'edac_remove_admin_notices' ), 1000 );
 		add_action( 'admin_notices', array( $this, 'edac_black_friday_notice' ) );
 		add_action( 'wp_ajax_edac_black_friday_notice_ajax', array( $this, 'edac_black_friday_notice_ajax' ) );
@@ -236,6 +237,10 @@ class Admin_Notices {
 	 */
 	public function edac_review_notice() {
 
+		if ( ! Helpers::current_user_can_see_widget() ) {
+			return;
+		}
+
 		$option             = 'edac_review_notice';
 		$edac_review_notice = get_option( $option );
 
@@ -352,8 +357,8 @@ class Admin_Notices {
 	 * @return string
 	 */
 	public function edac_password_protected_notice() {
-		if ( (bool) get_option( 'edac_password_protected' ) 
-			&& ! (bool) get_option( 'edac_password_protected_notice_dismiss' ) 
+		if ( (bool) get_option( 'edac_password_protected' )
+			&& ! (bool) get_option( 'edac_password_protected_notice_dismiss' )
 		) {
 			echo wp_kses( '<div class="edac_password_protected_notice notice notice-error is-dismissible"><p>' . $this->edac_password_protected_notice_text() . '</p></div>', 'post' );
 			return;

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -218,7 +218,7 @@ class Helpers {
 	 *
 	 * @since 1.9.3
 	 */
-	public static function current_user_can_see_widget(): bool {
+	public static function current_user_can_see_widgets_and_notices(): bool {
 		/**
 		 * Filter the capability required to view the dashboard widget.
 		 *

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -226,9 +226,6 @@ class Helpers {
 		 *
 		 * @param string $capability The capability required to view the dashboard widget.
 		 */
-		if ( current_user_can( apply_filters( 'edac_filter_dashboard_widget_capability', 'edit_posts' ) ) ) {
-			return true;
-		}
-		return false;
+		return current_user_can( apply_filters( 'edac_filter_dashboard_widget_capability', 'edit_posts' ) );
 	}
 }

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -217,6 +217,8 @@ class Helpers {
 	 * to see various widgets or notices.
 	 *
 	 * @since 1.9.3
+	 *
+	 * @return bool True if the current user has capabilities required, false otherwise.
 	 */
 	public static function current_user_can_see_widgets_and_notices(): bool {
 		/**

--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -211,4 +211,24 @@ class Helpers {
 		}
 		return $results;
 	}
+
+	/**
+	 * Do a capability check for the current user to ensure they have the required capability
+	 * to see various widgets or notices.
+	 *
+	 * @since 1.9.3
+	 */
+	public static function current_user_can_see_widget(): bool {
+		/**
+		 * Filter the capability required to view the dashboard widget.
+		 *
+		 * @since 1.9.3
+		 *
+		 * @param string $capability The capability required to view the dashboard widget.
+		 */
+		if ( current_user_can( apply_filters( 'edac_filter_dashboard_widget_capability', 'edit_posts' ) ) ) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/admin/class-widgets.php
+++ b/admin/class-widgets.php
@@ -27,14 +27,8 @@ class Widgets {
 	 * @return void
 	 */
 	public function dashboard_setup() {
-		/**
-		 * Filter the capability required to view the dashboard widget.
-		 *
-		 * @since 1.10.0
-		 *
-		 * @param string $capability The capability required to view the dashboard widget.
-		 */
-		if ( ! current_user_can( apply_filters( 'edac_filter_dashboard_widget_capability', 'edit_posts' ) ) ) {
+
+		if ( ! Helpers::current_user_can_see_widget() ) {
 			return;
 		}
 		wp_add_dashboard_widget(

--- a/admin/class-widgets.php
+++ b/admin/class-widgets.php
@@ -28,7 +28,7 @@ class Widgets {
 	 */
 	public function dashboard_setup() {
 
-		if ( ! Helpers::current_user_can_see_widget() ) {
+		if ( ! Helpers::current_user_can_see_widgets_and_notices() ) {
 			return;
 		}
 		wp_add_dashboard_widget(

--- a/admin/class-widgets.php
+++ b/admin/class-widgets.php
@@ -27,6 +27,16 @@ class Widgets {
 	 * @return void
 	 */
 	public function dashboard_setup() {
+		/**
+		 * Filter the capability required to view the dashboard widget.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param string $capability The capability required to view the dashboard widget.
+		 */
+		if ( ! current_user_can( apply_filters( 'edac_filter_dashboard_widget_capability', 'edit_posts' ) ) ) {
+			return;
+		}
 		wp_add_dashboard_widget(
 			'edac_dashboard_scan_summary',
 			'Accessibility Checker',

--- a/composer.lock
+++ b/composer.lock
@@ -615,7 +615,7 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.7",
+            "version": "1.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
@@ -757,16 +757,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.1",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69"
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2218c2252c874a4624ab2f613d86ac32d227bc69",
-                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
                 "shasum": ""
             },
             "require": {
@@ -809,26 +809,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
             },
-            "time": "2024-02-21T19:24:10+00:00"
+            "time": "2024-03-05T20:51:40+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -869,9 +870,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -1323,16 +1330,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.30",
+            "version": "9.2.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
                 "shasum": ""
             },
             "require": {
@@ -1389,7 +1396,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
             },
             "funding": [
                 {
@@ -1397,7 +1404,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:47:57+00:00"
+            "time": "2024-03-02T06:37:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1745,16 +1752,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -1789,7 +1796,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1797,7 +1804,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -2043,16 +2050,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -2097,7 +2104,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2105,7 +2112,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -2172,16 +2179,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -2237,7 +2244,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2245,20 +2252,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -2301,7 +2308,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -2309,7 +2316,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2545,16 +2552,16 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -2566,7 +2573,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2587,8 +2594,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -2596,7 +2602,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
@@ -2847,16 +2853,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -2885,7 +2891,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -2893,7 +2899,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -29,6 +29,11 @@ function edac_user_can_ignore() {
  */
 function edac_add_options_page() {
 
+	// we don't want to show even the welcome page to subscribers.
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		return;
+	}
+
 	add_menu_page(
 		__( 'Welcome to Accessibility Checker', 'accessibility-checker' ),
 		__( 'Accessibility Checker', 'accessibility-checker' ),
@@ -338,7 +343,7 @@ function edac_post_types_cb() {
 					$disabled = in_array( $post_type, $post_types, true ) ? '' : 'disabled';
 					?>
 					<label>
-						<input type="checkbox" name="<?php echo 'edac_post_types[]'; ?>" value="<?php echo esc_attr( $post_type ); ?>" 
+						<input type="checkbox" name="<?php echo 'edac_post_types[]'; ?>" value="<?php echo esc_attr( $post_type ); ?>"
 																<?php
 																checked( in_array( $post_type, $selected_post_types, true ), 1 );
 																echo esc_attr( $disabled );
@@ -454,7 +459,7 @@ function edac_include_accessibility_statement_link_cb() {
 	?>
 	<fieldset>
 		<label>
-			<input type="checkbox" name="<?php echo 'edac_include_accessibility_statement_link'; ?>" value="<?php echo '1'; ?>" 
+			<input type="checkbox" name="<?php echo 'edac_include_accessibility_statement_link'; ?>" value="<?php echo '1'; ?>"
 													<?php
 													checked( $option, 1 );
 													disabled( $disabled, false );
@@ -508,7 +513,7 @@ function edac_sanitize_accessibility_policy_page( $page ) {
  * Render the accessibility statement preview
  */
 function edac_accessibility_statement_preview_cb() {
-	echo wp_kses_post( 
+	echo wp_kses_post(
 		( new \EDAC\Inc\Accessibility_Statement() )->get_accessibility_statement()
 	);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility
 Requires at least: 6.2
 Tested up to: 6.4.3
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,6 +170,9 @@ No, Accessibility Checker runs completely on your server and does not require yo
 8. Accessibility Checker Summary tab on a page with no accessibility error or warnings and an included simplified summary.
 
 == Changelog ==
+
+= 1.9.3 =
+* Updated: capability checks for the welcome page, dashboard widget, and admin notices
 
 = 1.9.2 =
 * Fixed: filtered rules are not passed to the frontend highlighter, avoiding 'null' state issues

--- a/tests/phpunit/Admin/Helpers.php
+++ b/tests/phpunit/Admin/Helpers.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Class HelpersTest
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Helpers;
+
+/**
+ * Test cases to run against methods in the admin helpers class.
+ */
+class HelpersTest extends WP_UnitTestCase {
+
+	/**
+	 * Test capability check for widgets and notices being visible
+	 * or not in default configuration.
+	 *
+	 * @param string $role     The role to test.
+	 * @param bool   $expected The expected return value.
+	 *
+	 * @dataProvider userDataProvider
+	 */
+	public function test_capability_check_for_widgets_and_notices( string $role, bool $expected ) {
+		$user_id = $this->factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+		$this->assertEquals( $expected, Helpers::current_user_can_see_widgets_and_notices() );
+	}
+
+	/**
+	 * Test capability check for widgets and notices being visible
+	 * is filterable for different capabilities and those are
+	 * honoured when running the check.
+	 *
+	 * @param string $role              The role to test.
+	 * @param bool   $value             The default return value.
+	 * @param array  $filter_capability The capabilities to filter and their expected return values.
+	 *
+	 * @dataProvider userDataProvider
+	 */
+	public function test_capability_check_for_widgets_and_notices_is_filterable( string $role, bool $value, array $filter_capability ) {
+
+		foreach ( $filter_capability as $capability => $expected ) {
+			add_filter(
+				'edac_filter_dashboard_widget_capability',
+				function () use ( $capability ) {
+					return $capability;
+				}
+			);
+			$user_id = $this->factory()->user->create( array( 'role' => $role ) );
+			wp_set_current_user( $user_id );
+			$this->assertEquals( $expected, Helpers::current_user_can_see_widgets_and_notices() );
+		}
+	}
+
+	/**
+	 * The expected values for the capability check for widgets and notices.
+	 *
+	 * Passes in role, default value and an array of extra capabilities
+	 * and their expected return values from the check after filtering.
+	 *
+	 * @dataProvider userDataProvider
+	 */
+	public function userDataProvider(): array {
+		return array(
+			array(
+				'role'      => 'administrator',
+				'default'   => true,
+				'extra_cap' => array( 'manage_options' => true ),
+			),
+			array(
+				'role'      => 'editor',
+				'default'   => true,
+				'extra_cap' => array( 'manage_options' => false ),
+			),
+			array(
+				'role'      => 'author',
+				'default'   => true,
+				'extra_cap' => array(
+					'manage_options' => false,
+					'publish_posts'  => true,
+					'upload_files'   => true,
+				),
+			),
+			array(
+				'role'      => 'contributor',
+				'default'   => true,
+				'extra_cap' => array(
+					'publish_posts' => false,
+					'upload_files'  => false,
+				),
+			),
+			array(
+				'role'      => 'subscriber',
+				'default'   => false,
+				'extra_cap' => array( 'manage_options' => false ),
+			),
+		);
+	}
+}


### PR DESCRIPTION
To prevent subscriber-level roles from accessing the welcome page or seeing the dashboard widget/notices, some basic capability checks are added to gate it.

* Capability check of 'edit_posts' for the welcome page (aka contributor)
* Capability check of 'edit_posts' for widget and notices (aka contributor) - but this one runs through a new filter so that users can edit this if they choose.
* Notices are now wrapped in a new method that runs one `init` so that the capability checks can function after current_user is set.

Fixes: #531