### PR TITLE
Short-circuit edac_save_post() when post_status is trash

### DIFF
--- a/includes/validate.php
+++ b/includes/validate.php
@@ -51,6 +51,8 @@ function edac_post_on_load() {
  * @param object $post    The post object being saved.
  * @param bool   $update  Whether this is an existing post being updated.
  *
+ * @modified 1.10.0 to add a return when post_status is trash.
+ *
  * @return void
  */
 function edac_save_post( $post_ID, $post, $update ) {
@@ -62,6 +64,11 @@ function edac_save_post( $post_ID, $post, $update ) {
 
 	// prevents first past of save_post due to meta boxes on post editor in gutenberg.
 	if ( empty( $_POST ) ) {
+		return;
+	}
+
+	// Ignore posts in, or going to, trash.
+	if ( 'trash' === $post->post_status ) {
 		return;
 	}
 
@@ -200,7 +207,7 @@ function edac_remove_corrected_posts( $post_ID, $type, $pre = 1, $ruleset = 'php
 	if ( 0 === count( $rule_slugs ) ) {
 		return;
 	}
-	
+
 	if ( 1 === $pre ) {
 
 		// Set record flag before validating content.


### PR DESCRIPTION
This is a first pass at a solution for #535 . It returns from the save method when the post is trashed to avoid it, resulting in request errors later in the chain.

Bailing early here ensures that the rest of the flow runs and the data is purged.

There may be a better solution to this, but I haven't found anything as simple as this. I will continue to think and find something more robust if I can.

Resolves: #535 