### PR TITLE
Auto draft causing error attempting scan not-existing page

### DIFF
--- a/includes/classes/class-frontend-validate.php
+++ b/includes/classes/class-frontend-validate.php
@@ -33,9 +33,11 @@ class Frontend_Validate {
 	 * Validates the current post on the WordPress dashboard home under specific conditions.
 	 *
 	 * This function is triggered only when viewing the dashboard home ('index.php'), not in a customizer preview,
-	 * and if the current user has permissions to edit posts. It checks if the current post has been previously 
-	 * validated based on a specific post meta key ('_edac_post_checked'). If the post has not been validated, 
+	 * and if the current user has permissions to edit posts. It checks if the current post has been previously
+	 * validated based on a specific post meta key ('_edac_post_checked'). If the post has not been validated,
 	 * it initiates the validation process.
+	 *
+	 * @modified 1.10.0 Return early if post is an auto-draft.
 	 *
 	 * @return void The function does not return a value. It triggers validation for an unvalidated post or does nothing.
 	 * @since 1.9.0
@@ -47,8 +49,8 @@ class Frontend_Validate {
 		if ( 'index.php' === $pagenow && false === is_customize_preview() && current_user_can( 'edit_posts' ) ) {
 
 			global $post;
-			$post_id = is_object( $post ) ? $post->ID : null;       
-			if ( null === $post_id ) {
+			$post_id = is_object( $post ) ? $post->ID : null;
+			if ( null === $post_id || 'auto-draft' === $post->post_status ) {
 				return;
 			}
 

--- a/includes/classes/class-frontend-validate.php
+++ b/includes/classes/class-frontend-validate.php
@@ -32,10 +32,10 @@ class Frontend_Validate {
 	/**
 	 * Validates the current post on the WordPress dashboard home under specific conditions.
 	 *
-	 * This function is triggered only when viewing the dashboard home ('index.php'), not in a customizer preview,
-	 * and if the current user has permissions to edit posts. It checks if the current post has been previously
-	 * validated based on a specific post meta key ('_edac_post_checked'). If the post has not been validated,
-	 * it initiates the validation process.
+	 * This function is triggered only by the `template_redirect` hook. It returns early if not 'index.php', in a
+	 * customizer preview,  or if the current user does not have permissions to edit posts. It checks if the current
+	 * post has been previously validated based on a specific post meta key ('_edac_post_checked'). If the post has not
+	 * been validated, it initiates the validation process.
 	 *
 	 * @modified 1.10.0 Return early if post is an auto-draft.
 	 *

--- a/includes/classes/class-frontend-validate.php
+++ b/includes/classes/class-frontend-validate.php
@@ -30,12 +30,12 @@ class Frontend_Validate {
 	}
 
 	/**
-	 * Validates the current post on the WordPress dashboard home under specific conditions.
+	 * Validates the current post on the WordPress dashboard, under specific conditions.
 	 *
 	 * This function is triggered only by the `template_redirect` hook. It returns early if not 'index.php', in a
-	 * customizer preview,  or if the current user does not have permissions to edit posts. It checks if the current
-	 * post has been previously validated based on a specific post meta key ('_edac_post_checked'). If the post has not
-	 * been validated, it initiates the validation process.
+	 * customizer preview, the post is an 'auto-draft' or if the current user does not have permissions to edit posts.
+	 * It checks if the current post has been previously validated based on a specific post meta key
+	 * ('_edac_post_checked'). If the post has not been validated, it initiates the validation process.
 	 *
 	 * @modified 1.10.0 Return early if post is an auto-draft.
 	 *

--- a/readme.txt
+++ b/readme.txt
@@ -175,6 +175,7 @@ No, Accessibility Checker runs completely on your server and does not require yo
 * Updated: Improved aria-hidden scanning rule
 * Fixed: Prevent missing_transcript rule from flagging on certain links
 * Fixed: Prevent duplicate scan and ensure cleanup runs when post is trashed from the block editor
+* Fixed: Fix case where error may be thrown resulting in password protection message and logged error when creating new posts
 * Updated: Use local styles for notyf in frontend highlighter
 * Created: Class to insert scan result rules to the database
 * Deprecated: `edac_insert_rule_data` function


### PR DESCRIPTION
Adds a catch inside the Frontend_Validate classes validate method to return before attempting to validate if the post is an auto-draft.

Fixes: #539 