### PR TITLE
Fix missing clarifying parenthesis cs check

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -36,8 +36,8 @@ class Enqueue_Admin {
 	 */
 	public static function enqueue_styles() {
 		wp_enqueue_style( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/css/admin.css', array(), EDAC_VERSION, 'all' );
-	}   
-	
+	}
+
 	/**
 	 * Enqueue the admin and editorApp scripts.
 	 *
@@ -57,13 +57,13 @@ class Enqueue_Admin {
 			'accessibility_checker_ignored',
 		);
 
-		if ( is_array( $post_types ) && count( $post_types ) && ( in_array( $current_post_type, $post_types, true ) || in_array( $page, $enabled_pages, true ) ) || ( 'site-editor.php' !== $pagenow ) ) {
+		if ( ( is_array( $post_types ) && count( $post_types ) && ( in_array( $current_post_type, $post_types, true ) || in_array( $page, $enabled_pages, true ) ) ) || ( 'site-editor.php' !== $pagenow ) ) {
 
 			global $post;
 			$post_id = is_object( $post ) ? $post->ID : null;
 			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', array( 'jquery' ), EDAC_VERSION, false );
 
-		
+
 			wp_localize_script(
 				'edac',
 				'edac_script_vars',
@@ -74,26 +74,26 @@ class Enqueue_Admin {
 					'restNonce'  => wp_create_nonce( 'wp_rest' ),
 				)
 			);
-		
+
 
 			if ( 'post.php' === $pagenow ) {
-		
+
 
 				// Is this posttype setup to be checked?
 				$post_types        = get_option( 'edac_post_types' );
 				$current_post_type = get_post_type();
 				$active            = ( is_array( $post_types ) && in_array( $current_post_type, $post_types, true ) );
-	
+
 				$pro = is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID;
-	
+
 				if ( EDAC_DEBUG || strpos( EDAC_VERSION, '-beta' ) !== false ) {
 					$debug = true;
 				} else {
 					$debug = false;
 				}
-		
+
 				wp_enqueue_script( 'edac-editor-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/editorApp.bundle.js', false, EDAC_VERSION, false );
-	
+
 				wp_localize_script(
 					'edac-editor-app',
 					'edac_editor_app',
@@ -107,13 +107,13 @@ class Enqueue_Admin {
 						'authOk'     => false === (bool) get_option( 'edac_password_protected', false ),
 						'debug'      => $debug,
 						'scanUrl'    => get_preview_post_link(
-							$post_id, 
+							$post_id,
 							array( 'edac_pageScanner' => 1 )
 						),
 					)
 				);
-	
-			}       
+
+			}
 		}
 	}
 
@@ -125,13 +125,13 @@ class Enqueue_Admin {
 	public static function maybe_enqueue_email_opt_in_script() {
 
 		$page = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
-		if ( 'accessibility_checker' === $page 
-			&& true !== (bool) get_user_meta( get_current_user_id(), 'edac_email_optin', true ) 
+		if ( 'accessibility_checker' === $page
+			&& true !== (bool) get_user_meta( get_current_user_id(), 'edac_email_optin', true )
 		) {
 
 				wp_enqueue_style( 'email-opt-in-form', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/css/emailOptIn.css', false, EDAC_VERSION, 'all' );
 				wp_enqueue_script( 'email-opt-in-form', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/emailOptIn.bundle.js', false, EDAC_VERSION, true );
-		
+
 				wp_localize_script(
 					'email-opt-in-form',
 					'edac_email_opt_in_form',
@@ -140,7 +140,7 @@ class Enqueue_Admin {
 						'ajaxurl' => admin_url( 'admin-ajax.php' ),
 					)
 				);
-	
+
 		}
 	}
 }

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -57,7 +57,17 @@ class Enqueue_Admin {
 			'accessibility_checker_ignored',
 		);
 
-		if ( ( is_array( $post_types ) && count( $post_types ) && ( in_array( $current_post_type, $post_types, true ) || in_array( $page, $enabled_pages, true ) ) ) || ( 'site-editor.php' !== $pagenow ) ) {
+		if (
+			(
+				is_array( $post_types ) &&
+				count( $post_types ) &&
+				(
+					in_array( $current_post_type, $post_types, true ) ||
+					in_array( $page, $enabled_pages, true )
+				)
+			) ||
+			'site-editor.php' !== $pagenow
+		) {
 
 			global $post;
 			$post_id = is_object( $post ) ? $post->ID : null;

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "yoast/phpunit-polyfills": "^1.1.0",
         "yoast/wp-test-utils": "^1.2",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
-        "wp-coding-standards/wpcs": "^3.1",
+        "wp-coding-standards/wpcs": "^3.0",
         "equalizedigital/accessibility-checker-wp-env": "*",
         "doctrine/instantiator": "^1.3.1",
         "wp-phpunit/wp-phpunit": "*"
@@ -68,7 +68,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ],
         "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./tests/_output/report"
+            "@php ./vendor/phpunit/phpunit/phpunit"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "yoast/phpunit-polyfills": "^1.1.0",
         "yoast/wp-test-utils": "^1.2",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
-        "wp-coding-standards/wpcs": "^3.0",
+        "wp-coding-standards/wpcs": "^3.1",
         "equalizedigital/accessibility-checker-wp-env": "*",
         "doctrine/instantiator": "^1.3.1",
         "wp-phpunit/wp-phpunit": "*"
@@ -68,7 +68,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ],
         "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
+            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./tests/_output/report"
         ]
     }
 }

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -26,20 +26,20 @@ class Enqueue_Frontend {
 	public static function enqueue() {
 		self::maybe_enqueue_frontend_highlighter();
 	}
-	
+
 	/**
 	 * Enqueue the frontend highlighter.
 	 *
 	 * @return void
 	 */
 	public static function maybe_enqueue_frontend_highlighter() {
-		
+
 		// This loads on all pages, so bail as early as possible. Do checks that don't require DB calls first.
 
 
 		// Don't load on admin pages in iframe that is running a pageScan.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( is_admin() || isset( $_GET['edac_pageScanner'] ) && '1' === $_GET['edac_pageScanner'] ) {
+		if ( is_admin() || ( isset( $_GET['edac_pageScanner'] ) && '1' === $_GET['edac_pageScanner'] ) ) {
 			return;
 		}
 
@@ -55,17 +55,17 @@ class Enqueue_Frontend {
 		if ( is_customize_preview() || ! ( $post_id && current_user_can( 'edit_post', $post_id ) ) ) {
 			return;
 		}
-	
+
 
 		// Don't load if this pagetype is not setup to be scanned.
 		$post_types        = get_option( 'edac_post_types' );
 		$current_post_type = get_post_type();
 		$active            = ( is_array( $post_types ) && in_array( $current_post_type, $post_types, true ) );
-	
+
 
 		if ( $active ) {
 
-	
+
 			wp_enqueue_style( 'edac-frontend-highlighter-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/css/frontendHighlighterApp.css', false, EDAC_VERSION, 'all' );
 			wp_enqueue_script( 'edac-frontend-highlighter-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/frontendHighlighterApp.bundle.js', false, EDAC_VERSION, false );
 

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -38,8 +38,13 @@ class Enqueue_Frontend {
 
 
 		// Don't load on admin pages in iframe that is running a pageScan.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( is_admin() || ( isset( $_GET['edac_pageScanner'] ) && '1' === $_GET['edac_pageScanner'] ) ) {
+		if (
+			is_admin() ||
+			(
+				isset( $_GET['edac_pageScanner'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'1' === $_GET['edac_pageScanner'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			)
+		) {
 			return;
 		}
 

--- a/includes/rules/empty_button.php
+++ b/includes/rules/empty_button.php
@@ -41,7 +41,13 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore -- $post is
 				'' !== $error_code
 				&& ( ! isset( $image[0] ) || trim( $image[0]->getAttribute( 'alt' ) ) === '' )
 				&& ( ! isset( $input[0] ) || trim( $input[0]->getAttribute( 'value' ) ) === '' )
-				&& ( ! isset( $i[0] ) || ( ( trim( $i[0]->getAttribute( 'title' ) ) === '' ) && ( trim( $i[0]->getAttribute( 'aria-label' ) ) === '' ) ) )
+				&& (
+					! isset( $i[0] ) ||
+					(
+						( trim( $i[0]->getAttribute( 'title' ) ) === '' ) &&
+						( trim( $i[0]->getAttribute( 'aria-label' ) ) === '' )
+					)
+				)
 			) {
 				$errors[] = $error_code;
 			}

--- a/includes/rules/empty_button.php
+++ b/includes/rules/empty_button.php
@@ -41,7 +41,7 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore -- $post is
 				'' !== $error_code
 				&& ( ! isset( $image[0] ) || trim( $image[0]->getAttribute( 'alt' ) ) === '' )
 				&& ( ! isset( $input[0] ) || trim( $input[0]->getAttribute( 'value' ) ) === '' )
-				&& ( ! isset( $i[0] ) || ( trim( $i[0]->getAttribute( 'title' ) ) === '' ) && trim( $i[0]->getAttribute( 'aria-label' ) ) === '' )
+				&& ( ! isset( $i[0] ) || ( ( trim( $i[0]->getAttribute( 'title' ) ) === '' ) && ( trim( $i[0]->getAttribute( 'aria-label' ) ) === '' ) ) )
 			) {
 				$errors[] = $error_code;
 			}

--- a/includes/rules/img_alt_empty.php
+++ b/includes/rules/img_alt_empty.php
@@ -23,15 +23,18 @@ function edac_rule_img_alt_empty( $content, $post ) { // phpcs:ignore -- $post i
 			$elements = $dom->find( $tag );
 			foreach ( $elements as $element ) {
 				if (
-					( isset( $element )
+					(
+						isset( $element )
 						&& 'img' === $element->tag
 						&& $element->hasAttribute( 'alt' )
 						&& $element->getAttribute( 'alt' ) === ''
-						&& $element->getAttribute( 'role' ) !== 'presentation' )
-					|| ( 'input' === $element->tag
+						&& $element->getAttribute( 'role' ) !== 'presentation'
+					) || (
+						'input' === $element->tag
 						&& $element->hasAttribute( 'alt' )
 						&& $element->getAttribute( 'type' ) === 'image'
-						&& $element->getAttribute( 'alt' ) === '' )
+						&& $element->getAttribute( 'alt' ) === ''
+					)
 				) {
 
 					$image_code = $element->outertext;

--- a/includes/rules/img_alt_empty.php
+++ b/includes/rules/img_alt_empty.php
@@ -23,11 +23,11 @@ function edac_rule_img_alt_empty( $content, $post ) { // phpcs:ignore -- $post i
 			$elements = $dom->find( $tag );
 			foreach ( $elements as $element ) {
 				if (
-					isset( $element )
-					&& 'img' === $element->tag
-					&& $element->hasAttribute( 'alt' )
-					&& $element->getAttribute( 'alt' ) === ''
-					&& $element->getAttribute( 'role' ) !== 'presentation'
+					( isset( $element )
+						&& 'img' === $element->tag
+						&& $element->hasAttribute( 'alt' )
+						&& $element->getAttribute( 'alt' ) === ''
+						&& $element->getAttribute( 'role' ) !== 'presentation' )
 					|| ( 'input' === $element->tag
 						&& $element->hasAttribute( 'alt' )
 						&& $element->getAttribute( 'type' ) === 'image'

--- a/includes/rules/img_alt_missing.php
+++ b/includes/rules/img_alt_missing.php
@@ -22,14 +22,16 @@ function edac_rule_img_alt_missing( $content, $post ) { // phpcs:ignore -- $post
 		$elements = $dom->find( $tag );
 
 		foreach ( $elements as $element ) {
-			if ( isset( $element )
-			&& ( 'img' === $element->tag
-			&& ! $element->hasAttribute( 'alt' )
-			&& $element->getAttribute( 'role' ) !== 'presentation' )
-			&& $element->getAttribute( 'aria-hidden' ) !== 'true'
-			|| ( 'input' === $element->tag
-			&& ! $element->hasAttribute( 'alt' )
-			&& $element->getAttribute( 'type' ) === 'image' )
+			if ( ( isset( $element )
+					&& ( 'img' === $element->tag
+						&& ! $element->hasAttribute( 'alt' )
+						&& $element->getAttribute( 'role' ) !== 'presentation' )
+					&& $element->getAttribute( 'aria-hidden' ) !== 'true' )
+				|| (
+				'input' === $element->tag
+				&& ! $element->hasAttribute( 'alt' )
+				&& $element->getAttribute( 'type' ) === 'image'
+				)
 			) {
 
 				$image_code = $element->outertext;

--- a/includes/rules/img_alt_missing.php
+++ b/includes/rules/img_alt_missing.php
@@ -22,15 +22,19 @@ function edac_rule_img_alt_missing( $content, $post ) { // phpcs:ignore -- $post
 		$elements = $dom->find( $tag );
 
 		foreach ( $elements as $element ) {
-			if ( ( isset( $element )
-					&& ( 'img' === $element->tag
+			if (
+				(
+					isset( $element ) &&
+					(
+						'img' === $element->tag
 						&& ! $element->hasAttribute( 'alt' )
-						&& $element->getAttribute( 'role' ) !== 'presentation' )
-					&& $element->getAttribute( 'aria-hidden' ) !== 'true' )
-				|| (
-				'input' === $element->tag
-				&& ! $element->hasAttribute( 'alt' )
-				&& $element->getAttribute( 'type' ) === 'image'
+						&& $element->getAttribute( 'role' ) !== 'presentation'
+					)
+					&& $element->getAttribute( 'aria-hidden' ) !== 'true'
+				) || (
+					'input' === $element->tag
+					&& ! $element->hasAttribute( 'alt' )
+					&& $element->getAttribute( 'type' ) === 'image'
 				)
 			) {
 

--- a/includes/rules/text_small.php
+++ b/includes/rules/text_small.php
@@ -43,8 +43,13 @@ function edac_rule_text_small( $content, $post ) { // phpcs:ignore -- $post is r
 								preg_match_all( '!\d+!', $absolute_fontsize_errorcode, $matches );
 
 								if (
-									( stristr( $absolute_fontsize_errorcode, 'px' ) === 'px' && implode( ' ', $matches[0] ) <= 10 )
-									|| ( ( stristr( $absolute_fontsize_errorcode, 'pt' ) === 'pt' ) && ( implode( ' ', $matches[0] ) <= 13 ) )
+									(
+										stristr( $absolute_fontsize_errorcode, 'px' ) === 'px' &&
+										implode( ' ', $matches[0] ) <= 10
+									) || (
+										( stristr( $absolute_fontsize_errorcode, 'pt' ) === 'pt' ) &&
+										( implode( ' ', $matches[0] ) <= 13 )
+									)
 								) {
 									$errors[] = $element;
 								}
@@ -86,7 +91,10 @@ function ac_css_small_text_check( $content ) {
 
 				$value = str_replace( '.', '', preg_replace( '/\d/', '', $rules['font-size'] ) );
 
-				if ( ( 'px' === $value && $rules['font-size'] <= 10 ) || ( 'pt' === $value && $rules['font-size'] <= 13 ) ) {
+				if (
+					( 'px' === $value && $rules['font-size'] <= 10 ) ||
+					( 'pt' === $value && $rules['font-size'] <= 13 )
+				) {
 
 					$error_code = $element . '{ ';
 					foreach ( $rules as $key => $value ) {

--- a/includes/rules/text_small.php
+++ b/includes/rules/text_small.php
@@ -43,8 +43,8 @@ function edac_rule_text_small( $content, $post ) { // phpcs:ignore -- $post is r
 								preg_match_all( '!\d+!', $absolute_fontsize_errorcode, $matches );
 
 								if (
-									stristr( $absolute_fontsize_errorcode, 'px' ) === 'px' && implode( ' ', $matches[0] ) <= 10
-									|| stristr( $absolute_fontsize_errorcode, 'pt' ) === 'pt' && implode( ' ', $matches[0] ) <= 13
+									( stristr( $absolute_fontsize_errorcode, 'px' ) === 'px' && implode( ' ', $matches[0] ) <= 10 )
+									|| ( ( stristr( $absolute_fontsize_errorcode, 'pt' ) === 'pt' ) && ( implode( ' ', $matches[0] ) <= 13 ) )
 								) {
 									$errors[] = $element;
 								}
@@ -86,7 +86,7 @@ function ac_css_small_text_check( $content ) {
 
 				$value = str_replace( '.', '', preg_replace( '/\d/', '', $rules['font-size'] ) );
 
-				if ( 'px' === $value && $rules['font-size'] <= 10 || 'pt' === $value && $rules['font-size'] <= 13 ) {
+				if ( ( 'px' === $value && $rules['font-size'] <= 10 ) || ( 'pt' === $value && $rules['font-size'] <= 13 ) ) {
 
 					$error_code = $element . '{ ';
 					foreach ( $rules as $key => $value ) {


### PR DESCRIPTION
The latest WPCS update caused a new rule to run on our code to enforce clarifying parenthesis. That is a good rule so I fixed the issues flagged instead of disabling it.

I also took the opportunity to space out those changed conditions to improve readability while I was clarifying them with parenthesis.

Closes: #546 