### PR TITLE
Missing form label rule strict comparison fix

### DIFF
--- a/includes/rules/missing_form_label.php
+++ b/includes/rules/missing_form_label.php
@@ -43,7 +43,8 @@ function ac_input_has_label( $field, $dom ) {
 	if ( $field->getAttribute( 'aria-label' ) ) {
 		return true;
 	}
-	if ( $dom->find( 'label[for="' . $field->getAttribute( 'id' ) . '"]', -1 ) !== '' ) {
+	if ( $dom->find( 'label[for="' . $field->getAttribute( 'id' ) . '"]', -1 ) !== null ) {
+
 		return true;
 	}
 	return edac_field_has_label_parent( $field );


### PR DESCRIPTION
This PR fixes the strict comparison issue within the missing form label rule that prevented it from returning issues.

Fixes #543