### PR TITLE
added - edac_max_alt_length filter and edac_rule_img_alt_long tests #95

### DIFF
--- a/includes/rules/img_alt_long.php
+++ b/includes/rules/img_alt_long.php
@@ -14,11 +14,18 @@
  */
 function edac_rule_img_alt_long( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
-	$dom            = $content['html'];
-	$errors         = array();
-	$images         = $dom->find( 'img' );
-	$max_alt_length = absint( apply_filters( 'edac_max_alt_length', 300 ) );
-	$max_alt_length = max( 1, $max_alt_length );
+	$dom    = $content['html'];
+	$errors = array();
+	$images = $dom->find( 'img' );
+	
+	/**
+	 * Filter the max alt text length checked by the img_alt_long rule before it is considered an issue.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param int $length The length used in the rule to determine the max length before flagging as an issue.
+	 */
+	$max_alt_length = max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) );
 
 	foreach ( $images as $image ) {
 		if ( isset( $image ) && $image->hasAttribute( 'alt' ) && $image->getAttribute( 'alt' ) !== '' ) {

--- a/includes/rules/img_alt_long.php
+++ b/includes/rules/img_alt_long.php
@@ -14,14 +14,16 @@
  */
 function edac_rule_img_alt_long( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
-	$dom    = $content['html'];
-	$errors = array();
-	$images = $dom->find( 'img' );
+	$dom            = $content['html'];
+	$errors         = array();
+	$images         = $dom->find( 'img' );
+	$max_alt_length = absint( apply_filters( 'edac_max_alt_length', 300 ) );
+	$max_alt_length = max( 1, $max_alt_length );
 
 	foreach ( $images as $image ) {
 		if ( isset( $image ) && $image->hasAttribute( 'alt' ) && $image->getAttribute( 'alt' ) !== '' ) {
 			$alt = $image->getAttribute( 'alt' );
-			if ( strlen( $alt ) > 300 ) {
+			if ( strlen( $alt ) > $max_alt_length ) {
 				$image_code = $image;
 				$errors[]   = $image_code;
 			}

--- a/tests/phpunit/EDACRuleImgAltLongTest.php
+++ b/tests/phpunit/EDACRuleImgAltLongTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Class EDACRuleImgAltLongTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Admin Notices test case.
+ */
+class EDACRuleImgAltLongTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that edac_rule_img_alt_long function returns an empty array when all images have alt text within the allowed length.
+	 *
+	 * @return void
+	 */
+	public function test_empty_array_when_alt_text_is_within_allowed_length() {
+		$html    = '<img src="test.jpg" alt="This is a test image">';
+		$dom     = str_get_html( $html );
+		$content = array(
+			'html' => $dom,
+		);
+		$post    = null;
+		$errors  = edac_rule_img_alt_long( $content, $post );
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Test that edac_rule_img_alt_long function returns an array with errors when images have alt text longer than the allowed length.
+	 *
+	 * @return void
+	 */
+	public function test_returns_errors_when_alt_text_is_longer_than_allowed_length() {
+		$html    = '<img src="test.jpg" alt="' . str_repeat( 'a', 301 ) . '">';
+		$dom     = str_get_html( $html );
+		$content = array(
+			'html' => $dom,
+		);
+		$post    = null;
+		$errors  = edac_rule_img_alt_long( $content, $post );
+		$this->assertNotEmpty( $errors );
+	}
+
+	/**
+	 * Test that the edac_max_alt_length filter modifies the maximum allowed alt text length.
+	 *
+	 * @return void
+	 */
+	public function test_edac_max_alt_length_filter_modifies_max_alt_length() {
+		// Add a filter to modify the maximum alt text length.
+		add_filter(
+			'edac_max_alt_length',
+			function () {
+				return 10;
+			}
+		);
+
+		$html    = '<img src="test.jpg" alt="This is a long alt text">';
+		$dom     = str_get_html( $html );
+		$content = array(
+			'html' => $dom,
+		);
+		$post    = null;
+		$errors  = edac_rule_img_alt_long( $content, $post );
+
+		// Remove the filter after the test.
+		remove_filter( 'edac_max_alt_length', '__return_true' );
+
+		$this->assertNotEmpty( $errors );
+	}
+}


### PR DESCRIPTION
This PR adds a filter to control the max alt length and unit tests for the image alt long rule.

- Added: `edac_rule_img_alt_long` filter that defaults to `300`
- Added: unit test for the `edac_rule_img_alt_long` function
  - Test that function returns an empty array when all images have alt text within the allowed length
  -  Test that function returns an array with errors when images have alt text longer than the allowed length
  -  Test that the filter modifies the maximum allowed alt text length


Fixes #95 