### PR TITLE
Add a new script to help prep releases

### DIFF
--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# You must have the `sed` on your system and `semver` package
+# installed globally through npm (`npm install -g semver`) to
+# use this script. It will fail otherwise.
+#
+# Usage: ./prep_release.sh (major|minor|patch)
+#
+set -e
+
+if [[ -z "$1" ]]; then
+  echo "Must supply a release type (major|minor|patch)"
+  exit 1
+fi
+
+MAIN_FILE_PATH='accessibility-checker.php'
+PACKAGE_JSON_PATH='package.json'
+README_PATH='readme.txt'
+
+echo "Getting plugin version from ${MAIN_FILE_PATH}"
+VERSION=$(cat ${MAIN_FILE_PATH} | sed -En "s/ \* Version: .*? ([0-9]+(\.[0-9]+)*)/\1/p")
+echo "Current version: ${VERSION}"
+BUMPED_VERSION=$(npx semver ${VERSION} -i ${1})
+echo "Bumping to version: ${BUMPED_VERSION}"
+
+if [[ -z "${VERSION}" || -z "${BUMPED_VERSION}" ]]; then
+  echo "Failed to retrieve version from main file or semver could not bump the version";
+  exit 1
+fi
+
+MAIN_BRANCH=main
+DEVELOP_BRANCH=develop
+RELEASE_BRANCH_NAME=release/${BUMPED_VERSION}
+
+echo
+echo "Creating release branch"
+echo
+git fetch
+git checkout ${DEVELOP_BRANCH}
+git pull
+git checkout -b ${RELEASE_BRANCH_NAME}
+
+echo
+echo "Updating version in files"
+echo
+sed -i.bak -E "s/( \* Version:[[:space:]]*).*?${VERSION}/\1${BUMPED_VERSION}/g" "${MAIN_FILE_PATH}"
+sed -i.bak -E "s/(define\( 'EDAC_VERSION', ')[^']*/\1${BUMPED_VERSION}/" "${MAIN_FILE_PATH}"
+sed -i.bak -E "s/(\"version\": \")[^\"]*/\1${BUMPED_VERSION}/" package.json
+sed -i.bak -E "s/(Stable tag: )${VERSION}/\1${BUMPED_VERSION}/" readme.txt
+rm  "${MAIN_FILE_PATH}.bak" "${PACKAGE_JSON_PATH}.bak" "${README_PATH}.bak"
+
+echo
+echo "Committing version bump"
+echo
+git add ${MAIN_FILE_PATH} ${PACKAGE_JSON_PATH} ${README_PATH}
+git commit -m "Bump version ${VERSION} -> ${BUMPED_VERSION}"
+git push -u origin ${RELEASE_BRANCH_NAME}
+
+echo
+echo "Creating changelog"
+echo
+git checkout ${MAIN_BRANCH}
+git pull
+git checkout ${RELEASE_BRANCH_NAME}
+
+echo
+echo "Changelog: "
+echo
+git shortlog ${MAIN_BRANCH}..${DEVELOP_BRANCH} --grep "Merge pull request" --format=%b | cat | \
+    sed '/.*[rR]elease\/.*[0-9]\.[0-9]\.[0-9]/d' | \
+    sed 's/ \{6\}/\- [ \] /'
+
+echo
+echo "Use the link below to open a PR for the release. Use the changelog above to write a proper changelog in an additional commit on the branch."
+echo "https://github.com/equalizedigital/accessibility-checker/compare/${MAIN_BRANCH}...${RELEASE_BRANCH_NAME}?title=Release+v${BUMPED_VERSION}"
+


### PR DESCRIPTION
It fetches changes, updates local branches it operates on, creates a new branch and bumps the version in several places. Creates a list of PRs merged since last release and provides a link to open the PR against main with a pre-filled title.

Run it from the root of the repo with `./scripts/prep_release.sh patch` where the bump can be either major, minor or patch.

This is the output from my last test (ignore the silly version numbers, that was just for testing).

``` bash
Getting plugin version from accessibility-checker.php
Current version: 34.5.9
Bumping to version: 34.5.10
Creating release branch
M       scripts/dist.sh
Switched to branch 'develop'
Your branch is up-to-date with 'origin/develop'.
Already up-to-date.
Switched to a new branch 'release/34.5.10'

Updating version in files

> accessibility-checker@34.5.10 lint-staged-precommit
> lint-staged && npm run lint:js

✔ Preparing lint-staged...
✔ Running tasks for staged files...
✔ Applying modifications from tasks...
✔ Cleaning up temporary files...

> accessibility-checker@34.5.10 lint:js
> wp-scripts lint-js

[release/34.5.10 6f6f97c] Bump version 34.5.9 -> 34.5.10
 2 files changed, 2 insertions(+), 2 deletions(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 24 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 384 bytes | 384.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
remote: 
remote: Create a pull request for 'release/34.5.10' on GitHub by visiting:
remote:      https://github.com/equalizedigital/accessibility-checker/pull/new/release/34.5.10
remote: 
To github.com:equalizedigital/accessibility-checker.git
 * [new branch]      release/34.5.10 -> release/34.5.10
Branch 'release/34.5.10' set up to track remote branch 'release/34.5.10' from 'origin'.
Creating changelog
M       scripts/dist.sh
Switched to branch 'main'
Your branch is up-to-date with 'origin/main'.
Already up-to-date.
M       scripts/dist.sh
Switched to branch 'release/34.5.10'
Your branch is up-to-date with 'origin/release/34.5.10'.

Changelog: 

Steve Jones (1):
- [ ] added - edac_max_alt_length filter and edac_rule_img_alt_long tests #95

William Patton (1):
- [ ] Release/1.10.1


Use the link below to open a PR for the release. Use the changelog above to write a proper changelog in an additional commit on the branch.
https://github.com/equalizedigital/accessibility-checker/compare/main...release/34.5.10?title=Release+v34.5.10

```