### PR TITLE
Use Fewer post meta values

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -7,7 +7,7 @@
 
 namespace EDAC\Admin;
 
-use EDAC\Admin\Data\Post_Meta\Scan_Summary;
+use EDAC\Admin\Data\Post_Meta\{ Scan_Summary, Scan_Summary_Back_Compat };
 use EDAC\Inc\Summary_Generator;
 
 /**
@@ -77,7 +77,7 @@ class Ajax {
 		$post_id                   = (int) $_REQUEST['post_id'];
 		$summary                   = ( new Summary_Generator( $post_id ) )->generate_summary();
 		$simplified_summary_prompt = get_option( 'edac_simplified_summary_prompt' );
-		$simplified_summary        = ( new Scan_Summary( $post_id ) )->get( 'simplified_summary_text' );
+		$simplified_summary        = ( new Scan_Summary_Back_Compat( $post_id ) )->get( 'simplified_summary_text' );
 
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
@@ -493,7 +493,7 @@ class Ajax {
 
 		$post_id                        = (int) $_REQUEST['post_id'];
 		$html                           = '';
-		$simplified_summary             = ( new Scan_Summary( $post_id ) )->get( 'simplified_summary_text' );
+		$simplified_summary             = ( new Scan_Summary_Back_Compat( $post_id ) )->get( 'simplified_summary_text' );
 		$simplified_summary_position    = get_option( 'edac_simplified_summary_position', $default = false );
 		$content_post                   = get_post( $post_id );
 		$content                        = $content_post->post_content;
@@ -703,7 +703,7 @@ class Ajax {
 		$post_id           = (int) $_REQUEST['post_id'];
 		$sanitized_summary = isset( $_REQUEST['summary'] ) ? sanitize_text_field( $_REQUEST['summary'] ) : '';
 
-		( new Scan_Summary( $post_id ) )->save( 'simplified_summary_text', $sanitized_summary );
+		( new Scan_Summary_Back_Compat( $post_id ) )->save( 'simplified_summary_text', $sanitized_summary );
 		wp_send_json_success( wp_json_encode( $sanitized_summary ) );
 	}
 

--- a/admin/data/class-abstract-data.php
+++ b/admin/data/class-abstract-data.php
@@ -13,7 +13,7 @@ namespace EDAC\Admin\Data;
  * Abstract data class showing the basic structure and requirements for a data class.
  */
 abstract class Abstract_Data implements Interface_Data {
-	const PREFIX = 'edac_';
+	const PREFIX = '_edac_';
 	const KEY    = '';
 
 	/**

--- a/admin/data/class-abstract-data.php
+++ b/admin/data/class-abstract-data.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Abstract data class
+ *
+ * @since 1.11.0
+ *
+ * @package accessibility-checker
+ */
+
+namespace EDAC\Admin\Data;
+
+/**
+ * Abstract data class showing the basic structure and requirements for a data class.
+ */
+abstract class Abstract_Data implements Interface_Data {
+	const PREFIX = 'edac_';
+	const KEY    = '';
+
+	/**
+	 * Get data
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key Optional. Key to get specific data.
+	 *
+	 * @return mixed
+	 */
+	abstract public function get( string $key = '' );
+
+	/**
+	 * Save data
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param mixed  $data Data to save.
+	 * @param string $key Optional. Key to save specific data.
+	 */
+	abstract public function save( $data, string $key = '' );
+
+	/**
+	 * Delete data
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key Optional. Key to delete specific data.
+	 */
+	abstract public function delete( string $key = '' );
+}

--- a/admin/data/interface-data.php
+++ b/admin/data/interface-data.php
@@ -12,7 +12,7 @@ namespace EDAC\Admin\Data;
 /**
  * Interface for data classes
  */
-interface Data_Interface {
+interface Interface_Data {
 
 	/**
 	 * Get data

--- a/admin/data/interface-data.php
+++ b/admin/data/interface-data.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Interface for data classes
+ *
+ * @since 1.11.0
+ *
+ * @package accessibility-checker
+ */
+
+namespace EDAC\Admin\Data;
+
+/**
+ * Interface for data classes
+ */
+interface Data_Interface {
+
+	/**
+	 * Get data
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key Optional. Key to get specific data.
+	 *
+	 * @return mixed
+	 */
+	public function get( string $key = '' );
+
+	/**
+	 * Save data
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param mixed  $data Data to save.
+	 * @param string $key Optional. Key to save specific data.
+	 */
+	public function save( $data, string $key = '' );
+
+	/**
+	 * Delete data
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key Optional. Key to delete specific data.
+	 */
+	public function delete( string $key = '' );
+}

--- a/admin/data/post-meta/class-scan-summary-back-compat.php
+++ b/admin/data/post-meta/class-scan-summary-back-compat.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Data handler for scan summary
+ * Data handler for scan summary with back compat support.
+ *
+ * This class will ideally be removable after enough time has passed or enough
+ * updated versions have been released where we can be confident that all data
+ * in users systems has been updated to be stored in the singular root key.
  *
  * @since 1.11.0
  *
@@ -12,7 +16,7 @@ namespace EDAC\Admin\Data\Post_Meta;
 use EDAC\Admin\Data\Interface_Data;
 
 /**
- * Handle scan summary data
+ * Handle scan summary data in a backwards compatible way.
  *
  * @since 1.11.0
  */

--- a/admin/data/post-meta/class-scan-summary-back-compat.php
+++ b/admin/data/post-meta/class-scan-summary-back-compat.php
@@ -76,7 +76,7 @@ class Scan_Summary_Back_Compat extends Scan_Summary implements Interface_Data {
 	 *
 	 * @return void
 	 */
-	public function delete( string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+	public function delete( string $key = '' ): void {
 		parent::delete( $key );
 		foreach ( $this->column_sort_keys as $column ) {
 			// delete the old keys for back compat.

--- a/admin/data/post-meta/class-scan-summary-back-compat.php
+++ b/admin/data/post-meta/class-scan-summary-back-compat.php
@@ -116,6 +116,8 @@ class Scan_Summary_Back_Compat extends Scan_Summary implements Interface_Data {
 	private function get_key_for_back_compat( string $key ): string {
 		$back_compat_keys = array(
 			'simplified_summary_text' => '_edac_simplified_summary',
+			'post_checked'            => '_edac_post_checked',
+			'post_checked_time_js'    => '_edac_post_checked_js',
 		);
 		return $back_compat_keys[ $key ] ?? $key;
 	}

--- a/admin/data/post-meta/class-scan-summary-back-compat.php
+++ b/admin/data/post-meta/class-scan-summary-back-compat.php
@@ -119,6 +119,7 @@ class Scan_Summary_Back_Compat extends Scan_Summary implements Interface_Data {
 			'post_checked'            => '_edac_post_checked',
 			'post_checked_time_js'    => '_edac_post_checked_js',
 			'issue_density'           => '_edac_issue_density',
+			'density_data'            => '_edac_density_data',
 		);
 		return $back_compat_keys[ $key ] ?? $key;
 	}

--- a/admin/data/post-meta/class-scan-summary-back-compat.php
+++ b/admin/data/post-meta/class-scan-summary-back-compat.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Data handler for scan summary
+ *
+ * @since 1.11.0
+ *
+ * @package accessibility-checker
+ */
+
+namespace EDAC\Admin\Data\Post_Meta;
+
+use EDAC\Admin\Data\Interface_Data;
+
+/**
+ * Handle scan summary data
+ *
+ * @since 1.11.0
+ */
+class Scan_Summary_Back_Compat extends Scan_Summary implements Interface_Data {
+
+	/**
+	 * Scan summary data
+	 *
+	 * @var array
+	 */
+	protected array $summary;
+
+	/**
+	 * Get scan summary data
+	 *
+	 * @param string $key Optional. Key to get specific data.
+	 *
+	 * @return array|string
+	 */
+	public function get( string $key = '' ) {
+		if ( ! empty( $key ) ) {
+			return $this->summary[ $key ] ?? $this->back_compat_get( $key );
+		}
+
+		return parent::get( $key );
+	}
+
+	/**
+	 * Save scan summary data
+	 *
+	 * Also saves the keys we want to sort by as individual post_meta values.
+	 *
+	 * It may be confusing to have the data paramiter before the key parameter but this
+	 * is done so that data can be passed without a key to save the entire summary. The
+	 * key just allows a chunk to be saved.
+	 *
+	 * @param mixed  $data Data to save.
+	 * @param string $key Optional. Key to save specific data.
+	 *
+	 * @return void
+	 */
+	public function save( $data, string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+		parent::save( $data, $key );
+		if ( empty( $key ) ) {
+			return;
+		}
+		$back_compat_key = $this->get_key_for_back_compat( $key );
+		if ( $back_compat_key !== $key ) {
+			delete_post_meta( $this->post_id, $back_compat_key );
+		}
+	}
+
+	/**
+	 * Delete scan summary data
+	 *
+	 * @param string $key Optional. Key to delete specific data.
+	 *
+	 * @return void
+	 */
+	public function delete( string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+		parent::delete( $key );
+		foreach ( $this->column_sort_keys as $column ) {
+			// delete the old keys for back compat.
+			delete_post_meta(
+				$this->post_id,
+				$this->get_key_for_back_compat(
+					$this->root_key . '_' . $column
+				)
+			);
+		}
+	}
+
+	/**
+	 * For back compat with older data that was stored as individual post_meta values.
+	 *
+	 * This method should be removed after the next major release, or after a year, whichever comes first.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return mixed
+	 */
+	private function back_compat_get( string $key ) {
+		$maybe_back_compat_key = $this->get_key_for_back_compat( $key );
+		$meta_from_old_key     = get_post_meta( $this->post_id, $maybe_back_compat_key, true );
+		return $meta_from_old_key ?? '';
+	}
+
+	/**
+	 * Remap new keys to old keys to preserve back compat with older data.
+	 *
+	 * @param string $key - a key to check for a back compat equivalent.
+	 *
+	 * @return string - the back compat key if it exists, otherwise the original key.
+	 */
+	private function get_key_for_back_compat( string $key ): string {
+		$back_compat_keys = array(
+			'simplified_summary_text' => '_edac_simplified_summary',
+		);
+		return $back_compat_keys[ $key ] ?? $key;
+	}
+}

--- a/admin/data/post-meta/class-scan-summary-back-compat.php
+++ b/admin/data/post-meta/class-scan-summary-back-compat.php
@@ -118,6 +118,7 @@ class Scan_Summary_Back_Compat extends Scan_Summary implements Interface_Data {
 			'simplified_summary_text' => '_edac_simplified_summary',
 			'post_checked'            => '_edac_post_checked',
 			'post_checked_time_js'    => '_edac_post_checked_js',
+			'issue_density'           => '_edac_issue_density',
 		);
 		return $back_compat_keys[ $key ] ?? $key;
 	}

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -167,6 +167,7 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 			),
 			'post_checked_time_js'    => absint( $summary['post_checked_time_js'] ?? 0 ),
 			'issue_density'           => floatval( $summary['issue_density'] ?? 0 ),
+			'density_data'            => array_map( 'floatval', $summary['density_data'] ?? array( 0, 0 ) ),
 		);
 	}
 

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -116,14 +116,49 @@ class Scan_Summary implements Data_Interface {
 	 */
 	private function sanitize_summary( array $summary ): array {
 		return array(
-			'passed_tests'       => absint( $summary['passed_tests'] ?? 0 ),
-			'errors'             => absint( $summary['errors'] ?? 0 ),
-			'warnings'           => absint( $summary['warnings'] ?? 0 ),
-			'ignored'            => absint( $summary['ignored'] ?? 0 ),
-			'contrast_errors'    => absint( $summary['contrast_errors'] ?? 0 ),
-			'content_grade'      => absint( $summary['content_grade'] ?? 0 ),
-			'readability'        => sanitize_text_field( $summary['readability'] ?? '' ),
-			'simplified_summary' => filter_var( $summary['simplified_summary'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+			'passed_tests'            => absint( $summary['passed_tests'] ?? 0 ),
+			'errors'                  => absint( $summary['errors'] ?? 0 ),
+			'warnings'                => absint( $summary['warnings'] ?? 0 ),
+			'ignored'                 => absint( $summary['ignored'] ?? 0 ),
+			'contrast_errors'         => absint( $summary['contrast_errors'] ?? 0 ),
+			'content_grade'           => absint( $summary['content_grade'] ?? 0 ),
+			'readability'             => sanitize_text_field( $summary['readability'] ?? '' ),
+			'simplified_summary'      => filter_var( // I would like to rename this to 'simplified_summary_required'.
+				$summary['simplified_summary'] ?? false,
+				FILTER_VALIDATE_BOOLEAN
+			),
+			'simplified_summary_text' => wp_kses_post( $summary['simplified_summary_text'] ?? '' ),
 		);
+	}
+
+	/**
+	 * For back compat with older data that was stored as individual post_meta values.
+	 *
+	 * This method should be removed after the next major release, or after a year, whichever comes first.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return mixed
+	 */
+	private function back_compat_get( string $key ) {
+		$maybe_back_compat_key = $this->get_key_for_back_compat( $key );
+		$meta_from_old_key     = get_post_meta( $this->post_id, $maybe_back_compat_key, true );
+		return $meta_from_old_key ?? '';
+	}
+
+	/**
+	 * Remap new keys to old keys to preserve back compat with older data.
+	 *
+	 * @param string $key - a key to check for a back compat equivalent.
+	 *
+	 * @return string - the back compat key if it exists, otherwise the original key.
+	 */
+	private function get_key_for_back_compat( string $key ): string {
+		$back_compat_keys = array(
+			'simplified_summary_text' => '_edac_simplified_summary',
+		);
+		return $back_compat_keys[ $key ] ?? $key;
 	}
 }

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -124,6 +124,11 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 	 * @return void
 	 */
 	public function delete( string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key for back compat.
+		if ( ! empty( $key ) ) {
+			unset( $this->summary[ $key ] );
+			$this->save( $this->summary );
+			return;
+		}
 		delete_post_meta( $this->post_id, $this->root_key );
 		foreach ( $this->column_sort_keys as $column ) {
 			delete_post_meta(

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -161,6 +161,11 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 				FILTER_VALIDATE_BOOLEAN
 			),
 			'simplified_summary_text' => wp_kses_post( $summary['simplified_summary_text'] ?? '' ),
+			'post_checked'            => filter_var(
+				$summary['post_checked'] ?? false,
+				FILTER_VALIDATE_BOOLEAN
+			),
+			'post_checked_time_js'    => absint( $summary['post_checked_time_js'] ?? 0 ),
 		);
 	}
 

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -18,7 +18,7 @@ use EDAC\Admin\Data\Interface_Data;
  * @since 1.11.0
  */
 class Scan_Summary extends Abstract_Data implements Interface_Data {
-	const KEY = '_summary';
+	const KEY = 'summary';
 
 	/**
 	 * Storage key

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -55,7 +55,7 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 	 */
 	public function __construct( int $post_id = 0 ) {
 		$this->post_id          = $post_id;
-		$this->column_sort_keys = array( 'passed', 'error', 'warning', 'ignored', 'contrast_errors' );
+		$this->column_sort_keys = array( 'passed_tests', 'errors', 'warnings', 'ignored', 'contrast_errors' );
 
 		// There is no reason to create an instance of this class without wanting this data.
 		$summary       = get_post_meta( $this->post_id, $this->root_key, true );

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -86,12 +86,16 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 	 * is done so that data can be passed without a key to save the entire summary. The
 	 * key just allows a chunk to be saved.
 	 *
-	 * @param mixed  $data Data to save.
+	 * @param mixed  $data Data to save. This is expected to be an associative array if a key is not passed.
 	 * @param string $key Optional. Key to save specific data.
 	 *
 	 * @return void
 	 */
 	public function save( $data, string $key = '' ): void {
+		if ( empty( $key ) && ! is_array( $data ) ) {
+			// this is a fail, we may need to bubble a WP_Error back up.
+			return;
+		}
 		$this->summary = $this->sanitize_summary(
 			// If a key is passed, only update that key.
 			array_merge(

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -166,6 +166,7 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 				FILTER_VALIDATE_BOOLEAN
 			),
 			'post_checked_time_js'    => absint( $summary['post_checked_time_js'] ?? 0 ),
+			'issue_density'           => floatval( $summary['issue_density'] ?? 0 ),
 		);
 	}
 

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Data handler for scan summary
+ *
+ * @since 1.11.0
+ *
+ * @package accessibility-checker
+ */
+
+namespace EDAC\Admin\Data\Post_Meta;
+
+use EDAC\Admin\Data\Data_Interface;
+
+/**
+ * Handle scan summary data
+ *
+ * @since 1.11.0
+ */
+class Scan_Summary implements Data_Interface {
+	const SUMMARY_KEY = '_edac_summary';
+	/**
+	 * Scan summary data
+	 *
+	 * @var array
+	 */
+	private array $summary;
+
+	/**
+	 * Post ID
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Column sort keys to store as individual post_meta values
+	 *
+	 * @var string[]
+	 */
+	private array $column_sort_keys;
+
+	/**
+	 * Set up the post ID and colum sort keys.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function __construct( int $post_id = 0 ) {
+		$this->post_id          = $post_id;
+		$this->column_sort_keys = array( 'passed', 'error', 'warning', 'ignored', 'contrast_errors' );
+	}
+
+	/**
+	 * Get scan summary data
+	 *
+	 * @param string $key Optional. Key to get specific data.
+	 *
+	 * @return array|string
+	 */
+	public function get( string $key = '' ) {
+		if ( ! $this->summary ) {
+			$this->summary = get_post_meta( $this->post_id, self::SUMMARY_KEY, true );
+		}
+
+		if ( ! empty( $key ) ) {
+			return $this->summary[ $key ] ?? '';
+		}
+
+		return $this->summary;
+	}
+
+	/**
+	 * Save scan summary data
+	 *
+	 * Also saves the keys we want to sort by as individual post_meta values.
+	 *
+	 * @param mixed  $data Data to save.
+	 * @param string $key Optional. Key to save specific data.
+	 *
+	 * @return void
+	 */
+	public function save( $data, string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+		$this->summary = $this->sanitize_summary(
+			array_merge( $this->summary, $data )
+		);
+		update_post_meta( $this->post_id, self::SUMMARY_KEY, $this->summary );
+
+		// save the keys we want to sort by as individual post_meta values.
+		foreach ( $this->column_sort_keys as $column ) {
+			$value_to_store = $this->summary[ $column ] ?? 0;
+			update_post_meta( $this->post_id, self::SUMMARY_KEY . '_' . $column, $value_to_store );
+		}
+	}
+
+	/**
+	 * Delete scan summary data
+	 *
+	 * @param string $key Optional. Key to delete specific data.
+	 *
+	 * @return void
+	 */
+	public function delete( string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+		delete_post_meta( $this->post_id, self::SUMMARY_KEY );
+		foreach ( $this->column_sort_keys as $column ) {
+			delete_post_meta( $this->post_id, self::SUMMARY_KEY . '_' . $column );
+		}
+	}
+
+	/**
+	 * Sanitizes the summary metadata.
+	 *
+	 * @param array $summary An associative array containing the summary of accessibility checks.
+	 *
+	 * @return array The sanitized summary metadata.
+	 *
+	 * @since 1.11.0
+	 */
+	private function sanitize_summary( array $summary ): array {
+		return array(
+			'passed_tests'       => absint( $summary['passed_tests'] ?? 0 ),
+			'errors'             => absint( $summary['errors'] ?? 0 ),
+			'warnings'           => absint( $summary['warnings'] ?? 0 ),
+			'ignored'            => absint( $summary['ignored'] ?? 0 ),
+			'contrast_errors'    => absint( $summary['contrast_errors'] ?? 0 ),
+			'content_grade'      => absint( $summary['content_grade'] ?? 0 ),
+			'readability'        => sanitize_text_field( $summary['readability'] ?? '' ),
+			'simplified_summary' => filter_var( $summary['simplified_summary'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+		);
+	}
+}

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -91,7 +91,7 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 	 *
 	 * @return void
 	 */
-	public function save( $data, string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+	public function save( $data, string $key = '' ): void {
 		$this->summary = $this->sanitize_summary(
 			// If a key is passed, only update that key.
 			array_merge(
@@ -119,7 +119,7 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 	 *
 	 * @return void
 	 */
-	public function delete( string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key.
+	public function delete( string $key = '' ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- some implementations may need a key for back compat.
 		delete_post_meta( $this->post_id, $this->root_key );
 		foreach ( $this->column_sort_keys as $column ) {
 			delete_post_meta(

--- a/admin/data/post-meta/class-scan-summary.php
+++ b/admin/data/post-meta/class-scan-summary.php
@@ -163,4 +163,13 @@ class Scan_Summary extends Abstract_Data implements Interface_Data {
 			'simplified_summary_text' => wp_kses_post( $summary['simplified_summary_text'] ?? '' ),
 		);
 	}
+
+	/**
+	 * Return the root key that data is stored under.
+	 *
+	 * This was found to be useful in tests.
+	 */
+	public function get_root_key(): string {
+		return $this->root_key;
+	}
 }

--- a/includes/classes/class-frontend-validate.php
+++ b/includes/classes/class-frontend-validate.php
@@ -7,6 +7,8 @@
 
 namespace EDAC\Inc;
 
+use EDAC\Admin\Data\Post_Meta\Scan_Summary_Back_Compat;
+
 /**
  * A class that handles the validation of the page on the frontend.
  *
@@ -34,8 +36,8 @@ class Frontend_Validate {
 	 *
 	 * This function is triggered only by the `template_redirect` hook. It returns early if not 'index.php', in a
 	 * customizer preview, the post is an 'auto-draft' or if the current user does not have permissions to edit posts.
-	 * It checks if the current post has been previously validated based on a specific post meta key
-	 * ('_edac_post_checked'). If the post has not been validated, it initiates the validation process.
+	 * It checks if the current post has been previously validated based on a specific value in a meta key
+	 * ('_edac_summary[post_checked]'). If the post has not been validated, it initiates the validation process.
 	 *
 	 * @modified 1.10.0 Return early if post is an auto-draft.
 	 *
@@ -54,8 +56,7 @@ class Frontend_Validate {
 				return;
 			}
 
-			$checked = get_post_meta( $post->ID, '_edac_post_checked', true );
-			if ( ! $checked ) {
+			if ( ! ( new Scan_Summary_Back_Compat( $post->ID ) )->get( 'post_checked' ) ) {
 				edac_validate( $post->ID, $post, $action = 'load' );
 			}
 		}

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -12,8 +12,6 @@ use EDAC\Admin\Insert_Rule_Data;
 use EDAC\Admin\Scans_Stats;
 use EDAC\Admin\Settings;
 
-
-
 /**
  * Class that initializes and handles the REST api
  */

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -7,6 +7,7 @@
 
 namespace EDAC\Inc;
 
+use EDAC\Admin\Data\Post_Meta\Scan_Summary_Back_Compat;
 use EDAC\Admin\Helpers;
 use EDAC\Admin\Insert_Rule_Data;
 use EDAC\Admin\Scans_Stats;
@@ -251,7 +252,7 @@ class REST_Api {
 			( new Summary_Generator( $post_id ) )->generate_summary();
 
 			// store a record of this scan in the post's meta.
-			update_post_meta( $post_id, '_edac_post_checked_js', time() );
+			( new Scan_Summary_Back_Compat( $post->ID ) )->save( time(), 'post_checked_time_js' );
 
 			return new \WP_REST_Response(
 				array(

--- a/includes/classes/class-simplified-summary.php
+++ b/includes/classes/class-simplified-summary.php
@@ -7,6 +7,8 @@
 
 namespace EDAC\Inc;
 
+use EDAC\Admin\Data\Post_Meta\Scan_Summary;
+
 /**
  * A class that handles the simplified summary.
  */

--- a/includes/classes/class-simplified-summary.php
+++ b/includes/classes/class-simplified-summary.php
@@ -7,7 +7,7 @@
 
 namespace EDAC\Inc;
 
-use EDAC\Admin\Data\Post_Meta\Scan_Summary;
+use EDAC\Admin\Data\Post_Meta\Scan_Summary_Back_Compat;
 
 /**
  * A class that handles the simplified summary.
@@ -55,11 +55,14 @@ class Simplified_Summary {
 	/**
 	 * Simplified summary markup
 	 *
+	 * @modified 1.11.0 - Use new Scan_Summary_Back_Compat class to get simplified summary text.
+	 * @modified 1.11.0 - Added filter edac_filter_simplified_summary_header_element.
+	 *
 	 * @param int $post Post ID.
 	 * @return string
 	 */
 	public function simplified_summary_markup( $post ) {
-		$simplified_summary = ( new Scan_Summary( $post ) )->get( 'simplified_summary_text' );
+		$simplified_summary = ( new Scan_Summary_Back_Compat( $post ) )->get( 'simplified_summary_text' );
 
 		if ( ! $simplified_summary ) {
 			return '';

--- a/includes/classes/class-simplified-summary.php
+++ b/includes/classes/class-simplified-summary.php
@@ -59,9 +59,11 @@ class Simplified_Summary {
 	 * @return string
 	 */
 	public function simplified_summary_markup( $post ) {
-		$simplified_summary = get_post_meta( $post, '_edac_simplified_summary', true )
-			? get_post_meta( $post, '_edac_simplified_summary', true ) 
-			: '';
+		$simplified_summary = ( new Scan_Summary( $post ) )->get( 'simplified_summary_text' );
+
+		if ( ! $simplified_summary ) {
+			return '';
+		}
 
 		$simplified_summary_heading = apply_filters(
 			'edac_filter_simplified_summary_heading',

--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -266,9 +266,9 @@ class Summary_Generator {
 			$content_length = $issue_density_array[0][1];
 			$issue_density  = edac_get_issue_density( $issue_count, $element_count, $content_length );
 
-			update_post_meta( $this->post_id, '_edac_issue_density', floatval( $issue_density ) );
+			( new Scan_Summary_Back_Compat( $this->post_id ) )->save( 'issue_density', floatval( $issue_density ) );
 		} else {
-			delete_post_meta( $this->post_id, '_edac_issue_density' );
+			( new Scan_Summary_Back_Compat( $this->post_id ) )->delete( 'issue_density' );
 		}
 	}
 

--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -7,6 +7,8 @@
 
 namespace EDAC\Inc;
 
+use EDAC\Admin\Data\Post_Meta\Scan_Summary;
+
 /**
  * Class that handles summary generator
  *
@@ -79,7 +81,7 @@ class Summary_Generator {
 		$summary['errors']            -= $summary['contrast_errors'];
 		$summary['content_grade']      = $this->calculate_content_grade();
 		$summary['readability']        = $this->get_readability( $summary );
-		$summary['simplified_summary'] = (bool) ( get_post_meta( $this->post_id, '_edac_simplified_summary', true ) );
+		$summary['simplified_summary'] = (bool) ( ( new Scan_Summary() )->get( 'simplified_summary_text' ) );
 		$this->update_issue_density( $summary );
 		$this->save_summary_meta_data( $summary );
 
@@ -316,37 +318,12 @@ class Summary_Generator {
 	 * errors, warnings, ignored checks, contrast errors, content grade, readability, and whether a simplified summary is enabled.
 	 *
 	 * @param array $summary An associative array containing the summary of accessibility checks.
+	 * @return void
 	 *
 	 * @since 1.9.0
+	 * @modified 1.11.0 - Swapped to using Scan_Summary class to save the summary.
 	 */
-	private function save_summary_meta_data( $summary ) {
-		update_post_meta( $this->post_id, '_edac_summary', $this->sanitize_summary_meta_data( $summary ) );
-		update_post_meta( $this->post_id, '_edac_summary_passed_tests', absint( $summary['passed_tests'] ) );
-		update_post_meta( $this->post_id, '_edac_summary_errors', absint( $summary['errors'] ) );
-		update_post_meta( $this->post_id, '_edac_summary_warnings', absint( $summary['warnings'] ) );
-		update_post_meta( $this->post_id, '_edac_summary_ignored', absint( $summary['ignored'] ) );
-		update_post_meta( $this->post_id, '_edac_summary_contrast_errors', absint( $summary['contrast_errors'] ) );
-	}
-
-	/**
-	 * Sanitizes the summary metadata before saving it to the database.
-	 *
-	 * @param array $summary An associative array containing the summary of accessibility checks.
-	 *
-	 * @return array The sanitized summary metadata.
-	 *
-	 * @since 1.11.0
-	 */
-	private function sanitize_summary_meta_data( array $summary ): array {
-		return array(
-			'passed_tests'       => absint( $summary['passed_tests'] ?? 0 ),
-			'errors'             => absint( $summary['errors'] ?? 0 ),
-			'warnings'           => absint( $summary['warnings'] ?? 0 ),
-			'ignored'            => absint( $summary['ignored'] ?? 0 ),
-			'contrast_errors'    => absint( $summary['contrast_errors'] ?? 0 ),
-			'content_grade'      => absint( $summary['content_grade'] ?? 0 ),
-			'readability'        => sanitize_text_field( $summary['readability'] ?? '' ),
-			'simplified_summary' => filter_var( $summary['simplified_summary'] ?? false, FILTER_VALIDATE_BOOLEAN ),
-		);
+	private function save_summary_meta_data( array $summary ): void {
+		( new Scan_Summary( $this->post_id ) )->save( $summary );
 	}
 }

--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -7,7 +7,7 @@
 
 namespace EDAC\Inc;
 
-use EDAC\Admin\Data\Post_Meta\Scan_Summary;
+use EDAC\Admin\Data\Post_Meta\{ Scan_Summary, Scan_Summary_Back_Compat };
 
 /**
  * Class that handles summary generator
@@ -81,7 +81,7 @@ class Summary_Generator {
 		$summary['errors']            -= $summary['contrast_errors'];
 		$summary['content_grade']      = $this->calculate_content_grade();
 		$summary['readability']        = $this->get_readability( $summary );
-		$summary['simplified_summary'] = (bool) ( ( new Scan_Summary() )->get( 'simplified_summary_text' ) );
+		$summary['simplified_summary'] = (bool) ( ( new Scan_Summary_Back_Compat( $this->post_id ) )->get( 'simplified_summary_text' ) );
 		$this->update_issue_density( $summary );
 		$this->save_summary_meta_data( $summary );
 

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -356,23 +356,20 @@ function edac_get_content( $post ) {
 				$page_html         = $content['html']->save();
 				$body_density_data = edac_get_body_density_data( $page_html );
 
+				$scan_summary = new Scan_Summary_Back_Compat( $post->ID );
 				if ( false !== $body_density_data ) {
-					update_post_meta(
-						$post->ID,
-						'_edac_density_data',
-						array_map( 'intval', $body_density_data )
-					);
+					$scan_summary->save( $body_density_data, 'density_data' );
 				} else {
-					delete_post_meta( $post->ID, '_edac_density_data' );
+					$scan_summary->delete( 'density_data' );
 				}
 			}
 		} catch ( Exception $e ) {
-			update_post_meta( $post->ID, '_edac_density_data', array( 0, 0 ) );
+			( new Scan_Summary_Back_Compat( $post->ID ) )->save( array( 0, 0 ), 'density_data' );
 
 			$content['html'] = false;
 		}
 	} else {
-		update_post_meta( $post->ID, '_edac_density_data', array( 0, 0 ) );
+		( new Scan_Summary_Back_Compat( $post->ID ) )->save( array( 0, 0 ), 'density_data' );
 
 		$content['html'] = false;
 	}

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -5,6 +5,7 @@
  * @package Accessibility_Checker
  */
 
+use EDAC\Admin\Data\Post_Meta\Scan_Summary_Back_Compat;
 use EDAC\Admin\Helpers;
 use EDAC\Admin\Insert_Rule_Data;
 
@@ -38,8 +39,7 @@ function edac_post_on_load() {
 	global $pagenow;
 	if ( 'post.php' === $pagenow ) {
 		global $post;
-		$checked = get_post_meta( $post->ID, '_edac_post_checked', true );
-		if ( false === (bool) $checked ) {
+		if ( ( new Scan_Summary_Back_Compat( $post->ID ) )->get( 'post_checked' ) ) {
 			edac_validate( $post->ID, $post, $action = 'load' );
 		}
 	}
@@ -177,7 +177,7 @@ function edac_validate( $post_ID, $post, $action ) {
 	edac_remove_corrected_posts( $post_ID, $post->post_type, $pre = 2, 'php' );
 
 	// set post meta checked.
-	update_post_meta( $post_ID, '_edac_post_checked', true );
+	( new Scan_Summary_Back_Compat( $post->ID ) )->save( true, 'post_checked' );
 
 	do_action( 'edac_after_validate', $post_ID, $action );
 }

--- a/tests/phpunit/Admin/post-meta/ScanSummaryBackCompatTest.php
+++ b/tests/phpunit/Admin/post-meta/ScanSummaryBackCompatTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for the back compat Scan Summary class.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Data\Post_Meta\Scan_Summary_Back_Compat;
+
+/**
+ * Test cases for the class added as an overlay to handle back compat
+ * for the Scan Summary class that fetches the summary data.
+ *
+ * The bulk of the functionality is in the parent class, Scan_Summary
+ * which has tests covering most of the functionality.
+ */
+class ScanSummaryBackCompatTest extends WP_UnitTestCase {
+
+	/**
+	 * Hold an instance of the Scan_Summary_Back_Compat class.
+	 *
+	 * @var Scan_Summary_Back_Compat $scan_summary_back_compat
+	 */
+	private Scan_Summary_Back_Compat $scan_summary_back_compat;
+
+	/**
+	 * Set up the scan summary property before each test and the post id.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->post_id                  = $this->factory()->post->create();
+		$this->scan_summary_back_compat = new Scan_Summary_Back_Compat( $this->post_id );
+	}
+
+	/**
+	 * Remove the post after each test.
+	 */
+	protected function tearDown(): void {
+		wp_delete_post( $this->post_id, true );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that before any scan data is saved it returns empty array.
+	 */
+	public function test_returns_empty_array_when_no_data_is_saved(): void {
+		$this->assertEquals( array(), $this->scan_summary_back_compat->get() );
+	}
+
+	/**
+	 * Test that it returns saved data for old key from dedicated post meta.
+	 */
+	public function test_returns_saved_data_when_requested_by_the_old_key(): void {
+		$simplified_summary_text = '<p>Simplified summary</p>';
+		$old_key                 = '_edac_simplified_summary';
+		update_post_meta( $this->post_id, $old_key, $simplified_summary_text );
+
+		$this->assertEquals( $simplified_summary_text, $this->scan_summary_back_compat->get( 'simplified_summary_text' ) );
+	}
+
+	/**
+	 * Test that when a key is saved it deletes the old key.
+	 */
+	public function test_deletes_old_key_when_new_key_is_saved(): void {
+		$simplified_summary_text = '<p>Simplified summary</p>';
+		$old_key                 = '_edac_simplified_summary';
+		$new_key                 = 'simplified_summary_text';
+		update_post_meta( $this->post_id, $old_key, $simplified_summary_text );
+		$this->assertEquals( $simplified_summary_text, $this->scan_summary_back_compat->get( $old_key ) );
+
+		$this->scan_summary_back_compat->save( $simplified_summary_text, $new_key );
+
+		$this->assertEquals( $simplified_summary_text, $this->scan_summary_back_compat->get( $new_key ) );
+		// meta should be deleted after saving the new key.
+		$this->assertEquals( '', get_post_meta( $this->post_id, $old_key, true ) );
+	}
+}

--- a/tests/phpunit/Admin/post-meta/ScanSummaryBackCompatTest.php
+++ b/tests/phpunit/Admin/post-meta/ScanSummaryBackCompatTest.php
@@ -13,6 +13,8 @@ use EDAC\Admin\Data\Post_Meta\Scan_Summary_Back_Compat;
  *
  * The bulk of the functionality is in the parent class, Scan_Summary
  * which has tests covering most of the functionality.
+ *
+ * @group scan-summary
  */
 class ScanSummaryBackCompatTest extends WP_UnitTestCase {
 
@@ -73,5 +75,23 @@ class ScanSummaryBackCompatTest extends WP_UnitTestCase {
 		$this->assertEquals( $simplified_summary_text, $this->scan_summary_back_compat->get( $new_key ) );
 		// meta should be deleted after saving the new key.
 		$this->assertEquals( '', get_post_meta( $this->post_id, $old_key, true ) );
+	}
+
+	/**
+	 * Test that the delete method removes the post meta data.
+	 */
+	public function test_delete_method_removes_post_meta_data(): void {
+		$simplified_summary_text = '<p>Simplified summary</p>';
+		$key                     = 'simplified_summary_text';
+		$this->scan_summary_back_compat->save( $simplified_summary_text, $key );
+
+		// Assert that the data was saved correctly.
+		$this->assertEquals( $simplified_summary_text, $this->scan_summary_back_compat->get( $key ) );
+
+		// Call the delete method.
+		$this->scan_summary_back_compat->delete( $key );
+
+		// Assert that the data was deleted.
+		$this->assertEmpty( $this->scan_summary_back_compat->get( $key ) );
 	}
 }

--- a/tests/phpunit/Admin/post-meta/ScanSummaryTest.php
+++ b/tests/phpunit/Admin/post-meta/ScanSummaryTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests for the Scan Summary class.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Data\Post_Meta\Scan_Summary;
+
+/**
+ * Test cases for the Scan Summary class.
+ */
+class ScanSummaryTest extends WP_UnitTestCase {
+
+	/**
+	 * Hold an instance of the Scan_Summary class.
+	 *
+	 * @var Scan_Summary $scan_summary
+	 */
+	private Scan_Summary $scan_summary;
+
+	/**
+	 * Set up the scan summary property before each test and the post id.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->post_id      = $this->factory()->post->create();
+		$this->scan_summary = new Scan_Summary( $this->post_id );
+	}
+
+	/**
+	 * Remove the post after each test.
+	 */
+	protected function tearDown(): void {
+		wp_delete_post( $this->post_id, true );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that before any scan data is saved it returns empty array.
+	 */
+	public function test_returns_empty_array_when_no_data_is_saved(): void {
+		$this->assertEquals( array(), $this->scan_summary->get() );
+	}
+
+	/**
+	 * Test that it returns saved data for single keys when requested.
+	 */
+	public function test_returns_saved_data_when_requested_by_key(): void {
+		$passed_tests            = 5;
+		$simplified_summary_text = '<p>Simplified summary</p>';
+
+		$this->scan_summary->save(
+			array(
+				'passed_tests'            => $passed_tests,
+				'simplified_summary_text' => $simplified_summary_text,
+			)
+		);
+
+		$this->assertEquals(
+			$passed_tests,
+			$this->scan_summary->get( 'passed_tests' )
+		);
+		$this->assertEquals(
+			$simplified_summary_text,
+			$this->scan_summary->get( 'simplified_summary_text' )
+		);
+	}
+
+	/**
+	 * Test that it can save data for a single key.
+	 */
+	public function test_can_save_by_key(): void {
+		$passed_tests = 5;
+		$this->scan_summary->save( $passed_tests, 'passed_tests' );
+		$this->assertEquals( 5, $this->scan_summary->get( 'passed_tests' ) );
+	}
+
+	/**
+	 * Test that a single key can be saved and it gets merged rather than
+	 * overwriting the entire array.
+	 */
+	public function test_single_key_save_doesnt_override_entire_array(): void {
+
+		$key                 = 'passed_tests';
+		$valid_summary_array = $this->get_a_valid_summary();
+		$passed_tests_before = $valid_summary_array[ $key ];
+
+		$this->scan_summary->save( $valid_summary_array );
+		$summary_before           = $this->scan_summary->get();
+		$keys_count_before_update = count( $summary_before );
+		// should be the same as the valid summary array.
+		$this->assertEquals( $passed_tests_before, $valid_summary_array[ $key ] );
+
+		$passed_tests = 9;
+		$this->scan_summary->save( $passed_tests, $key );
+		$summary_after = $this->scan_summary->get();
+		// should return same number of keys before and after saving single item.
+		$this->assertEquals( $keys_count_before_update, count( $summary_after ) );
+		// but with an updated value for the passed_tests key.
+		$this->assertEquals( $passed_tests, $summary_after[ $key ] );
+	}
+
+	/**
+	 * Test that it can delete a single key, making it the default value
+	 * without deleting the entire array.
+	 */
+	public function test_delete_single_key_removes_data_for_that_key(): void {
+		$passed_tests = 5;
+		$key          = 'passed_tests';
+		$this->scan_summary->save( $passed_tests, $key );
+		$summary_before = $this->scan_summary->get();
+		$this->assertEquals( $passed_tests, $summary_before[ $key ] );
+
+		$this->scan_summary->delete( $key );
+		$summary_after = $this->scan_summary->get();
+		// data will have changed.
+		$this->assertNotEquals( $passed_tests, $summary_after[ $key ] );
+
+		// should have the same number of keys.
+		$this->assertEquals( count( $summary_before ), count( $summary_after ) );
+	}
+
+	/**
+	 * Test that the sanitizer converts data from all strings to the expected types.
+	 */
+	public function test_sanitize_summary_returns_expected_types(): void {
+		$summary = array(
+			'passed_tests'            => '5',
+			'errors'                  => '3',
+			'warnings'                => '2',
+			'ignored'                 => '1',
+			'contrast_errors'         => '4',
+			'content_grade'           => '90',
+			'readability'             => '9th Grade',
+			'simplified_summary'      => 'true',
+			'simplified_summary_text' => '<p>Test</p>',
+		);
+
+		$expected = $this->get_a_valid_summary();
+
+		$this->assertEquals( $expected, $this->scan_summary->sanitize_summary( $summary ) );
+	}
+
+	/**
+	 * The valid summary data used to compare against in some tests.
+	 */
+	private function get_a_valid_summary(): array {
+		return array(
+			'passed_tests'            => 5,
+			'errors'                  => 3,
+			'warnings'                => 2,
+			'ignored'                 => 1,
+			'contrast_errors'         => 4,
+			'content_grade'           => 90,
+			'readability'             => '9th Grade',
+			'simplified_summary'      => true,
+			'simplified_summary_text' => '<p>Test</p>',
+		);
+	}
+}

--- a/tests/phpunit/Admin/post-meta/ScanSummaryTest.php
+++ b/tests/phpunit/Admin/post-meta/ScanSummaryTest.php
@@ -9,6 +9,8 @@ use EDAC\Admin\Data\Post_Meta\Scan_Summary;
 
 /**
  * Test cases for the Scan Summary class.
+ *
+ * @group scan-summary
  */
 class ScanSummaryTest extends WP_UnitTestCase {
 
@@ -140,6 +142,41 @@ class ScanSummaryTest extends WP_UnitTestCase {
 		$expected = $this->get_a_valid_summary();
 
 		$this->assertEquals( $expected, $this->scan_summary->sanitize_summary( $summary ) );
+	}
+
+	/**
+	 * Test that it can fully delete all the meta data for a post.
+	 */
+	public function test_delete_all_data(): void {
+		$valid_summary_array = $this->get_a_valid_summary();
+		$this->scan_summary->save( $valid_summary_array );
+
+		$sort_keys = $this->scan_summary->column_sort_keys;
+
+		$this->assertNotEmpty( get_post_meta( $this->post_id, $this->scan_summary->get_root_key(), true ) );
+		foreach ( $sort_keys as $col ) {
+			$this->assertNotEmpty( get_post_meta( $this->post_id, $this->scan_summary->get_root_key() . '_' . $col, true ) );
+		}
+
+		$this->scan_summary->delete();
+		$this->assertEquals( '', get_post_meta( $this->post_id, $this->scan_summary->get_root_key(), true ) );
+		foreach ( $sort_keys as $col ) {
+			$this->assertEquals( '', get_post_meta( $this->post_id, $this->scan_summary::PREFIX . '_' . $col, true ) );
+		}
+	}
+
+	/**
+	 * Test that passing empty key and non-array data to save does nothing.
+	 */
+	public function test_save_does_nothing_with_empty_key_and_non_array_data(): void {
+		$valid_summary_array = $this->get_a_valid_summary();
+		$this->scan_summary->save( $valid_summary_array );
+
+		$summary_before = $this->scan_summary->get();
+		$this->scan_summary->save( 'not an array', '' );
+		$summary_after = $this->scan_summary->get();
+
+		$this->assertEquals( $summary_before, $summary_after );
 	}
 
 	/**

--- a/tests/phpunit/Admin/post-meta/ScanSummaryTest.php
+++ b/tests/phpunit/Admin/post-meta/ScanSummaryTest.php
@@ -137,6 +137,13 @@ class ScanSummaryTest extends WP_UnitTestCase {
 			'readability'             => '9th Grade',
 			'simplified_summary'      => 'true',
 			'simplified_summary_text' => '<p>Test</p>',
+			'post_checked'            => 'false',
+			'post_checked_time_js'    => '0',
+			'issue_density'           => '5',
+			'density_data'            => array(
+				'5.5',
+				'6.6',
+			),
 		);
 
 		$expected = $this->get_a_valid_summary();
@@ -193,6 +200,13 @@ class ScanSummaryTest extends WP_UnitTestCase {
 			'readability'             => '9th Grade',
 			'simplified_summary'      => true,
 			'simplified_summary_text' => '<p>Test</p>',
+			'post_checked'            => false,
+			'post_checked_time_js'    => '0',
+			'issue_density'           => 5,
+			'density_data'            => array(
+				5.5,
+				6.6,
+			),
 		);
 	}
 }

--- a/tests/phpunit/includes/classes/SimplifiedSummaryTest.php
+++ b/tests/phpunit/includes/classes/SimplifiedSummaryTest.php
@@ -46,7 +46,6 @@ class SimplifiedSummaryTest extends WP_UnitTestCase {
 	public function test_simplified_summary_markup_with_summary() {
 		$post_id = self::factory()->post->create();
 		( new Scan_Summary( $post_id ) )->save( 'This is a simplified summary.', 'simplified_summary_text' );
-		update_post_meta( $post_id, '_edac_simplified_summary', 'This is a simplified summary.' );
 
 		$output = $this->simplified_summary->simplified_summary_markup( $post_id );
 		$this->assertStringContainsString( '<div class="edac-simplified-summary">', $output );

--- a/tests/phpunit/includes/classes/SimplifiedSummaryTest.php
+++ b/tests/phpunit/includes/classes/SimplifiedSummaryTest.php
@@ -5,6 +5,7 @@
  * @package Accessibility_Checker
  */
 
+use EDAC\Admin\Data\Post_Meta\Scan_Summary;
 use EDAC\Inc\Simplified_Summary;
 
 /**
@@ -44,6 +45,7 @@ class SimplifiedSummaryTest extends WP_UnitTestCase {
 	 */
 	public function test_simplified_summary_markup_with_summary() {
 		$post_id = self::factory()->post->create();
+		( new Scan_Summary( $post_id ) )->save( 'This is a simplified summary.', 'simplified_summary_text' );
 		update_post_meta( $post_id, '_edac_simplified_summary', 'This is a simplified summary.' );
 
 		$output = $this->simplified_summary->simplified_summary_markup( $post_id );
@@ -51,6 +53,22 @@ class SimplifiedSummaryTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<h2>Simplified Summary</h2>', $output );
 		$this->assertStringContainsString( '<p>This is a simplified summary.</p>', $output );
 		$this->assertStringContainsString( '</div>', $output );
+	}
+
+	/**
+	 * Tests output of simplified_summary_markup with a summary that passes through back compat methods.
+	 *
+	 * Verifies that the correct HTML markup is returned when a post
+	 * has a simplified summary.
+	 *
+	 * @return void
+	 */
+	public function test_simplified_summary_markup_with_summary_back_compat() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, '_edac_simplified_summary', 'This is a simplified summary.' );
+
+		$output = $this->simplified_summary->simplified_summary_markup( $post_id );
+		$this->assertStringContainsString( '<div class="edac-simplified-summary">', $output );
 	}
 
 	/**

--- a/tests/phpunit/includes/classes/SummaryGeneratorTest.php
+++ b/tests/phpunit/includes/classes/SummaryGeneratorTest.php
@@ -39,4 +39,39 @@ class SummaryGeneratorTest extends WP_UnitTestCase {
 			get_post_meta( $post_id, '_edac_density_data', true )
 		);
 	}
+
+	/**
+	 * Verify that the expected post_meta values exist when the summary data is saved.
+	 *
+	 * @throws ReflectionException If the method does not exist this is thrown.
+	 */
+	public function test_summary_data_is_saved() {
+
+		$post_id           = self::factory()->post->create();
+		$summary_generator = new Summary_Generator( $post_id );
+
+		// Reflection means that the method was hard to test in isolation and
+		// likely warrants a refactor so that the method is more testable.
+		$method = ( new ReflectionClass( get_class( $summary_generator ) ) )
+			->getMethod( 'save_summary_meta_data' );
+		$method->setAccessible( true );
+
+		$method->invoke(
+			$summary_generator,
+			array(
+				'passed_tests'    => 1,
+				'errors'          => 2,
+				'warnings'        => 3,
+				'ignored'         => 4,
+				'contrast_errors' => 5,
+			)
+		);
+
+		$this->assertNotEmpty( get_post_meta( $post_id, '_edac_summary', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_edac_summary_passed_tests', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_edac_summary_errors', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_edac_summary_warnings', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_edac_summary_ignored', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_edac_summary_contrast_errors', true ) );
+	}
 }


### PR DESCRIPTION
This PR aims to reduce the number of different post meta values in favor of storing as much data inside of a single post meta as possible.

The exception is that for sorting by columns some meta still must exist in 2 places.

It reduces the total number of post meta by 5 and introduces a single interface to getting any piece of post meta.

https://github.com/equalizedigital/accessibility-checker/pull/578/files#diff-ac3197d4f34d0b1b8fafdf64365bd3e7cb32db3aa83571ea74fcdfe464adf0eeR118-R122

Closes: #402 