### PR TITLE
Use wp nonce methods rather than custom ones in the validate flow

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -125,6 +125,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/deactivation.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/helper-functions.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/options-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/validate.php';
+
 /**
  * Filters and Actions
  */
@@ -133,6 +134,8 @@ add_action( 'admin_init', 'edac_register_setting' );
 add_action( 'admin_head', 'edac_post_on_load' );
 add_filter( 'save_post', 'edac_save_post', 10, 3 );
 add_action( 'pre_get_posts', 'edac_show_draft_posts' );
+add_filter( 'nonce_life', 'edac_nonce_life_for_validate', 10, 2 );
+
 if ( is_plugin_active( 'oxygen/functions.php' ) ) {
 	add_action( 'added_post_meta', 'edac_oxygen_builder_save_post', 10, 4 );
 	add_action( 'updated_post_meta', 'edac_oxygen_builder_save_post', 10, 4 );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -449,60 +449,6 @@ function edac_replace_css_variables( $value, $css_array ) {
 }
 
 /**
- * Generates a nonce that expires after a specified number of seconds.
- *
- * @param string $secret secret.
- * @param int    $timeout_seconds The number of seconds after which the nonce expires.
- * @return string
- */
-function edac_generate_nonce( $secret, $timeout_seconds = 120 ) {
-
-	$length      = 10;
-	$chars       = '1234567890qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM';
-	$ll          = strlen( $chars ) - 1;
-	$salt        = '';
-	$salt_length = 0;
-
-	while ( $salt_length < $length ) {
-		$salt       .= $chars[ wp_rand( 0, $ll ) ];
-		$salt_length = strlen( $salt );
-	}
-
-	$time     = time();
-	$max_time = $time + $timeout_seconds;
-	$nonce    = $salt . ',' . $max_time . ',' . sha1( $salt . $secret . $max_time );
-	return $nonce;
-}
-
-/**
- * Verifies if the nonce is valid and not expired.
- *
- * @param string $secret secret.
- * @param string $nonce nonce.
- * @return boolean
- */
-function edac_is_valid_nonce( $secret, $nonce ) {
-	if ( ! is_string( $nonce ) ) {
-		return false;
-	}
-	$a = explode( ',', $nonce );
-	if ( count( $a ) !== 3 ) {
-		return false;
-	}
-	$salt     = $a[0];
-	$max_time = (int) $a[1];
-	$hash     = $a[2];
-	$back     = sha1( $salt . $secret . $max_time );
-	if ( $back !== $hash ) {
-		return false;
-	}
-	if ( time() > $max_time ) {
-		return false;
-	}
-	return true;
-}
-
-/**
  * Upcoming meetups in json format
  *
  * @param string  $meetup meetup name.
@@ -539,7 +485,6 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 
 	return $output;
 }
-
 
 /**
  * Upcoming meetups in html

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -331,6 +331,9 @@ function edac_get_content( $post ) {
 			// Add the token to the URL.
 			$url = add_query_arg( 'edac_token', $token, $url );
 
+			// Since this uses a wp nonce we need to send along the cookies of the user making the request.
+			$context_opts['http']['header'] = 'Cookie: ' . edac_get_current_user_cookies();
+
 		}
 
 		try {
@@ -473,6 +476,20 @@ function edac_show_draft_posts( $query ) {
 
 	// If we've reached this point, alter the query to include 'publish', 'draft', and 'pending' posts.
 	$query->set( 'post_status', array( 'publish', 'draft', 'pending' ) );
+}
+
+/**
+ * Get current user cookies
+ *
+ * @return string
+ */
+function edac_get_current_user_cookies(): string {
+	$cookies = array();
+	// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE -- User must be logged in to trigger this so it's a valid use for cookies on the server.
+	foreach ( $_COOKIE as $key => $value ) {
+		$cookies[] = $key . '=' . $value;
+	}
+	return implode( '; ', $cookies );
 }
 
 /**

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -326,7 +326,7 @@ function edac_get_content( $post ) {
 		if ( 'draft' === $post->post_status || 'pending' === $post->post_status ) {
 
 			// Generate a token that is valid for a short period of time.
-			$token = edac_generate_nonce( 'draft-or-pending-status', 120 );
+			$token = wp_create_nonce( EDAC_VALIDATE_NONCE_ACTION );
 
 			// Add the token to the URL.
 			$url = add_query_arg( 'edac_token', $token, $url );
@@ -467,7 +467,7 @@ function edac_show_draft_posts( $query ) {
 	}
 
 	// If the passed token is no longer valid, we do nothing and return early.
-	if ( false === edac_is_valid_nonce( 'draft-or-pending-status', $url_token ) ) {
+	if ( ! wp_verify_nonce( $url_token, EDAC_VALIDATE_NONCE_ACTION ) ) {
 		return;
 	}
 

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -8,6 +8,8 @@
 use EDAC\Admin\Helpers;
 use EDAC\Admin\Insert_Rule_Data;
 
+const EDAC_VALIDATE_NONCE_ACTION = 'edac-validate-draft-or-pending-status';
+
 /**
  * Oxygen Builder on save
  *
@@ -471,4 +473,20 @@ function edac_show_draft_posts( $query ) {
 
 	// If we've reached this point, alter the query to include 'publish', 'draft', and 'pending' posts.
 	$query->set( 'post_status', array( 'publish', 'draft', 'pending' ) );
+}
+
+/**
+ * Sets the nonce life for the 'edac-validate-draft-or-pending-status' action
+ * to a really low TTL.
+ *
+ * @param int    $seconds The time the nonce is valid for.
+ * @param string $action  The nonce action.
+ *
+ * @return int
+ */
+function edac_nonce_life_for_validate( int $seconds, string $action ) {
+	if ( EDAC_VALIDATE_NONCE_ACTION === $action ) {
+		return MINUTE_IN_SECONDS * 2;
+	}
+	return $seconds;
 }


### PR DESCRIPTION
The validation flow used a custom-generated short-lived nonce to get the HTML content of draft or pending pages.

An actual WP nonce can be used instead here, which is what this PR swaps over to use.

The custom nonce was needed because the request didn't have any user context, but we can give it the user context so the wp nonce validates by forwarding the cookies in the request. Since this flow can only happen through a logged-in user that seems reasonable to me.

Closes: #580 