### PR TITLE
Don't build wp-env when doing npm install in CI as those containers are not needed

### DIFF
--- a/.github/workflows/deploy-on-release-to-dot-org.yml
+++ b/.github/workflows/deploy-on-release-to-dot-org.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: NPM install, build and generate release artefacts
         run: |
-          npm install
+          npm install --ignore-scripts
           npm run build
           npm run dist:dotorg
           echo "::set-output name=zip-path::./dist/${{ github.event.repository.name }}/${{ github.event.repository.name }}.zip"

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -41,7 +41,7 @@ jobs:
 
       # The lint stage doesn't run the unit tests or use code style, so no need for PHPUnit, WPCS or phpcompatibility.
       - name: 'Install NPM packages'
-        run: npm install
+        run: npm install --ignore-scripts
 
       # Only run ESLint on changed JavaScript files.
       - name: 'Get changed JavaScript files'


### PR DESCRIPTION
This takes the action from running in about 2.5-3 minutes down to running in around 30s.
![Screenshot from 2024-04-19 22-17-19](https://github.com/equalizedigital/accessibility-checker/assets/3902039/8ce8c536-c47f-4ce3-a29c-11b04ca3f39e)
