### PR TITLE
Fixed improperly titled admin notice doc blocks

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -110,7 +110,7 @@ class Admin_Notices {
 	}
 
 	/**
-	 * Get GAAD Promo Message
+	 * Get Black Friday Promo Message
 	 *
 	 * @return string
 	 */
@@ -216,7 +216,7 @@ class Admin_Notices {
 	}
 
 	/**
-	 * Review Admin Notice Ajax
+	 * GAAD Admin Notice Ajax
 	 *
 	 * @return void
 	 *
@@ -379,7 +379,7 @@ class Admin_Notices {
 	}
 
 	/**
-	 * Review Admin Notice Ajax
+	 * Password Protected Admin Notice Ajax
 	 *
 	 * @return void
 	 *


### PR DESCRIPTION
The PR fixes the admin notices doc blocks that were improperly titled.