### PR TITLE
Hotfix: Rules strict data comparisons 

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.11.0
+ * Version:           1.11.1
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -41,7 +41,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.11.0' );
+	define( 'EDAC_VERSION', '1.11.1' );
 }
 
 // Current database version.

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -266,7 +266,7 @@ class Admin_Notices {
 		$edac_review_notice_reminder = get_transient( $transient );
 
 		// first time if notice has never been shown wait 14 days.
-		if ( false === $edac_review_notice_reminder && false === $edac_review_notice ) {
+		if ( false === $edac_review_notice_reminder && empty( $edac_review_notice ) ) {
 			// if option isn't set and plugin has been active for more than 14 days show notice. This is for current users.
 			if ( edac_days_active() > 14 ) {
 				update_option( $option, 'play' );

--- a/includes/rules/empty_button.php
+++ b/includes/rules/empty_button.php
@@ -27,9 +27,9 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore -- $post is
 	// check buttons.
 	foreach ( $buttons as $button ) {
 		if (
-			str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $button->plaintext ) ) === ''
-			&& $button->getAttribute( 'aria-label' ) === ''
-			&& $button->getAttribute( 'title' ) === ''
+			empty( str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $button->plaintext ) ) )
+			&& empty( $button->getAttribute( 'aria-label' ) )
+			&& empty( $button->getAttribute( 'title' ) )
 		) {
 
 			$error_code = $button->outertext;
@@ -39,13 +39,13 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore -- $post is
 
 			if (
 				'' !== $error_code
-				&& ( ! isset( $image[0] ) || trim( $image[0]->getAttribute( 'alt' ) ) === '' )
-				&& ( ! isset( $input[0] ) || trim( $input[0]->getAttribute( 'value' ) ) === '' )
+				&& ( ! isset( $image[0] ) || empty( trim( $image[0]->getAttribute( 'alt' ) ) ) )
+				&& ( ! isset( $input[0] ) || empty( trim( $input[0]->getAttribute( 'value' ) ) ) )
 				&& (
 					! isset( $i[0] ) ||
 					(
-						( trim( $i[0]->getAttribute( 'title' ) ) === '' ) &&
-						( trim( $i[0]->getAttribute( 'aria-label' ) ) === '' )
+						( empty( trim( $i[0]->getAttribute( 'title' ) ) ) ) &&
+						( empty( trim( $i[0]->getAttribute( 'aria-label' ) ) ) )
 					)
 				)
 			) {
@@ -56,7 +56,7 @@ function edac_rule_empty_button( $content, $post ) { // phpcs:ignore -- $post is
 
 	// check inputs.
 	foreach ( $inputs as $input ) {
-		if ( $input->getAttribute( 'value' ) === '' ) {
+		if ( empty( $input->getAttribute( 'value' ) ) ) {
 			$errors[] = $input->outertext;
 		}
 	}

--- a/includes/rules/empty_heading_tag.php
+++ b/includes/rules/empty_heading_tag.php
@@ -30,6 +30,7 @@ function edac_rule_empty_heading_tag( $content, $post ) { // phpcs:ignore -- $po
 					empty( str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', htmlentities( trim( $heading->plaintext ) ) ) ) || 
 					empty( str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $heading->plaintext ) ) )
 				) && 
+					empty( $heading->getAttribute( 'aria-label' ) ) &&
 					! preg_match(
 						'#<img(\S|\s)*alt=(\'|\")(\w|\s)(\w|\s|\p{P}|\(|\)|\p{Sm}|~|`|’|\^|\$)+(\'|\")#',
 						$heading_code 

--- a/includes/rules/empty_heading_tag.php
+++ b/includes/rules/empty_heading_tag.php
@@ -26,7 +26,15 @@ function edac_rule_empty_heading_tag( $content, $post ) { // phpcs:ignore -- $po
 
 			$heading_code = $heading->outertext;
 
-			if ( ( str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', htmlentities( trim( $heading->plaintext ) ) ) === '' || str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $heading->plaintext ) ) === '' ) && ! preg_match( '#<img(\S|\s)*alt=(\'|\")(\w|\s)(\w|\s|\p{P}|\(|\)|\p{Sm}|~|`|’|\^|\$)+(\'|\")#', $heading_code ) ) {
+			if ( ( 
+					empty( str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', htmlentities( trim( $heading->plaintext ) ) ) ) || 
+					empty( str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $heading->plaintext ) ) )
+				) && 
+					! preg_match(
+						'#<img(\S|\s)*alt=(\'|\")(\w|\s)(\w|\s|\p{P}|\(|\)|\p{Sm}|~|`|’|\^|\$)+(\'|\")#',
+						$heading_code 
+					) 
+			) {
 
 				$errors[] = $heading_code;
 

--- a/includes/rules/empty_link.php
+++ b/includes/rules/empty_link.php
@@ -24,8 +24,8 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 		if (
 			str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $link->plaintext ) ) === ''
 			&& $link->hasAttribute( 'href' )
-			&& $link->getAttribute( 'aria-label' ) === ''
-			&& $link->getAttribute( 'title' ) === ''
+			&& empty( $link->getAttribute( 'aria-label' ) )
+			&& empty( $link->getAttribute( 'title' ) )
 		) {
 
 			// This link does not have plaintext within the tag &
@@ -45,7 +45,7 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 				// does not have a name.
 
 				$image = $link->find( 'img' );
-				if ( ! $error && isset( $input[0] ) && trim( $image[0]->getAttribute( 'alt' ) ) === '' ) {
+				if ( ! $error && isset( $input[0] ) && empty( trim( $image[0]->getAttribute( 'alt' ) ) ) ) {
 
 					// The first image inside the link does not have an alt.
 					// Throw error.
@@ -53,7 +53,7 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 				}
 
 				$input = $link->find( 'input' );
-				if ( ! $error && isset( $input[0] ) && trim( $image[0]->getAttribute( 'value' ) ) === '' ) {
+				if ( ! $error && isset( $input[0] ) && empty( trim( $image[0]->getAttribute( 'value' ) ) ) ) {
 
 					// The first input inside the link does not have a value.
 					// Throw error.
@@ -62,8 +62,8 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 
 				$i = $link->find( 'i' );
 				if ( ! $error && isset( $input[0] ) &&
-				trim( $i[0]->getAttribute( 'title' ) ) === '' &&
-				trim( $i[0]->getAttribute( 'aria-label' ) ) === ''
+				empty( trim( $i[0]->getAttribute( 'title' ) ) ) &&
+				empty( trim( $i[0]->getAttribute( 'aria-label' ) ) )
 				) {
 
 					// The first i inside the link does not have a title &

--- a/includes/rules/empty_link.php
+++ b/includes/rules/empty_link.php
@@ -22,7 +22,7 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 		$error = false;
 
 		if (
-			str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $link->plaintext ) ) === ''
+			(string) str_ireplace( [ ' ', '&nbsp;', '-', '_' ], '', trim( $link->plaintext ) ) === ''
 			&& $link->hasAttribute( 'href' )
 			&& empty( $link->getAttribute( 'aria-label' ) )
 			&& empty( $link->getAttribute( 'title' ) )

--- a/includes/rules/iframe_missing_title.php
+++ b/includes/rules/iframe_missing_title.php
@@ -19,7 +19,7 @@ function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore -- 
 	$errors      = [];
 
 	foreach ( $iframe_tags as $iframe ) {
-		if ( isset( $iframe ) && $iframe->getAttribute( 'title' ) === '' && $iframe->getAttribute( 'aria-label' ) === '' ) {
+		if ( isset( $iframe ) && empty( $iframe->getAttribute( 'title' ) ) && empty( $iframe->getAttribute( 'aria-label' ) ) ) {
 
 			$iframecode = htmlspecialchars( $iframe->outertext );
 

--- a/includes/rules/img_alt_empty.php
+++ b/includes/rules/img_alt_empty.php
@@ -27,13 +27,13 @@ function edac_rule_img_alt_empty( $content, $post ) { // phpcs:ignore -- $post i
 						isset( $element )
 						&& 'img' === $element->tag
 						&& $element->hasAttribute( 'alt' )
-						&& $element->getAttribute( 'alt' ) === ''
+						&& (string) $element->getAttribute( 'alt' ) === ''
 						&& $element->getAttribute( 'role' ) !== 'presentation'
 					) || (
 						'input' === $element->tag
 						&& $element->hasAttribute( 'alt' )
 						&& $element->getAttribute( 'type' ) === 'image'
-						&& $element->getAttribute( 'alt' ) === ''
+						&& (string) $element->getAttribute( 'alt' ) === ''
 					)
 				) {
 

--- a/includes/rules/img_linked_alt_empty.php
+++ b/includes/rules/img_linked_alt_empty.php
@@ -28,7 +28,7 @@ function edac_rule_img_linked_alt_empty( $content, $post ) { // phpcs:ignore -- 
 
 				if ( isset( $image )
 					&& $image->hasAttribute( 'alt' )
-					&& $image->getAttribute( 'alt' ) === ''
+					&& (string) $image->getAttribute( 'alt' ) === ''
 					&& $image->getAttribute( 'role' ) !== 'presentation' ) {
 
 					$image_code = $a;

--- a/includes/rules/img_linked_alt_empty.php
+++ b/includes/rules/img_linked_alt_empty.php
@@ -21,7 +21,7 @@ function edac_rule_img_linked_alt_empty( $content, $post ) { // phpcs:ignore -- 
 	foreach ( $as as $a ) {
 
 		// anchors with aria-label or title or valid node text.
-		if ( $a->getAttribute( 'aria-label' ) === '' && $a->getAttribute( 'title' ) === '' && strlen( $a->plaintext ) <= 5 ) {
+		if ( empty( $a->getAttribute( 'aria-label' ) ) && empty( $a->getAttribute( 'title' ) ) && strlen( $a->plaintext ) <= 5 ) {
 
 			$images = $a->find( 'img' );
 			foreach ( $images as $image ) {

--- a/includes/rules/img_linked_alt_missing.php
+++ b/includes/rules/img_linked_alt_missing.php
@@ -21,7 +21,7 @@ function edac_rule_img_linked_alt_missing( $content, $post ) { // phpcs:ignore -
 	foreach ( $as as $a ) {
 
 		// anchors with aria-label or title or valid node text.
-		if ( $a->getAttribute( 'aria-label' ) === '' && $a->getAttribute( 'title' ) === '' && strlen( $a->plaintext ) <= 5 ) {
+		if ( empty( $a->getAttribute( 'aria-label' ) ) && empty( $a->getAttribute( 'title' ) ) && strlen( $a->plaintext ) <= 5 ) {
 
 			$images = $a->find( 'img' );
 			foreach ( $images as $image ) {

--- a/includes/rules/long_description_invalid.php
+++ b/includes/rules/long_description_invalid.php
@@ -28,7 +28,7 @@ function edac_rule_long_description_invalid( $content, $post ) { // phpcs:ignore
 				$file_parts = pathinfo( $longdesc );
 				$valid_url  = filter_var( $longdesc, FILTER_VALIDATE_URL );
 
-				if ( $image->getAttribute( 'longdesc' ) === ''
+				if ( (string) $image->getAttribute( 'longdesc' ) === ''
 				|| ! $valid_url
 				|| ! $file_parts['extension']
 				|| ! $file_parts['filename']

--- a/includes/rules/missing_title.php
+++ b/includes/rules/missing_title.php
@@ -22,7 +22,7 @@ function edac_rule_missing_title( $content, $post ) {
 		return [ "Missing Title - Post ID: $post->ID" ];
 	}
 	if ( ( ! isset( $title ) || '' === $title->innertext || '-' === $title->innertext )
-		&& ( ! isset( $meta_title ) || ( $meta_title->hasAttribute( 'content' ) && ( $meta_title->getAttribute( 'content' ) === '' || strlen( $meta_title->getAttribute( 'content' ) ) <= 1 ) ) )
+		&& ( ! isset( $meta_title ) || ( $meta_title->hasAttribute( 'content' ) && ( (string) $meta_title->getAttribute( 'content' ) === '' || strlen( $meta_title->getAttribute( 'content' ) ) <= 1 ) ) )
 	) {
 		return [ "Missing title tag or meta title tag - Post ID: $post->ID" ];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility
 Requires at least: 6.2
 Tested up to: 6.5.2
-Stable tag: 1.11.0
+Stable tag: 1.11.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,6 +170,11 @@ No, Accessibility Checker runs completely on your server and does not require yo
 8. Accessibility Checker Summary tab on a page with no accessibility error or warnings and an included simplified summary.
 
 == Changelog ==
+
++ 1.11.1 =
+* Fixed: type Casting on several rules
+* Fixed: strict data comparison on several rules
+* Updated: empty heading tag rule to consider aria-label
 
 = 1.11.0 =
 * Updated: Tested up to WP 6.5.2


### PR DESCRIPTION
The PR fixes issues within rules where strict data comparisons from the refactor broke functionality.

* Fixed: type Casting on several rules
* Fixed: strict data comparison on several rules
* Updated: empty heading tag rule to consider aria-label