### PR TITLE
When readability score is 0 use `N/A` instead of `0th`

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -152,7 +152,7 @@ class Ajax {
 			<div class="edac-summary-readability-level">
 				<div><img src="' . EDAC_PLUGIN_URL . 'assets/images/readability icon navy.png" alt="" width="54"></div>
 				<div class="edac-panel-number' . ( ( (int) $summary['content_grade'] <= 9 || 'none' === $simplified_summary_prompt ) ? ' passed-text-color' : ' failed-text-color' ) . '">
-					' . $summary['readability'] . '
+					' . ( 0 === (int) $summary['readability'] ? esc_html__( 'N/A', 'accessibility-checker' ) : esc_html( $summary['readability'] ) ) . '
 				</div>
 				<div class="edac-panel-number-label' . ( ( (int) $summary['readability'] <= 9 || 'none' === $simplified_summary_prompt ) ? ' passed-text-color' : ' failed-text-color' ) . '">Reading <br />Level</div>
 			</div>


### PR DESCRIPTION
The summary display was showing 0th as readability score when check-able content was empty. This PR swaps to showing `N/A` instead of `0th` when that is the case.

![Screenshot from 2024-05-06 15-07-49](https://github.com/equalizedigital/accessibility-checker/assets/3902039/570176f0-8d71-457a-a7bf-34f9d16c1ee2)

Fixes #604 