### PR TITLE
Add a formatted cached at time to the summary data for the widget

### DIFF
--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -317,6 +317,8 @@ class Scans_Stats {
 		$formatting['passed_percentage_formatted']            = Helpers::format_percentage( $data['passed_percentage'] );
 		$formatting['avg_issue_density_percentage_formatted'] = Helpers::format_percentage( $data['avg_issue_density_percentage'] );
 
+		$formatting['cached_at_formatted'] = Helpers::format_date( $data['cached_at'], true );
+
 		$data = array_merge( $data, $formatting );
 
 		if ( $data['posts_scanned'] > 0 ) {

--- a/admin/class-welcome-page.php
+++ b/admin/class-welcome-page.php
@@ -207,7 +207,7 @@ class Welcome_Page {
 							<div class="edac-inner-row">
 								<?php if ( $summary['fullscan_completed_at'] > 0 ) : ?>
 									<div class="edac-stat-number edac-timestamp-to-local">
-										<?php echo esc_html( $summary['fullscan_completed_at_formatted'] ); ?>
+										<?php echo isset( $summary['cached_at_formatted'] ) ? esc_html( $summary['cached_at_formatted'] ) : esc_html( $summary['fullscan_completed_at_formatted'] ); ?>
 									</div>
 								<?php else : ?>
 									<div class="edac-stat-number">

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -709,26 +709,10 @@ const fillDashboardWidget = () => {
 						passedPercentageFormatted;
 				}
 
-				// Set completedAt
-				const completedAt = data.stats.fullscan_completed_at;
-				const completedAtFormatted =
-					data.stats.fullscan_completed_at_formatted;
-				const completedAtEl = document.querySelector(
-					'#edac-summary-info-date'
-				);
-				completedAtEl.textContent = completedAtFormatted;
-
-				/*
-      const expires_at = data.stats.expires_at;
-      const now = Date.now();
-      const mins_to_exp = Math.round((expires_at - Math.floor(now / 1000))/60);
-      const cache_hit = data.stats.cache_hit;
-      if(completedAtEl && completedAt){
-        completedAtEl.textContent = completedAt;
-        completedAtEl.setAttribute('data-edac-cache-hit', cache_hit);
-        completedAtEl.setAttribute('data-edac-cache-mins-to-expiration', mins_to_exp + ' minutes');
-      }
-      */
+				// Set the summary cached at time for display in the dashboard widget.
+				const summaryCachedAt = data.stats.cached_at_formatted || data.stats.fullscan_completed_at_formatted;
+				const summaryCachedAtEl = document.getElementById( 'edac-summary-info-date' );
+				summaryCachedAtEl.textContent = summaryCachedAt;
 
 				// scanned
 				const postsScanned = data.stats.posts_scanned;


### PR DESCRIPTION
The summary widgets in the main dashboard page and the main accessibility checker page was showing a date that was the last fullsite scan completion time. That was probably ideal when we were using cron to scan the site each day - but now that full site scanning is manual run only it no longer makes sense.

Swapping to using a formatted date from the cache_time of the summary data. I put a fallback in place for the old value for back compat reasons. 