### PR TITLE
Remove the artefact upload step from the deploy workflow

### DIFF
--- a/.github/workflows/deploy-on-release-to-dot-org.yml
+++ b/.github/workflows/deploy-on-release-to-dot-org.yml
@@ -45,14 +45,3 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           BUILD_DIR: ./dist/${{ github.event.repository.name }}/
-
-      - name: Upload release asset
-        if: github.event.release # can only run in context of a release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ steps.dist-build.outputs.zip-path }}
-          asset_name: ${{ github.event.repository.name }}.zip
-          asset_content_type: application/zip


### PR DESCRIPTION
This artefact was to be uploaded to the release but it doesn't work as intended so it can be a manual step for the moment