### PR TITLE
Rule Viewable

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -415,7 +415,7 @@ class Ajax {
 
 						$html .= '<button class="edac-details-rule-records-record-actions-ignore' . $ignore_class . '" aria-expanded="false" aria-controls="edac-details-rule-records-record-ignore-' . $row['id'] . '">' . EDAC_SVG_IGNORE_ICON . '<span class="edac-details-rule-records-record-actions-ignore-label">' . $ignore_label . '</span></button>';
 
-						if ( 'missing_headings' !== $rule['slug'] ) {
+						if ( ! isset( $rule['viewable'] ) || $rule['viewable'] ) {
 
 							$url = add_query_arg(
 								[

--- a/includes/rules.php
+++ b/includes/rules.php
@@ -98,6 +98,7 @@ return [
 			'<code>&lt;h1&gt;</code>',
 			'<code>&lt;h6&gt;</code>'
 		),
+		'viewable'  => false,
 	],
 	[
 		'title'     => esc_html__( 'Text Justified', 'accessibility-checker' ),
@@ -428,5 +429,6 @@ return [
 		'summary'   => esc_html__( 'Zooming is disabled via viewport meta tag that includes `user-scalable=no` or a `maximum-scale` value of less than 2. This limits low-vision users that want to increase text sizes, zoom into the page or who use a magnifier.', 'accessibility-checker' ),
 		'ruleset'   => 'js',
 		'combines'  => [ 'meta-viewport' ],
+		'viewable'  => false,
 	],
 ];


### PR DESCRIPTION
This PR adds a `boolean` item to the rules array called `viewable`. This can be used to control if the "View on page" should be displayed.

- Added: `viewable` item set to false to rules array for `missing_headings` and `meta_viewport`.
- Updated: conditional logic on the details panel