### PR TITLE
Don't flag missing iframe title if it's display: none and visibility: hidden

### DIFF
--- a/includes/rules/iframe_missing_title.php
+++ b/includes/rules/iframe_missing_title.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase -- underscore is for valid function name.
 /**
- * Accessibility Checker pluign file.
+ * Accessibility Checker plugin file.
  *
  * @package Accessibility_Checker
  */
@@ -20,6 +20,11 @@ function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore -- 
 
 	foreach ( $iframe_tags as $iframe ) {
 		if ( isset( $iframe ) && empty( $iframe->getAttribute( 'title' ) ) && empty( $iframe->getAttribute( 'aria-label' ) ) ) {
+
+			$display_none_and_visibility_hidden = preg_match( '/(?=.*display\s*:\s*none)(?=.*visibility\s*:\s*hidden)/is', $iframe->getAttribute( 'style' ) );
+			if ( $display_none_and_visibility_hidden ) {
+				continue;
+			}
 
 			$iframecode = htmlspecialchars( $iframe->outertext );
 


### PR DESCRIPTION
This PR adds a check for `display:none` and `visibility: hidden` before determining if it should create an issue for an iframe. Google tag manager iframe should no longer create noise with this change since it has both.

Closes: #184 