### PR TITLE
Check for `typeof` 'number' instead of `instanceof Number`

### DIFF
--- a/src/pageScanner/helpers/helpers.js
+++ b/src/pageScanner/helpers/helpers.js
@@ -4,5 +4,5 @@ export const fontSizeInPx = ( node ) => {
 	}
 
 	const fontSize = parseFloat( window.getComputedStyle( node ).fontSize );
-	return fontSize instanceof Number ? fontSize : 0;
+	return typeof fontSize === 'number' ? fontSize : 0;
 };


### PR DESCRIPTION
Fixes an issue introduced in last merges with the helper to get fontsize