### PR TITLE
Only consider possible heading if the tag wraps the entire text content

### DIFF
--- a/src/pageScanner/checks/paragraph-styled-as-header.js
+++ b/src/pageScanner/checks/paragraph-styled-as-header.js
@@ -40,9 +40,15 @@ export default {
 		const fontStyle = style.getPropertyValue( 'font-style' );
 		const isItalic = [ 'italic', 'oblique' ].includes( fontStyle );
 
-		const hasBoldOrItalicTag = node.querySelector( 'b, strong, i, em' ) !== null;
+		let wrappedByBoldOrItalicTag = false;
+		const boldOrItalicTags = node.querySelectorAll( 'b, strong, i, em' );
+		boldOrItalicTags.forEach( ( tag ) => {
+			if ( tag.textContent === node.textContent ) {
+				wrappedByBoldOrItalicTag = true;
+			}
+		} );
 
-		if ( isBold || isItalic || hasBoldOrItalicTag ) {
+		if ( isBold || isItalic || wrappedByBoldOrItalicTag ) {
 			return true;
 		}
 


### PR DESCRIPTION
Links that are modified by the New Window Warning plugin contain an `<i>` tag, which highlighted the possible header check was checking the containing tags incorrectly. This PR updates it to check if the tag wraps the entire text instead of simply checking it exists inside the scanned node.

Fixes: #652 