### PR TITLE
Don't operate on JS rules when doing rulecheck for php ruleset

### DIFF
--- a/includes/validate.php
+++ b/includes/validate.php
@@ -250,16 +250,19 @@ function edac_validate( $post_ID, $post, $action ) {
 function edac_remove_corrected_posts( $post_ID, $type, $pre = 1, $ruleset = 'php' ) {
 	global $wpdb;
 
-	$rules      = edac_register_rules();
-	$rule_slugs = [];
+	$rules          = edac_register_rules();
+	$js_rule_slugs  = [];
+	$php_rule_slugs = [];
+	// Separate the JS rules and the PHP rules.
 	foreach ( $rules as $rule ) {
-		if ( 'js' === $ruleset && isset( $rule['ruleset'] ) && 'js' === $rule['ruleset'] ) {
-			$rule_slugs[] = $rule['slug'];
-		} elseif ( 'js' !== $ruleset && ( ! isset( $rule['ruleset'] ) || 'js' !== $rule['ruleset'] ) ) {
-			$rule_slugs[] = $rule['slug'];
+		if ( isset( $rule['ruleset'] ) && 'js' === $rule['ruleset'] ) {
+			$js_rule_slugs[] = $rule['slug'];
+		} else {
+			$php_rule_slugs[] = $rule['slug'];
 		}
 	}
-
+	// Operate only on the slugs for the ruleset we are checking in this call.
+	$rule_slugs = 'js' === $ruleset ? $js_rule_slugs : $php_rule_slugs;
 	if ( 0 === count( $rule_slugs ) ) {
 		return;
 	}

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -255,7 +255,7 @@ function edac_remove_corrected_posts( $post_ID, $type, $pre = 1, $ruleset = 'php
 	foreach ( $rules as $rule ) {
 		if ( 'js' === $ruleset && isset( $rule['ruleset'] ) && 'js' === $rule['ruleset'] ) {
 			$rule_slugs[] = $rule['slug'];
-		} elseif ( 'js' !== $ruleset ) {
+		} elseif ( 'js' !== $ruleset && ( ! isset( $rule['ruleset'] ) || 'js' !== $rule['ruleset'] ) ) {
 			$rule_slugs[] = $rule['slug'];
 		}
 	}


### PR DESCRIPTION
This PR makes a change that excludes the JS rules from the PHP rule check flow when a post is updated. It prevents any JS rule issues from being deleted from the database at the end of the PHP scan (they will still be deleted if corrected when the JS scan runs).

This solves the issue reported that specific ignored issues (investigating, I found that it was all JS rules subject to this bug) would return when posts were updated and no longer be ignored.

Fixes: #655 