### PR TITLE
Allow frontend highlighter position to be moved from right to left of screen

### DIFF
--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -78,12 +78,13 @@ class Enqueue_Frontend {
 				'edac-frontend-highlighter-app',
 				'edacFrontendHighlighterApp',
 				[
-					'postID'    => $post_id,
-					'nonce'     => wp_create_nonce( 'ajax-nonce' ),
-					'edacUrl'   => esc_url_raw( get_site_url() ),
-					'ajaxurl'   => admin_url( 'admin-ajax.php' ),
-					'loggedIn'  => is_user_logged_in(),
-					'appCssUrl' => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,
+					'postID'         => $post_id,
+					'nonce'          => wp_create_nonce( 'ajax-nonce' ),
+					'edacUrl'        => esc_url_raw( get_site_url() ),
+					'ajaxurl'        => admin_url( 'admin-ajax.php' ),
+					'loggedIn'       => is_user_logged_in(),
+					'appCssUrl'      => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,
+					'widgetPosition' => get_option( 'edac_frontend_highlighter_position', 'right' ),
 				]
 			);
 

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -111,6 +111,13 @@ function edac_register_setting() {
 		'edac_settings'
 	);
 
+	add_settings_section(
+		'edac_frontend_highlighter',
+		__( 'Frontend Accessibility Checker', 'accessibility-checker' ),
+		'edac_frontend_highlighter_section_cb',
+		'edac_settings'
+	);
+
 	// Add fields.
 	add_settings_field(
 		'edac_post_types',
@@ -184,6 +191,16 @@ function edac_register_setting() {
 		[ 'label_for' => 'edac_accessibility_statement_preview' ]
 	);
 
+	add_settings_field(
+		'edac_frontend_highlighter_position',
+		__( 'Frontend Accessibility Checker Position', 'accessibility-checker' ),
+		'edac_frontend_highlighter_position_cb',
+		'edac_settings',
+		'edac_frontend_highlighter',
+		[ 'label_for' => 'edac_frontend_highlighter_position' ]
+	);
+
+
 	// Register settings.
 	register_setting( 'edac_settings', 'edac_post_types', 'edac_sanitize_post_types' );
 	register_setting( 'edac_settings', 'edac_delete_data', 'edac_sanitize_checkbox' );
@@ -208,6 +225,8 @@ function edac_register_setting() {
 	register_setting( 'edac_settings', 'edac_add_footer_accessibility_statement', 'edac_sanitize_checkbox' );
 	register_setting( 'edac_settings', 'edac_include_accessibility_statement_link', 'edac_sanitize_checkbox' );
 	register_setting( 'edac_settings', 'edac_accessibility_policy_page', 'edac_sanitize_accessibility_policy_page' );
+
+	register_setting( 'edac_settings', 'edac_frontend_highlighter_position', 'edac_sanitize_frontend_highlighter_position' );
 }
 
 /**
@@ -230,6 +249,17 @@ function edac_general_cb() {
 		);
 	}
 
+	echo '</p>';
+}
+
+/**
+ * Render the copy used to explain the frontend highlighter section.
+ *
+ * @return void
+ */
+function edac_frontend_highlighter_section_cb() {
+	echo '<p>';
+	esc_html_e( 'Use the settings below to configure the frontend accessibility checker.', 'accessibility-checker' );
 	echo '</p>';
 }
 
@@ -286,6 +316,30 @@ function edac_simplified_summary_position_cb() {
 }
 
 /**
+ * Renders radio inputs for the frontend highlighter position option.
+ *
+ * @return void
+ */
+function edac_frontend_highlighter_position_cb() {
+	$position = get_option( 'edac_frontend_highlighter_position', 'right' );
+	?>
+		<fieldset>
+			<label>
+				<input type="radio" name="<?php echo 'edac_frontend_highlighter_position'; ?>" id="edac_frontend_highlighter_position" value="right" <?php checked( $position, 'right' ); ?>>
+				<?php esc_html_e( 'Bottom Right Corner (default)', 'accessibility-checker' ); ?>
+			</label>
+			<br>
+			<label>
+				<input type="radio" name="edac_frontend_highlighter_position" value="left" <?php checked( $position, 'left' ); ?>>
+				<?php esc_html_e( 'Bottom Left Corner', 'accessibility-checker' ); ?>
+			</label>
+			<br>
+		</fieldset>
+		<p class="edac-description"><?php echo esc_html__( 'Set where you would like the frontend accessibility checker to appear on the page.', 'accessibility-checker' ); ?></p>
+	<?php
+}
+
+/**
  * Sanitize the text position value before being saved to database
  *
  * @param array $position Position value.
@@ -296,6 +350,20 @@ function edac_sanitize_simplified_summary_position( $position ) {
 	if ( in_array( $position, [ 'before', 'after', 'none' ], true ) ) {
 		return $position;
 	}
+}
+
+/**
+ * Sanitize the frontend highlighter position value before being saved to database.
+ *
+ * @param string $position the position to save. Can only be 'right' or 'left'.
+ *
+ * @return string
+ */
+function edac_sanitize_frontend_highlighter_position( string $position ): string {
+	if ( in_array( $position, [ 'right', 'left' ], true ) ) {
+		return $position;
+	}
+	return 'right';
 }
 
 /**

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -335,8 +335,10 @@ class AccessibilityCheckerHighlight {
 	 * This function adds a new div element to the DOM, which contains the accessibility checker panel.
 	 */
 	addHighlightPanel() {
+		const widgetPosition = edacFrontendHighlighterApp.widgetPosition || 'right';
+
 		const newElement = `
-			<div id="edac-highlight-panel" class="edac-highlight-panel">
+			<div id="edac-highlight-panel" class="edac-highlight-panel edac-highlight-panel--${ widgetPosition }">
 			<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="Accessibility Checker Tools"></button>
 			<div id="edac-highlight-panel-description" class="edac-highlight-panel-description" role="dialog" aria-labelledby="edac-highlight-panel-description-title" tabindex="0">
 			<button class="edac-highlight-panel-description-close edac-highlight-panel-controls-close" aria-label="Close">×</button>

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -16,16 +16,16 @@ body {
 .edac-highlight {
 
     all: unset;
-   
+
     * {
         all: unset;
     }
 
-    
+
     display: inline-block;
     clear: both;
 
-   
+
     &-element-selected{
         outline: dashed 4px transparent !important;
         outline-offset: 5px !important;
@@ -33,7 +33,7 @@ body {
 
         &-min-width {
             min-width: 25px !important;
-            display: inline-block !important;    
+            display: inline-block !important;
         }
         &-min-height {
             min-height: 16px !important;
@@ -61,33 +61,40 @@ body {
         &-ignored{
             background: transparent url("../images/highlight-icon-ignored.svg") center center no-repeat !important;
         }
-       
+
         &-selected, &:hover, &:focus {
            outline: solid 5px rgba(0,208,255,.75) !important;
         }
     }
     &-panel{
-        
+
         * {
             all: unset;
         }
 
-        a:not(.edac-highlight-panel-description-reference) { 
-            all: revert !important; 
+        a:not(.edac-highlight-panel-description-reference) {
+            all: revert !important;
             color: $color-white !important;
         }
-       
+
         width: auto;
         max-width: 400px !important;
         position: fixed !important;
-        bottom: 15px !important;
-        right: 15px !important;
         z-index: 2147483647 !important;
-       
+		bottom: 15px !important;
+
+		&--right {
+			right: 15px !important;
+		}
+
+		&--left {
+			left: 15px !important;
+		}
+
         &-visible {
             width: 400px !important;
         }
-    
+
         &-toggle{
             width: 50px !important;
             height: 50px !important;
@@ -100,7 +107,7 @@ body {
             float: right !important;
             &:hover, &:focus {
                 cursor: pointer !important;
-                outline: solid 5px rgba(0,208,255,.75) !important; 
+                outline: solid 5px rgba(0,208,255,.75) !important;
             }
         }
         &-description {
@@ -276,7 +283,7 @@ body {
                     &:disabled {
                         display: none !important;
                     }
-                
+
                 }
             }
             .edac-highlight-disable-styles{
@@ -297,7 +304,7 @@ body {
             .edac-highlight-panel-controls-buttons {
              //   display: flex !important;
                 justify-content: space-around;
-                
+
                 button {
                     padding: 4px 7px !important;
                     margin-right: 0px !important;
@@ -305,13 +312,13 @@ body {
             }
 
         }
-   
+
         @media screen and (max-width: calc($extra-small-screen-width ) ) {
 
             .edac-highlight-panel-controls-buttons {
                 display: flex !important;
                 justify-content: space-around;
-                
+
                 button {
                     padding: 4px 7px !important;
                     margin-right: 0px !important;
@@ -319,7 +326,7 @@ body {
             }
 
         }
-   
+
     }
 }
 


### PR DESCRIPTION
This PR adds a setting that allows people to set the side that the frontend highlighter appears when viewing pages.

It only offers right or left as options. The 3rd option requested (in the admin bar) would require a bigger refactor of the logic for the UI and didn't seem feasible to do quickly.

There are future plans to move the widget to be a sidebar element instead so this change is just a stopgap to prevent our widget interfering with other widget bubbles in the lower right corner on some sites.