### PR TITLE
Check all child nodes inside a paragraph rather than just the first

### DIFF
--- a/src/pageScanner/checks/paragraph-not-empty.js
+++ b/src/pageScanner/checks/paragraph-not-empty.js
@@ -12,8 +12,8 @@ export default {
 			return true;
 		}
 
-		// Pass if there are child nodes and the first child is not a text node (notType of 3).
-		if ( node.childNodes.length && node.childNodes[ 0 ].nodeType !== 3 ) {
+		// Pass if there are child nodes and any child nodes are not text nodes (not Type of 3).
+		if ( node.childNodes.length && Array.from( node.childNodes ).some( ( child ) => child.nodeType !== 3 ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
This PR changes the empty paragraph check to look at all child nodes rather than just the first.

When the check was added, I assumed the first child node would not be just whitespace. This allowed unexpected failures when the first element was a space.

Fixes: #666 