### PR TITLE
Add filter to allow frontend highlighter to be shown to other users

### DIFF
--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -36,7 +36,7 @@ class Frontend_Highlight {
 		 * highlighter. You can use the filter to perform additional permission checks
 		 * on who can see it.
 		 *
-		 * @since 1.4.0
+		 * @since 1.14.0
 		 *
 		 * @param bool $visibility The visibility of the frontend highlighter. Default is false, return true to show the frontend highlighter.
 		 */

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -36,7 +36,7 @@ class Frontend_Highlight {
 		 * highlighter. You can use the filter to perform additional permission checks
 		 * on who can see it.
 		 *
-		 * @since 1.x.x
+		 * @since 1.4.0
 		 *
 		 * @param bool $visibility The visibility of the frontend highlighter. Default is false, return true to show the frontend highlighter.
 		 */

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -27,6 +27,9 @@ class Frontend_Highlight {
 	 */
 	public function init_hooks() {
 		add_action( 'wp_ajax_edac_frontend_highlight_ajax', [ $this, 'ajax' ] );
+		if ( apply_filters( 'edac_filter_frontend_highlighter_visibility', false ) ) {
+			add_action( 'wp_ajax_nopriv_edac_frontend_highlight_ajax', [ $this, 'ajax' ] );
+		}
 	}
 
 	/**

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -27,7 +27,21 @@ class Frontend_Highlight {
 	 */
 	public function init_hooks() {
 		add_action( 'wp_ajax_edac_frontend_highlight_ajax', [ $this, 'ajax' ] );
+
+		/**
+		 * Filter the visibility of the frontend highlighter.
+		 *
+		 * 'edac_filter_frontend_highlighter_visibility' is a filter that can be used
+		 * to allow users without edit permissions on the post to see the frontend
+		 * highlighter. You can use the filter to perform additional permission checks
+		 * on who can see it.
+		 *
+		 * @since 1.x.x
+		 *
+		 * @param bool $visibility The visibility of the frontend highlighter. Default is false, return true to show the frontend highlighter.
+		 */
 		if ( apply_filters( 'edac_filter_frontend_highlighter_visibility', false ) ) {
+			// A nopriv endpoint allows logged-out users to access the endpoint.
 			add_action( 'wp_ajax_nopriv_edac_frontend_highlight_ajax', [ $this, 'ajax' ] );
 		}
 	}

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -61,6 +61,18 @@ class Enqueue_Frontend {
 		if (
 			is_customize_preview() ||
 			(
+				/**
+				 * Filter the visibility of the frontend highlighter.
+				 *
+				 * 'edac_filter_frontend_highlighter_visibility' is a filter that can be used
+				 * to allow users without edit permissions on the post to see the frontend
+				 * highlighter. You can use the filter to perform additional permission checks
+				 * on who can see it.
+				 *
+				 * @since 1.x.x
+				 *
+				 * @param bool $visibility The visibility of the frontend highlighter. Default is false, return true to show the frontend highlighter.
+				 */
 				! apply_filters( 'edac_filter_frontend_highlighter_visibility', false ) &&
 				! ( $post_id && current_user_can( 'edit_post', $post_id ) )
 			)

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -37,7 +37,7 @@ class Enqueue_Frontend {
 		// This loads on all pages, so bail as early as possible. Do checks that don't require DB calls first.
 
 
-		// Don't load on admin pages in iframe that is running a pageScan.
+		// Don't load on admin pages or in an iframe that is running a pageScan.
 		if (
 			is_admin() ||
 			(
@@ -48,7 +48,7 @@ class Enqueue_Frontend {
 			return;
 		}
 
-		// Don't load on customizer pages or if the user is not able to edit this page.
+		// Don't load on the frontend if we don't have a post to work with.
 		global $post;
 		$post_id = is_object( $post ) ? $post->ID : null;
 
@@ -56,8 +56,15 @@ class Enqueue_Frontend {
 			return;
 		}
 
-		// Dont load if the user is not able to edit this page or if we are in a customizer preview.
-		if ( is_customize_preview() || ! ( $post_id && current_user_can( 'edit_post', $post_id ) ) ) {
+		// Don't load in a customizer preview or user can't edit the page. A filter
+		// can override the edit requirement to allow anyone to see it.
+		if (
+			is_customize_preview() ||
+			(
+				! apply_filters( 'edac_filter_frontend_highlighter_visibility', false ) &&
+				! ( $post_id && current_user_can( 'edit_post', $post_id ) )
+			)
+		) {
 			return;
 		}
 

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -69,7 +69,7 @@ class Enqueue_Frontend {
 				 * highlighter. You can use the filter to perform additional permission checks
 				 * on who can see it.
 				 *
-				 * @since 1.x.x
+				 * @since 1.4.0
 				 *
 				 * @param bool $visibility The visibility of the frontend highlighter. Default is false, return true to show the frontend highlighter.
 				 */

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -69,7 +69,7 @@ class Enqueue_Frontend {
 				 * highlighter. You can use the filter to perform additional permission checks
 				 * on who can see it.
 				 *
-				 * @since 1.4.0
+				 * @since 1.14.0
 				 *
 				 * @param bool $visibility The visibility of the frontend highlighter. Default is false, return true to show the frontend highlighter.
 				 */


### PR DESCRIPTION
This PR adds a filter (used in 2 places) that will allow a site owner to choose to output the frontend highlighter to people, even those without edit_post permissions on the currently viewed post.

TODO: update the `since` tag in the filter docs if we schedule this to go out in a specific release.

Usage example:
``` PHP
/*
 * Returning True allows the current visitor to see the highlighter.
 *
 * Default value is false. You can use a function instead to perform
 * more fine-grained checks as per your needs.
 */
add_filter('edac_filter_frontend_highlighter_visibility', '__return_true');
```

Closes: #669 