### PR TITLE
Added max width to issue image/svg

### DIFF
--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -621,7 +621,12 @@
               word-break: break-word;
             }
 
-            &-image {}
+            &-image {
+              img, svg {
+                max-width: 100%;
+                height: auto;
+              }
+            }
 
             &-actions {
               border-right: none;


### PR DESCRIPTION
This PR adds a max width of 100% to the issue image/svg to prevent it from breaking outside the column.

<img width="723" alt="Screenshot 2024-06-19 at 9 47 11 PM" src="https://github.com/equalizedigital/accessibility-checker/assets/2895788/511e1023-6a63-4f66-bc58-0cd5e5a08ab9">

Fixes #111