### PR TITLE
Summary panel a11y

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -100,54 +100,56 @@ class Ajax {
 			}
 		}
 
-		$html['content'] .= '<div class="edac-summary-total">';
+		$html['content'] .= '<ul>';
+		
+			$html['content'] .= '<li class="edac-summary-total" aria-label="' . $summary['passed_tests'] . '% Passed Tests">';
 
-		$html['content'] .= '<div class="edac-summary-total-progress-circle ' . ( ( $summary['passed_tests'] > 50 ) ? ' over50' : '' ) . '">
-			<div class="edac-summary-total-progress-circle-label">
-				<div class="edac-panel-number">' . $summary['passed_tests'] . '%</div>
-				<div class="edac-panel-number-label">Passed Tests<sup>*</sup></div>
-			</div>
-			<div class="left-half-clipper">
-				<div class="first50-bar"></div>
-				<div class="value-bar" style="transform: rotate(' . $summary['passed_tests'] * 3.6 . 'deg);"></div>
-			</div>
-		</div>';
+				$html['content'] .= '<div class="edac-summary-total-progress-circle ' . ( ( $summary['passed_tests'] > 50 ) ? ' over50' : '' ) . '">
+					<div class="edac-summary-total-progress-circle-label">
+						<div class="edac-panel-number">' . $summary['passed_tests'] . '%</div>
+						<div class="edac-panel-number-label">Passed Tests<sup>*</sup></div>
+					</div>
+					<div class="left-half-clipper">
+						<div class="first50-bar"></div>
+						<div class="value-bar" style="transform: rotate(' . $summary['passed_tests'] * 3.6 . 'deg);"></div>
+					</div>
+				</div>';
 
-		$html['content'] .= '<div class="edac-summary-total-mobile">
-			<div class="edac-panel-number">' . $summary['passed_tests'] . '%</div>
-			<div class="edac-panel-number-label">Passed Tests<sup>*</sup></div>
-			<div class="edac-summary-total-mobile-bar"><span style="width:' . ( $summary['passed_tests'] ) . '%;"></span></div>
-		</div>';
+				$html['content'] .= '<div class="edac-summary-total-mobile">
+					<div class="edac-panel-number">' . $summary['passed_tests'] . '%</div>
+					<div class="edac-panel-number-label">Passed Tests<sup>*</sup></div>
+					<div class="edac-summary-total-mobile-bar"><span style="width:' . ( $summary['passed_tests'] ) . '%;"></span></div>
+				</div>';
 
-		$html['content'] .= '</div>';
+			$html['content'] .= '</li>';
 
-		$html['content'] .= '
-		<div class="edac-summary-stats">
-			<div class="edac-summary-stat edac-summary-errors' . ( ( $summary['errors'] > 0 ) ? ' has-errors' : '' ) . '">
-				<div class="edac-panel-number">
-					' . $summary['errors'] . '
-				</div>
-				<div class="edac-panel-number-label">Error' . ( ( 1 !== $summary['errors'] ) ? 's' : '' ) . '</div>
+			$html['content'] .= '<div class="edac-summary-stats">
+				' . edac_generate_summary_stat(
+				'edac-summary-errors',
+				$summary['errors'],
+				/* translators: %s: Number of errors */
+					sprintf( _n( '%s Error', '%s Errors', $summary['errors'], 'accessibility-checker' ), $summary['errors'] )
+			) . '
+				' . edac_generate_summary_stat(
+				'edac-summary-contrast',
+				$summary['contrast_errors'],
+				/* translators: %s: Number of contrast errors */
+					sprintf( _n( '%s Contrast Error', '%s Contrast Errors', $summary['contrast_errors'], 'accessibility-checker' ), $summary['contrast_errors'] )
+			) . '
+				' . edac_generate_summary_stat(
+				'edac-summary-warnings',
+				$summary['warnings'],
+				/* translators: %s: Number of warnings */
+					sprintf( _n( '%s Warning', '%s Warnings', $summary['warnings'], 'accessibility-checker' ), $summary['warnings'] )
+			) . '
+				' . edac_generate_summary_stat(
+				'edac-summary-ignored',
+				$summary['ignored'],
+				/* translators: %s: Number of ignored items */
+					sprintf( _n( '%s Ignored Item', '%s Ignored Items', $summary['ignored'], 'accessibility-checker' ), $summary['ignored'] )
+			) . '
 			</div>
-			<div class="edac-summary-stat edac-summary-contrast' . ( ( $summary['contrast_errors'] > 0 ) ? ' has-errors' : '' ) . '">
-				<div class="edac-panel-number">
-					' . $summary['contrast_errors'] . '
-				</div>
-				<div class="edac-panel-number-label">Contrast Error' . ( ( 1 !== $summary['contrast_errors'] ) ? 's' : '' ) . '</div>
-			</div>
-			<div class="edac-summary-stat edac-summary-warnings' . ( ( $summary['warnings'] > 0 ) ? ' has-warning' : '' ) . '">
-				<div class="edac-panel-number">
-					' . $summary['warnings'] . '
-				</div>
-				<div class="edac-panel-number-label">Warning' . ( ( 1 !== $summary['warnings'] ) ? 's' : '' ) . '</div>
-			</div>
-			<div class="edac-summary-stat edac-summary-ignored">
-				<div class="edac-panel-number">
-					' . $summary['ignored'] . '
-				</div>
-				<div class="edac-panel-number-label">Ignored Item' . ( ( 1 !== $summary['ignored'] ) ? 's' : '' ) . '</div>
-			</div>
-		</div>
+		</ul>
 		<div class="edac-summary-readability">
 			<div class="edac-summary-readability-level">
 				<div><img src="' . EDAC_PLUGIN_URL . 'assets/images/readability icon navy.png" alt="" width="54"></div>

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -107,7 +107,7 @@ class Ajax {
 				$html['content'] .= '<div class="edac-summary-total-progress-circle ' . ( ( $summary['passed_tests'] > 50 ) ? ' over50' : '' ) . '">
 					<div class="edac-summary-total-progress-circle-label">
 						<div class="edac-panel-number">' . $summary['passed_tests'] . '%</div>
-						<div class="edac-panel-number-label">Passed Tests<sup>*</sup></div>
+						<div class="edac-panel-number-label">Passed Tests<sup><a href="#edac-summary-disclaimer" aria-label="About passed tests.">*</a></sup></div>
 					</div>
 					<div class="left-half-clipper">
 						<div class="first50-bar"></div>
@@ -117,7 +117,7 @@ class Ajax {
 
 				$html['content'] .= '<div class="edac-summary-total-mobile">
 					<div class="edac-panel-number">' . $summary['passed_tests'] . '%</div>
-					<div class="edac-panel-number-label">Passed Tests<sup>*</sup></div>
+					<div class="edac-panel-number-label">Passed Tests<sup><a href="#edac-summary-disclaimer" aria-label="About passed tests.">*</a></sup></div>
 					<div class="edac-summary-total-mobile-bar"><span style="width:' . ( $summary['passed_tests'] ) . '%;"></span></div>
 				</div>';
 
@@ -163,7 +163,7 @@ class Ajax {
 				<div class="edac-summary-readability-summary-text' . ( ( ( 'none' === $simplified_summary_prompt || $summary['simplified_summary'] || (int) $summary['content_grade'] <= 9 ) && ! $simplified_summary_grade_failed ) ? ' active' : '' ) . '">' . $simplified_summary_text . '</div>
 			</div>
 		</div>
-		<div class="edac-summary-disclaimer"><small>* True accessibility requires manual testing in addition to automated scans. <a href="https://a11ychecker.com/help4280">Learn how to manually test for accessibility</a>.</small></div>
+		<div id="edac-summary-disclaimer" class="edac-summary-disclaimer"><small>* True accessibility requires manual testing in addition to automated scans. <a href="https://a11ychecker.com/help4280">Learn how to manually test for accessibility</a>.</small></div>
 		';
 
 		if ( ! $html ) {

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -967,3 +967,26 @@ function edac_get_file_opened_as_binary( string $filename ) {
 
 	return $fh;
 }
+
+/**
+ * Generate a summary statistic list item.
+ * 
+ * @since 1.14.0
+ *
+ * @param string $item_class     The base CSS class for the list item.
+ * @param int    $count     The count of items to display.
+ * @param string $label      The translated label with count included.
+ *
+ * @return string The generated HTML list item.
+ */
+function edac_generate_summary_stat( string $item_class, int $count, string $label ): string {
+	$has_error_class = ( $count > 0 ) ? ' has-errors' : '';
+
+	return '
+        <li class="edac-summary-stat ' . $item_class . $has_error_class . '" aria-label="' . $label . '">
+            <div class="edac-panel-number">
+                ' . $count . '
+            </div>
+            <div class="edac-panel-number-label">' . $label . '</div>
+        </li>';
+}

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -338,34 +338,38 @@
         &:nth-child(4) {
           margin-right: 0;
         }
-
-        &.has-errors {
-          background-color: $color-red;
-        }
-
-        &.has-warning {
-          color: $color-blue-dark;
-          background-color: $color-yellow;
-          background-image: url("../images/warning icon navy.png");
-        }
       }
 
       &-errors {
         color: $color-white;
         background-color: $color-green;
         background-image: url("../images/error icon white.png");
+
+        &.has-errors {
+          background-color: $color-red;
+        }
       }
 
       &-contrast {
         color: $color-white;
         background-color: $color-green;
         background-image: url("../images/contrast icon white.png");
+
+        &.has-errors {
+          background-color: $color-red;
+        }
       }
 
       &-warnings {
         color: $color-white;
         background-color: $color-green;
         background-image: url("../images/warning icon white.png");
+
+        &.has-errors {
+          color: $color-blue-dark;
+          background-color: $color-yellow;
+          background-image: url("../images/warning icon navy.png");
+        }
       }
 
       &-ignored {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -204,19 +204,16 @@
           background-color: $color-gray-light;
           border-radius: 50%;
           line-height: $progress-circle-size;
-
-          /* Text inside the control */
-          //transform: scale(.7, .7);
           display: none;
-
-
+          a {
+            color: $color-dark-gray;
+            text-decoration: none;
+          }
           @include breakpoint(xs) {
             display: inline-block;
-            //transform: scale(1, 1);
           }
 
           @include breakpoint(xl) {
-            //transform: scale(1, 1);
           }
 
           &:after {


### PR DESCRIPTION
This PR updates the summary tiles to an unordered list with aria labels for improved a11y.

- Added helper class to output summary items as list items with aria labels.
- Update summary labels to be translatable.
- Update CSS logic
- Linked asterisk to description and added screen reader text

Fixes #359
Fixes #358