### PR TITLE
Add wp cli commands to get stats and delete stats

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,10 @@
         }
     },
     "autoload-dev": {
-        "classmap": []
+        "classmap": [],
+		"psr-4": {
+			"EqualizeDigital\\AccessibilityChecker\\Tests\\": "tests/phpunit/"
+		}
     },
     "scripts": {
         "lint": [

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "autoload-dev": {
         "classmap": [],
 		"psr-4": {
-			"EqualizeDigital\\AccessibilityChecker\\Tests\\": "tests/phpunit/"
+			"EqualizeDigital\\AccessibilityChecker\\Tests\\TestHelpers\\": "tests/phpunit/TestHelpers/"
 		}
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,10 @@
             "admin/",
             "includes/classes/",
             "includes/deprecated/"
-        ]
+        ],
+		"Psr-4": {
+			"EqualizeDigital\\AccessibilityChecker\\": "includes/classes/"
+		}
     },
     "autoload-dev": {
         "classmap": []

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
             "includes/classes/",
             "includes/deprecated/"
         ],
-		"Psr-4": {
+		"psr-4": {
 			"EqualizeDigital\\AccessibilityChecker\\": "includes/classes/"
 		}
     },

--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,9 @@
             "includes/classes/",
             "includes/deprecated/"
         ],
-		"psr-4": {
-			"EqualizeDigital\\AccessibilityChecker\\": "includes/classes/"
-		}
+        "psr-4": {
+            "EqualizeDigital\\AccessibilityChecker\\": "includes/classes/"
+        }
     },
     "autoload-dev": {
         "classmap": []

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -96,7 +96,7 @@ class BootstrapCLI {
 				$this->wp_cli::warning(
 					sprintf(
 						// translators: 1: a php classname, 2: an error message that was thrown about why this failed to register.
-						__( 'Failed to register command %1$s because %2$s', 'accessibility-checker' ),
+						esc_html__( 'Failed to register command %1$s because %2$s', 'accessibility-checker' ),
 						$command,
 						$e->getMessage()
 					)

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -24,6 +24,17 @@ use WP_CLI;
 class BootstrapCLI {
 
 	/**
+	 * The WP-CLI instance.
+	 *
+	 * This allows injecting a mock WP-CLI instance for testing.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @var WP_CLI
+	 */
+	private $wp_cli;
+
+	/**
 	 * The boot method on this class will use this array to register custom WP-CLI commands.
 	 *
 	 * @since 1.15.0
@@ -35,6 +46,17 @@ class BootstrapCLI {
 		GetSiteStats::class,
 		GetStats::class,
 	];
+
+	/**
+	 * Set up the internal wp_cli property.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @param WP_CLI|null $wp_cli The WP-CLI instance.
+	 */
+	public function __construct( $wp_cli = null ) {
+		$this->wp_cli = $wp_cli ? $wp_cli : new WP_CLI();
+	}
 
 	/**
 	 * Register the WP-CLI commands by looping through the commands array and adding each command.
@@ -65,17 +87,17 @@ class BootstrapCLI {
 			}
 
 			try {
-				WP_CLI::add_command(
+				$this->wp_cli::add_command(
 					$command::get_name(),
 					$command,
 					$command::get_args()
 				);
 			} catch ( Exception $e ) {
-				WP_CLI::warning(
+				$this->wp_cli::warning(
 					sprintf(
 						// translators: 1: a php classname, 2: an error message that was thrown about why this failed to register.
 						__( 'Failed to register command %1$s because %2$s', 'accessibility-checker' ),
-						get_class( $command ),
+						$command,
 						$e->getMessage()
 					)
 				);

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Bootstrap the CLI commands for the Accessibility Checker plugin.
+ *
+ * @since 1.15.0
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\WPCLI;
+
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\CLICommandInterface;
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\DeleteStats;
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\GetStats;
+use Exception;
+use WP_CLI;
+
+/**
+ * Handles the registration of WP-CLI commands for the Accessibility Checker plugin.
+ *
+ * @since 1.15.0
+ */
+class BootstrapCLI {
+
+	/**
+	 * The boot method on this class will use this array to register custom WP-CLI commands.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @var CLICommandInterface[]
+	 */
+	protected array $commands = [
+		GetStats::class,
+		DeleteStats::class,
+	];
+
+	/**
+	 * Register the WP-CLI commands by looping through the commands array and adding each command.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Bail if not running in WP_CLI.
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		/**
+		 * Filter the list of classes that hold the commands to be registered.
+		 *
+		 * @since 1.15.0
+		 *
+		 * @param CLICommandInterface[] $commands array of classes to register as commands.
+		 */
+		$commands = apply_filters( 'edac_filter_command_classes', $this->commands );
+
+		foreach ( $commands as $command ) {
+			// All commands must follow the interface.
+			if ( ! ( $command instanceof CLICommandInterface ) ) {
+				continue;
+			}
+
+			try {
+				WP_CLI::add_command(
+					$command::get_name(),
+					$command,
+					$command::get_args()
+				);
+			} catch ( Exception $e ) {
+				WP_CLI::warning( sprintf(
+					// translators: 1: a php classname, 2: an error message that was thrown about why this failed to register.
+					__( 'Failed to register command %1$s because %2$s', 'accessibility-checker' ),
+					get_class( $command ),
+					$e->getMessage()
+				) );
+			}
+		}
+	}
+}

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -58,7 +58,8 @@ class BootstrapCLI {
 
 		foreach ( $commands as $command ) {
 			// All commands must follow the interface.
-			if ( ! ( $command instanceof CLICommandInterface ) ) {
+			if ( ! is_subclass_of( $command, CLICommandInterface::class, true ) ) {
+				error_log('not a cli');
 				continue;
 			}
 

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -59,7 +59,6 @@ class BootstrapCLI {
 		foreach ( $commands as $command ) {
 			// All commands must follow the interface.
 			if ( ! is_subclass_of( $command, CLICommandInterface::class, true ) ) {
-				error_log('not a cli');
 				continue;
 			}
 

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -11,6 +11,7 @@ namespace EqualizeDigital\AccessibilityChecker\WPCLI;
 
 use EqualizeDigital\AccessibilityChecker\WPCLI\Command\CLICommandInterface;
 use EqualizeDigital\AccessibilityChecker\WPCLI\Command\DeleteStats;
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\GetSiteStats;
 use EqualizeDigital\AccessibilityChecker\WPCLI\Command\GetStats;
 use Exception;
 use WP_CLI;
@@ -30,8 +31,9 @@ class BootstrapCLI {
 	 * @var CLICommandInterface[]
 	 */
 	protected array $commands = [
-		GetStats::class,
 		DeleteStats::class,
+		GetSiteStats::class,
+		GetStats::class,
 	];
 
 	/**

--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -69,12 +69,14 @@ class BootstrapCLI {
 					$command::get_args()
 				);
 			} catch ( Exception $e ) {
-				WP_CLI::warning( sprintf(
-					// translators: 1: a php classname, 2: an error message that was thrown about why this failed to register.
-					__( 'Failed to register command %1$s because %2$s', 'accessibility-checker' ),
-					get_class( $command ),
-					$e->getMessage()
-				) );
+				WP_CLI::warning(
+					sprintf(
+						// translators: 1: a php classname, 2: an error message that was thrown about why this failed to register.
+						__( 'Failed to register command %1$s because %2$s', 'accessibility-checker' ),
+						get_class( $command ),
+						$e->getMessage()
+					)
+				);
 			}
 		}
 	}

--- a/includes/classes/WPCLI/Command/CLICommandInterface.php
+++ b/includes/classes/WPCLI/Command/CLICommandInterface.php
@@ -1,0 +1,40 @@
+<?php /* phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- WP_CLI doesn't follow WP method name rules */
+/**
+ * Interface CLICommandInterface
+ *
+ * @since 1.15.0
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\WPCLI\Command;
+
+/**
+ * Interface defining the methods required for a WP-CLI command to be bootstrapped by this plugin.
+ */
+interface CLICommandInterface {
+
+	/**
+	 * Get the name of the command
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string;
+
+	/**
+	 * Get the arguments for the command
+	 *
+	 * @return array
+	 */
+	public static function get_args(): array;
+
+	/**
+	 * Run the command
+	 *
+	 * @param array $options Positional args passed to the command.
+	 * @param array $arguments Associative args passed to the command.
+	 *
+	 * @return mixed
+	 */
+	public function __invoke( array $options = [], array $arguments = [] );
+}

--- a/includes/classes/WPCLI/Command/DeleteStats.php
+++ b/includes/classes/WPCLI/Command/DeleteStats.php
@@ -68,7 +68,7 @@ class DeleteStats implements CLICommandInterface {
 	}
 
 	/**
-	 * Run the command to delete stats for a given post id.
+	 * Delete the accessibility-checker stats for a given post ID.
 	 *
 	 * @param array $options This is the positional argument, the post ID in this case.
 	 * @param array $arguments This is the associative argument, not used in this command but kept for consistency with cli commands using this pattern.

--- a/includes/classes/WPCLI/Command/DeleteStats.php
+++ b/includes/classes/WPCLI/Command/DeleteStats.php
@@ -58,7 +58,7 @@ class DeleteStats implements CLICommandInterface {
 				[
 					'type'        => 'positional',
 					'name'        => 'post_id',
-					'description' => 'The ID of the post to delete stats for.',
+					'description' => esc_html__( 'The ID of the post to delete stats for.', 'accessibility-checker' ),
 					'optional'    => true,
 					'default'     => 0,
 					'repeating'   => false,
@@ -80,17 +80,29 @@ class DeleteStats implements CLICommandInterface {
 		$post_id = $options[0] ?? 0;
 
 		if ( 0 === $post_id ) {
-			$this->wp_cli::error( "No Post ID provided.\n" );
+			$this->wp_cli::error( esc_html__( 'No Post ID provided.', 'accessibility-checker' ) );
 		}
 
 		$post_exists = (bool) get_post( $post_id );
 
 		if ( ! $post_exists ) {
-			$this->wp_cli::error( "Post ID {$post_id} does not exist.\n" );
+			$this->wp_cli::error(
+				sprintf(
+					// translators: 1: a post ID.
+					esc_html__( 'Post ID %1$s does not exist.', 'accessibility-checker' ),
+					$post_id
+				)
+			);
 			return;
 		}
 
 		Purge_Post_Data::delete_post( $post_id );
-		$this->wp_cli::success( "Stats of {$post_id} deleted! \n" );
+		$this->wp_cli::success(
+			sprintf(
+				// translators: 1: a post ID.
+				esc_html__( 'Stats of %1$s deleted.', 'accessibility-checker' ),
+				$post_id
+			)
+		);
 	}
 }

--- a/includes/classes/WPCLI/Command/DeleteStats.php
+++ b/includes/classes/WPCLI/Command/DeleteStats.php
@@ -21,6 +21,24 @@ use WP_CLI\ExitException;
 class DeleteStats implements CLICommandInterface {
 
 	/**
+	 * The WP-CLI instance.
+	 *
+	 * This lets a mock be passed in for testing.
+	 *
+	 * @var mixed|WP_CLI
+	 */
+	private $wp_cli;
+
+	/**
+	 * GetStats constructor.
+	 *
+	 * @param mixed|WP_CLI $wp_cli The WP-CLI instance.
+	 */
+	public function __construct( $wp_cli = null ) {
+		$this->wp_cli = $wp_cli ?? new WP_CLI();
+	}
+
+	/**
 	 * Get the name of the command
 	 *
 	 * @return string
@@ -59,23 +77,20 @@ class DeleteStats implements CLICommandInterface {
 	 * @throws ExitException If the post ID is not provided, does not exist, or the class we need isn't available.
 	 */
 	public function __invoke( array $options = [], array $arguments = [] ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$post_id = $options[0] ?? null;
+		$post_id = $options[0] ?? 0;
 
 		if ( 0 === $post_id ) {
-			WP_CLI::error( "No Post ID provided, getting all stats not implemented yet.\n" );
+			$this->wp_cli::error( "No Post ID provided.\n" );
 		}
 
 		$post_exists = (bool) get_post( $post_id );
 
 		if ( ! $post_exists ) {
-			WP_CLI::error( "Post ID {$post_id} does not exist.\n" );
-		}
-
-		if ( class_exists( 'EDAC\Admin\Purge_Post_Data' ) === false ) {
-			WP_CLI::error( "Purge_Post_Data class not found, is Accessibility Checker installed and activated?\n" );
+			$this->wp_cli::error( "Post ID {$post_id} does not exist.\n" );
+			return;
 		}
 
 		Purge_Post_Data::delete_post( $post_id );
-		WP_CLI::success( "Stats of {$post_id} deleted! \n" );
+		$this->wp_cli::success( "Stats of {$post_id} deleted! \n" );
 	}
 }

--- a/includes/classes/WPCLI/Command/DeleteStats.php
+++ b/includes/classes/WPCLI/Command/DeleteStats.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Delete stats for a post.
+ *
+ * @since 1.15.0
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\WPCLI\Command;
+
+use EDAC\Admin\Purge_Post_Data;
+use WP_CLI;
+use WP_CLI\ExitException;
+
+/**
+ * Deletes stats for a given post ID.
+ *
+ * @package PattonWebz\AccessibilityCheckerCLI\Command
+ */
+class DeleteStats implements CLICommandInterface {
+
+	/**
+	 * Get the name of the command
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'accessibility-checker delete-stats';
+	}
+
+	/**
+	 * Get the arguments for the command
+	 *
+	 * @return array
+	 */
+	public static function get_args(): array {
+		return [
+			'synopsis' => [
+				[
+					'type'        => 'positional',
+					'name'        => 'post_id',
+					'description' => 'The ID of the post to delete stats for.',
+					'optional'    => true,
+					'default'     => 0,
+					'repeating'   => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Run the command to delete stats for a given post id.
+	 *
+	 * @param array $options This is the positional argument, the post ID in this case.
+	 * @param array $arguments This is the associative argument, not used in this command but kept for consistency with cli commands using this pattern.
+	 *
+	 * @return void
+	 * @throws ExitException If the post ID is not provided, does not exist, or the class we need isn't available.
+	 */
+	public function __invoke( array $options = [], array $arguments = [] ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$post_id = $options[0] ?? null;
+
+		if ( 0 === $post_id ) {
+			WP_CLI::error( "No Post ID provided, getting all stats not implemented yet.\n" );
+		}
+
+		$post_exists = (bool) get_post( $post_id );
+
+		if ( ! $post_exists ) {
+			WP_CLI::error( "Post ID {$post_id} does not exist.\n" );
+		}
+
+		if ( class_exists( 'EDAC\Admin\Purge_Post_Data' ) === false ) {
+			WP_CLI::error( "Purge_Post_Data class not found, is Accessibility Checker installed and activated?\n" );
+		}
+
+		Purge_Post_Data::delete_post( $post_id );
+		WP_CLI::success( "Stats of {$post_id} deleted! \n" );
+	}
+}

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -74,6 +74,7 @@ class GetSiteStats implements CLICommandInterface {
 					'name'        => 'clear-cache',
 					'description' => esc_html__( 'Clear the cache before retrieving the stats (can be intensive).', 'accessibility-checker' ),
 					'repeating'   => false,
+					'optional'    => true,
 				],
 			],
 		];

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -82,7 +82,7 @@ class GetSiteStats implements CLICommandInterface {
 	}
 
 	/**
-	 * Run the command that gets the stats for the whole site.
+	 * Gets the accessibility-checker stats for the whole site. Use the --clear-cache flag to clear the cache before retrieving the stats.
 	 *
 	 * @since 1.15.0
 	 *

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Get stats for the entire site.
+ *
+ * @since 1.15.0
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\WPCLI\Command;
+
+use EDAC\Admin\Scans_Stats;
+use WP_CLI;
+use WP_CLI\ExitException;
+
+/**
+ * Get stats for the entire site.
+ *
+ * @since 1.15.0
+ *
+ * @package AccessibilityCheckerCLI
+ */
+class GetSiteStats implements CLICommandInterface {
+
+	/**
+	 * Get the name of the command.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'accessibility-checker get-site-stats';
+	}
+
+	/**
+	 * Get the arguments for the command
+	 *
+	 * @since 1.15.0
+	 *
+	 * @return array
+	 */
+	public static function get_args(): array {
+		return [
+			'synopsis' => [
+				[
+					'type'        => 'assoc',
+					'name'        => 'stat',
+					'description' => 'Keys to show in the results. Defaults to all keys.',
+					'optional'    => true,
+					'default'     => null,
+					'repeating'   => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Run the command that gets the stats for the whole site.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @param array $options The positional argument, none is this case.
+	 * @param array $arguments The associative arguments, the stat keys in this case.
+	 *
+	 * @return void
+	 * @throws ExitException If the post ID does not exist, or the class we need isn't available.
+	 */
+	public function __invoke( array $options = [], array $arguments = [] ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$all_stats = $this->get_all_stats();
+
+		if ( ! empty( $arguments['stat'] ) ) {
+			$items_to_return = [];
+			$requested_stats = explode( ',', $arguments['stat'] );
+			foreach ( $requested_stats as $key ) {
+				$stats_key = trim( $key );
+				if ( ! isset( $all_stats[ $stats_key ] ) ) {
+					WP_CLI::error( "Stat key: {$stats_key} not found in stats." );
+				}
+				$items_to_return[ $stats_key ] = $all_stats[ $stats_key ];
+			}
+		}
+
+		if ( $items_to_return ) {
+			WP_CLI::success( wp_json_encode( $items_to_return, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		WP_CLI::success( wp_json_encode( $all_stats, JSON_PRETTY_PRINT ) );
+	}
+
+	/**
+	 * Gets the sites from the entire site.
+	 *
+	 * A limitation is this can only provide the stats for scanned pages, if
+	 * some pages are not scanned they are not reflected in the stats. Use the
+	 * 'scannable_posts_count' and the 'posts_scanned' values to determine if
+	 * the whole site is reflected or not.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @throws ExitException If ScanStats class is not found or no stats are found.
+	 */
+	private function get_all_stats(): array {
+
+		if ( class_exists( 'EDAC\Admin\Scans_Stats' ) === false ) {
+			WP_CLI::error( "Scans_Stats class not found, is Accessibility Checker installed and activated?.\n" );
+		}
+
+		$stats = ( new Scans_Stats() )->summary();
+
+		if ( empty( $stats ) ) {
+			WP_CLI::error( "No stats found.\n" );
+		}
+
+		return $stats;
+	}
+}

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -106,7 +106,7 @@ class GetSiteStats implements CLICommandInterface {
 			foreach ( $requested_stats as $key ) {
 				$stats_key = trim( $key );
 				if ( ! isset( $all_stats[ $stats_key ] ) ) {
-					WP_CLI::error( "Stat key: {$stats_key} not found in stats." );
+					$this->wp_cli::error( "Stat key: {$stats_key} not found in stats." );
 				}
 				$items_to_return[ $stats_key ] = $all_stats[ $stats_key ];
 			}

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -64,7 +64,7 @@ class GetSiteStats implements CLICommandInterface {
 				[
 					'type'        => 'assoc',
 					'name'        => 'stat',
-					'description' => 'Keys to show in the results. Defaults to all keys.',
+					'description' => esc_html__( 'Keys to show in the results. Defaults to all keys.', 'accessibility-checker' ),
 					'optional'    => true,
 					'default'     => null,
 					'repeating'   => true,
@@ -72,7 +72,7 @@ class GetSiteStats implements CLICommandInterface {
 				[
 					'type'        => 'assoc',
 					'name'        => 'clear-cache',
-					'description' => 'Clear the cache before retrieving the stats (can be intensive).',
+					'description' => esc_html__( 'Clear the cache before retrieving the stats (can be intensive).', 'accessibility-checker' ),
 					'optional'    => true,
 					'default'     => true,
 					'repeating'   => false,
@@ -106,7 +106,13 @@ class GetSiteStats implements CLICommandInterface {
 			foreach ( $requested_stats as $key ) {
 				$stats_key = trim( $key );
 				if ( ! isset( $all_stats[ $stats_key ] ) ) {
-					$this->wp_cli::error( "Stat key: {$stats_key} not found in stats." );
+					$this->wp_cli::error(
+						sprintf(
+							// translators: 1: a stat key that was requested but not found.
+							esc_html__( 'Stat key: %1$s not found in stats.', 'accessibility-checker' ),
+							$stats_key
+						)
+					);
 					return;
 				}
 				$items_to_return[ $stats_key ] = $all_stats[ $stats_key ];

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -99,7 +99,7 @@ class GetSiteStats implements CLICommandInterface {
 			}
 		}
 
-		if ( $items_to_return ) {
+		if ( isset( $items_to_return ) ) {
 			$this->wp_cli::success( wp_json_encode( $items_to_return, JSON_PRETTY_PRINT ) );
 			return;
 		}

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -107,6 +107,7 @@ class GetSiteStats implements CLICommandInterface {
 				$stats_key = trim( $key );
 				if ( ! isset( $all_stats[ $stats_key ] ) ) {
 					$this->wp_cli::error( "Stat key: {$stats_key} not found in stats." );
+					return;
 				}
 				$items_to_return[ $stats_key ] = $all_stats[ $stats_key ];
 			}

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -98,7 +98,7 @@ class GetSiteStats implements CLICommandInterface {
 			( new Scans_Stats() )->clear_cache();
 		}
 
-		$all_stats = $this->get_all_stats();
+		$all_stats = ( new Scans_Stats() )->summary();
 
 		if ( ! empty( $arguments['stat'] ) ) {
 			$items_to_return = [];
@@ -118,32 +118,5 @@ class GetSiteStats implements CLICommandInterface {
 		}
 
 		$this->wp_cli::success( wp_json_encode( $all_stats, JSON_PRETTY_PRINT ) );
-	}
-
-	/**
-	 * Gets the sites from the entire site.
-	 *
-	 * A limitation is this can only provide the stats for scanned pages, if
-	 * some pages are not scanned they are not reflected in the stats. Use the
-	 * 'scannable_posts_count' and the 'posts_scanned' values to determine if
-	 * the whole site is reflected or not.
-	 *
-	 * @since 1.15.0
-	 *
-	 * @throws ExitException If ScanStats class is not found or no stats are found.
-	 */
-	private function get_all_stats(): array {
-
-		if ( class_exists( 'EDAC\Admin\Scans_Stats' ) === false ) {
-			$this->wp_cli::error( "Scans_Stats class not found, is Accessibility Checker installed and activated?.\n" );
-		}
-
-		$stats = ( new Scans_Stats() )->summary();
-
-		if ( empty( $stats ) ) {
-			$this->wp_cli::error( "No stats found.\n" );
-		}
-
-		return $stats;
 	}
 }

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -70,11 +70,9 @@ class GetSiteStats implements CLICommandInterface {
 					'repeating'   => true,
 				],
 				[
-					'type'        => 'assoc',
+					'type'        => 'flag',
 					'name'        => 'clear-cache',
 					'description' => esc_html__( 'Clear the cache before retrieving the stats (can be intensive).', 'accessibility-checker' ),
-					'optional'    => true,
-					'default'     => true,
 					'repeating'   => false,
 				],
 			],

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -23,6 +23,24 @@ use WP_CLI\ExitException;
 class GetSiteStats implements CLICommandInterface {
 
 	/**
+	 * The WP-CLI instance.
+	 *
+	 * This lets a mock be passed in for testing.
+	 *
+	 * @var mixed|WP_CLI
+	 */
+	private $wp_cli;
+
+	/**
+	 * GetStats constructor.
+	 *
+	 * @param mixed|WP_CLI $wp_cli The WP-CLI instance.
+	 */
+	public function __construct( $wp_cli = null ) {
+		$this->wp_cli = $wp_cli ?? new WP_CLI();
+	}
+
+	/**
 	 * Get the name of the command.
 	 *
 	 * @since 1.15.0
@@ -82,11 +100,11 @@ class GetSiteStats implements CLICommandInterface {
 		}
 
 		if ( $items_to_return ) {
-			WP_CLI::success( wp_json_encode( $items_to_return, JSON_PRETTY_PRINT ) );
+			$this->wp_cli::success( wp_json_encode( $items_to_return, JSON_PRETTY_PRINT ) );
 			return;
 		}
 
-		WP_CLI::success( wp_json_encode( $all_stats, JSON_PRETTY_PRINT ) );
+		$this->wp_cli::success( wp_json_encode( $all_stats, JSON_PRETTY_PRINT ) );
 	}
 
 	/**
@@ -104,13 +122,13 @@ class GetSiteStats implements CLICommandInterface {
 	private function get_all_stats(): array {
 
 		if ( class_exists( 'EDAC\Admin\Scans_Stats' ) === false ) {
-			WP_CLI::error( "Scans_Stats class not found, is Accessibility Checker installed and activated?.\n" );
+			$this->wp_cli::error( "Scans_Stats class not found, is Accessibility Checker installed and activated?.\n" );
 		}
 
 		$stats = ( new Scans_Stats() )->summary();
 
 		if ( empty( $stats ) ) {
-			WP_CLI::error( "No stats found.\n" );
+			$this->wp_cli::error( "No stats found.\n" );
 		}
 
 		return $stats;

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -69,6 +69,14 @@ class GetSiteStats implements CLICommandInterface {
 					'default'     => null,
 					'repeating'   => true,
 				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'clear-cache',
+					'description' => 'Clear the cache before retrieving the stats (can be intensive).',
+					'optional'    => true,
+					'default'     => true,
+					'repeating'   => false,
+				],
 			],
 		];
 	}
@@ -85,6 +93,11 @@ class GetSiteStats implements CLICommandInterface {
 	 * @throws ExitException If the post ID does not exist, or the class we need isn't available.
 	 */
 	public function __invoke( array $options = [], array $arguments = [] ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! empty( $arguments['clear-cache'] ) ) {
+			// Clear the cache.
+			( new Scans_Stats() )->clear_cache();
+		}
+
 		$all_stats = $this->get_all_stats();
 
 		if ( ! empty( $arguments['stat'] ) ) {

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Get stats for a give post ID or all posts.
+ *
+ * @since 1.15.0
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\WPCLI\Command;
+
+use EDAC\Admin\Scans_Stats;
+use EDAC\Inc\Summary_Generator;
+use WP_CLI;
+use WP_CLI\ExitException;
+
+/**
+ * Get stats for a give post ID or all posts.
+ *
+ * @since 1.15.0
+ *
+ * @package AccessibilityCheckerCLI
+ */
+class GetStats implements CLICommandInterface {
+
+	/**
+	 * An array of valid stats keys.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @var array|string[]
+	 */
+	private array $valid_stats = [
+		'passed_tests',
+		'errors',
+		'warnings',
+		'ignored',
+		'contrast_errors',
+		'content_grade',
+		'readability',
+		'simplified_summary',
+	];
+
+	/**
+	 * Get the name of the command.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'accessibility-checker get-stats';
+	}
+
+	/**
+	 * Get the arguments for the command
+	 *
+	 * @since 1.15.0
+	 *
+	 * @return array
+	 */
+	public static function get_args(): array {
+		return [
+			'synopsis' => [
+				[
+					'type'        => 'positional',
+					'name'        => 'post_id',
+					'description' => 'The ID of the post to get stats for.',
+					'optional'    => true,
+					'default'     => 0,
+					'repeating'   => false,
+				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'stat',
+					'description' => 'Keys to show in the results. Defaults to all keys. "passed_tests", "errors", "warnings", "ignored", "contrast_errors", "content_grade", "readability", "simplified_summary"',
+					'optional'    => true,
+					'default'     => null,
+					'repeating'   => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Run the command that gets the stats for a post ID or the stats for the whole site.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @param array $options The positional argument, the post ID in this case.
+	 * @param array $arguments The associative argument, the stat key in this case.
+	 *
+	 * @return void
+	 * @throws ExitException If the post ID does not exist, or the class we need isn't available.
+	 */
+	public function __invoke( array $options = [], array $arguments = [] ) {
+		$post_id = $options[0] ?? null;
+
+		if ( 0 === $post_id ) {
+			$all_stats_json = $this->get_all_stats();
+
+			WP_CLI::success( $all_stats_json );
+		}
+
+		$post_exists = (bool) get_post( $post_id );
+
+		if ( ! $post_exists ) {
+			WP_CLI::error( "Post ID {$post_id} does not exist.\n" );
+		}
+
+		if ( class_exists( 'EDAC\Inc\Summary_Generator' ) === false ) {
+			WP_CLI::error( "Summary_Generator class not found, is Accessibility Checker installed and activated?.\n" );
+		}
+
+		$stats = ( new Summary_Generator( $post_id ) )->generate_summary();
+
+		if ( empty( $stats ) ) {
+			WP_CLI::error( "No stats found for post ID {$post_id}.\n" );
+		}
+
+		$value = $arguments['stat'] && in_array( $arguments['stat'], $this->valid_stats, true )
+			? [ $arguments['stat'] => $stats[ $arguments['stat'] ] ]
+			: $stats;
+
+		WP_CLI::success( wp_json_encode( $value ) . "\n" );
+	}
+
+	/**
+	 * Gets the sites from the entire site.
+	 *
+	 * A limitation is this can only stats for scanned pages, if some pages are not scanned they are not reflected in the stats.
+	 *
+	 * @since 1.15.0
+	 *
+	 * @throws ExitException If ScanStats class is not found or no stats are found.
+	 */
+	private function get_all_stats() {
+
+		if ( class_exists( 'EDAC\Admin\Scans_Stats' ) === false ) {
+			WP_CLI::error( "Scans_Stats class not found, is Accessibility Checker installed and activated?.\n" );
+		}
+
+		$stats = ( new Scans_Stats() )->summary();
+
+		if ( empty( $stats ) ) {
+			WP_CLI::error( "No stats found.\n" );
+		}
+
+		return wp_json_encode( $stats );
+	}
+}

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -104,7 +104,7 @@ class GetStats implements CLICommandInterface {
 	}
 
 	/**
-	 * Run the command that gets the stats for a post ID or the stats for the whole site.
+	 * Gets the accessibility-checker stats for a given post ID.
 	 *
 	 * @since 1.15.0
 	 *

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -96,12 +96,6 @@ class GetStats implements CLICommandInterface {
 	public function __invoke( array $options = [], array $arguments = [] ) {
 		$post_id = $options[0] ?? null;
 
-		if ( 0 === $post_id ) {
-			$all_stats_json = $this->get_all_stats();
-
-			WP_CLI::success( $all_stats_json );
-		}
-
 		$post_exists = (bool) get_post( $post_id );
 
 		if ( ! $post_exists ) {
@@ -123,29 +117,5 @@ class GetStats implements CLICommandInterface {
 			: $stats;
 
 		WP_CLI::success( wp_json_encode( $value ) . "\n" );
-	}
-
-	/**
-	 * Gets the sites from the entire site.
-	 *
-	 * A limitation is this can only stats for scanned pages, if some pages are not scanned they are not reflected in the stats.
-	 *
-	 * @since 1.15.0
-	 *
-	 * @throws ExitException If ScanStats class is not found or no stats are found.
-	 */
-	private function get_all_stats() {
-
-		if ( class_exists( 'EDAC\Admin\Scans_Stats' ) === false ) {
-			WP_CLI::error( "Scans_Stats class not found, is Accessibility Checker installed and activated?.\n" );
-		}
-
-		$stats = ( new Scans_Stats() )->summary();
-
-		if ( empty( $stats ) ) {
-			WP_CLI::error( "No stats found.\n" );
-		}
-
-		return wp_json_encode( $stats );
 	}
 }

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -120,11 +120,6 @@ class GetStats implements CLICommandInterface {
 			return;
 		}
 
-		if ( class_exists( 'EDAC\Inc\Summary_Generator' ) === false ) {
-			$this->wp_cli::error( "Summary_Generator class not found, is Accessibility Checker installed and activated?.\n" );
-			return;
-		}
-
 		$stats = ( new Summary_Generator( $post_id ) )->generate_summary();
 
 		if (

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -127,12 +127,10 @@ class GetStats implements CLICommandInterface {
 
 		$stats = ( new Summary_Generator( $post_id ) )->generate_summary();
 
-		if ( empty( $stats ) ) {
-			$this->wp_cli::error( "No stats found for post ID {$post_id}." );
-			return;
-		}
-
-		if ( 100 === (int) $stats['passed_tests'] && 0 === (int) $stats['ignored'] ) {
+		if (
+			empty( $stats ) ||
+			( 100 === (int) $stats['passed_tests'] && 0 === (int) $stats['ignored'] )
+		) {
 			$this->wp_cli::success( "Either the post is not yet scanned or all tests passed for post ID {$post_id}." );
 			return;
 		}

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -140,12 +140,8 @@ class GetStats implements CLICommandInterface {
 			$requested_stats = explode( ',', $arguments['stat'] );
 			foreach ( $requested_stats as $key ) {
 				$stats_key = trim( $key );
-				if ( ! in_array( $stats_key, self::$valid_stats, true ) ) {
-					$this->wp_cli::error( "Invalid stat key: {$stats_key}. Valid keys are: " . implode( ', ', $this->valid_stats ) . '.' );
-					return;
-				}
-				if ( ! isset( $stats[ $stats_key ] ) ) {
-					$this->wp_cli::error( "Stat key: {$stats_key} not found in stats." );
+				if ( ! in_array( $stats_key, self::$valid_stats, true ) || ! isset( $stats[ $stats_key ] ) ) {
+					$this->wp_cli::error( "Invalid stat key: {$stats_key}. Valid keys are: " . implode( ', ', self::$valid_stats ) . '.' );
 					return;
 				}
 				$items_to_return[ $stats_key ] = $stats[ $stats_key ];

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -82,7 +82,7 @@ class GetStats implements CLICommandInterface {
 				[
 					'type'        => 'positional',
 					'name'        => 'post_id',
-					'description' => 'The ID of the post to get stats for.',
+					'description' => esc_html__( 'The ID of the post to get stats for.', 'accessibility-checker' ),
 					'optional'    => true,
 					'default'     => 0,
 					'repeating'   => false,
@@ -90,7 +90,11 @@ class GetStats implements CLICommandInterface {
 				[
 					'type'        => 'assoc',
 					'name'        => 'stat',
-					'description' => 'Keys to show in the results. Defaults to all keys. Pass items in as a comma separated list if you want multiple. Valid keys are: ' . implode( ', ', self::$valid_stats ) . '.',
+					'description' => sprintf(
+						// translators: 1: a comma separated list of valid stats keys that should not be translated.
+						'Keys to show in the results. Defaults to all keys. Pass items in as a comma separated list if you want multiple. Valid keys are: %1$s.',
+						implode( ', ', self::$valid_stats )
+					),
 					'optional'    => true,
 					'default'     => null,
 					'repeating'   => true,
@@ -116,7 +120,13 @@ class GetStats implements CLICommandInterface {
 		$post_exists = (bool) get_post( $post_id );
 
 		if ( ! $post_exists ) {
-			$this->wp_cli::error( "Post ID {$post_id} does not exist." );
+			$this->wp_cli::error(
+				sprintf(
+					// translators: 1: a post ID.
+					esc_html__( 'Post ID %1$d does not exist.', 'accessibility-checker' ),
+					$post_id
+				)
+			);
 			return;
 		}
 
@@ -126,7 +136,13 @@ class GetStats implements CLICommandInterface {
 			empty( $stats ) ||
 			( 100 === (int) $stats['passed_tests'] && 0 === (int) $stats['ignored'] )
 		) {
-			$this->wp_cli::success( "Either the post is not yet scanned or all tests passed for post ID {$post_id}." );
+			$this->wp_cli::success(
+				sprintf(
+					// translators: 1: a post ID.
+					esc_html__( 'Either the post is not yet scanned or all tests passed for post ID %1$d.', 'accessibility-checker' ),
+					$post_id
+				)
+			);
 			return;
 		}
 
@@ -136,7 +152,15 @@ class GetStats implements CLICommandInterface {
 			foreach ( $requested_stats as $key ) {
 				$stats_key = trim( $key );
 				if ( ! in_array( $stats_key, self::$valid_stats, true ) || ! isset( $stats[ $stats_key ] ) ) {
-					$this->wp_cli::error( "Invalid stat key: {$stats_key}. Valid keys are: " . implode( ', ', self::$valid_stats ) . '.' );
+					$this->wp_cli::error(
+						sprintf(
+						// translators: 1: a stat key, 2: a comma separated list of valid stats keys.
+							'Invalid stat key: %1$s. Valid keys are: %2$s.',
+							$stats_key,
+							implode( ', ', self::$valid_stats )
+						)
+					);
+
 					return;
 				}
 				$items_to_return[ $stats_key ] = $stats[ $stats_key ];

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -9,6 +9,7 @@ namespace EDAC\Inc;
 
 use EDAC\Admin\Admin;
 use EDAC\Admin\Meta_Boxes;
+use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 
 /**
  * Main plugin functionality class.
@@ -52,5 +53,10 @@ class Plugin {
 
 		$frontend_validate = new Frontend_Validate();
 		$frontend_validate->init_hooks();
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$cli = new BootstrapCLI();
+			$cli->register();
+		}
 	}
 }

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -31,6 +31,12 @@ class Plugin {
 		// The REST api must load if admin or not.
 		$rest_api = new REST_Api();
 		$rest_api->init_hooks();
+
+		// When WP CLI is enabled, load the CLI commands.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$cli = new BootstrapCLI();
+			$cli->register();
+		}
 	}
 
 	/**
@@ -53,10 +59,5 @@ class Plugin {
 
 		$frontend_validate = new Frontend_Validate();
 		$frontend_validate->init_hooks();
-
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			$cli = new BootstrapCLI();
-			$cli->register();
-		}
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Coding Standards for Accessibility Checker">
-	<description>Accessibility Checker Wordpress Coding Standards</description>
+	<description>Accessibility Checker WordPress Coding Standards</description>
 
 	<!-- Scan all files in directory -->
 	<file>.</file>
@@ -146,5 +146,13 @@
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 	</rule>
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+	<!-- Exclude rules that block PSR-4 compliance -->
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+	</rule>
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+	</rule>
 
 </ruleset>

--- a/tests/phpunit/Mocks/Mock_WP_CLI.php
+++ b/tests/phpunit/Mocks/Mock_WP_CLI.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Mocks the WP_CLI class for testing.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Tests\Mocks;
+
+use Exception;
+use stdClass;
+
+/**
+ * Mocks the WP_CLI class for testing
+ *
+ * This is a simple mock that only implements the methods needed for testing.
+ */
+class Mock_WP_CLI {
+
+	/**
+	 * Holds the array of commands registered.
+	 *
+	 * @var array|mixed
+	 */
+	public static $commands = [];
+
+	/**
+	 * Flag to emulate a command being added that throws an exception.
+	 *
+	 * @var bool
+	 */
+	private static bool $add_command_should_throw = false;
+
+	/**
+	 * Sets the static flag to determine if add_command should throw.
+	 *
+	 * @param bool $should_throw True if the add_command method should throw.
+	 *
+	 * @return void
+	 */
+	public static function set_add_command_should_throw( bool $should_throw = false ): void {
+		self::$add_command_should_throw = $should_throw;
+	}
+
+	/**
+	 * Emulates the WP_CLI::add_command method good enough for testing.
+	 *
+	 * @param string          $name The command name.
+	 * @param callable|string $command_callable The callable for the command.
+	 *
+	 * @return void
+	 * @throws Exception If the add fails (IE if the fail flag is set to true).
+	 */
+	public static function add_command( string $name, $command_callable ) {
+		if ( self::$add_command_should_throw ) {
+			throw new Exception( 'add_command should throw' );
+		}
+		self::$commands[ $name ] = $command_callable;
+	}
+
+	/**
+	 * Emulates the WP_CLI::get_root_command method good enough for testing.
+	 *
+	 * @return stdClass
+	 */
+	public static function get_root_command(): object {
+		// Create an object with a get_subcommands method.
+		return new class() {
+
+			/**
+			 * Get the subcommands.
+			 *
+			 * @return array
+			 */
+			public static function get_subcommands(): array {
+				return Mock_WP_CLI::$commands;
+			}
+		};
+	}
+
+	/**
+	 * Echos a warning.
+	 *
+	 * @param string $message The message to echo.
+	 *
+	 * @return void
+	 */
+	public static function warning( string $message ) {
+		echo 'Warning: ' . esc_html( $message );
+	}
+
+	/**
+	 * Echos a success.
+	 *
+	 * @param string $message The message to echo.
+	 *
+	 * @return void
+	 */
+	public static function success( string $message ) {
+		echo 'Success: ' . esc_html( $message );
+	}
+
+	/**
+	 * Echos an error.
+	 *
+	 * @param string $message The message to echo.
+	 *
+	 * @return void
+	 */
+	public static function error( string $message ) {
+		echo 'Error: ' . esc_html( $message );
+	}
+
+	/**
+	 * Echos a log.
+	 *
+	 * @param string $message The message to echo.
+	 *
+	 * @return void
+	 */
+	public static function log( string $message ) {
+		echo 'Log: ' . esc_html( $message );
+	}
+}

--- a/tests/phpunit/TestHelpers/DatabaseHelpers.php
+++ b/tests/phpunit/TestHelpers/DatabaseHelpers.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Helper methods for database operations to support tests.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Tests\TestHelpers;
+
+use EDAC\Admin\Update_Database;
+use WP_Post;
+
+/**
+ * Some helper methods for database operations useful for testing.
+ */
+class DatabaseHelpers {
+
+	/**
+	 * Create the table for the plugin.
+	 *
+	 * Used for setup before tests.
+	 *
+	 * @return void
+	 */
+	public static function create_table() {
+		( new Update_Database() )->edac_update_database();
+	}
+	/**
+	 * Insert a record to the database for a given post.
+	 *
+	 * @param WP_Post $post The post to insert the record for.
+	 *
+	 * @return void
+	 */
+	public static function insert_test_issue_to_db( WP_Post $post ): void {
+
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		$wpdb->insert( // phpcs:ignore WordPress.DB -- using direct query for testing.
+			$table_name,
+			[
+				'postid'        => $post->ID,
+				'siteid'        => get_current_blog_id(),
+				'type'          => $post->post_type,
+				'rule'          => 'empty_paragraph_tag',
+				'ruletype'      => 'warning',
+				'object'        => '<p></p>',
+				'recordcheck'   => 1,
+				'user'          => get_current_user_id(),
+				'ignre'         => 0,
+				'ignre_user'    => null,
+				'ignre_date'    => null,
+				'ignre_comment' => null,
+				'ignre_global'  => 0,
+			]
+		);
+	}
+
+	/**
+	 * Drops the table for the plugin if it exists.
+	 *
+	 * Used for cleanup after tests.
+	 *
+	 * @return void
+	 */
+	public static function drop_table() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $table_name ); // phpcs:ignore WordPress.DB -- query for a unit test.
+	}
+}

--- a/tests/phpunit/TestHelpers/Mocks/Mock_WP_CLI.php
+++ b/tests/phpunit/TestHelpers/Mocks/Mock_WP_CLI.php
@@ -5,7 +5,7 @@
  * @package Accessibility_Checker
  */
 
-namespace EqualizeDigital\AccessibilityChecker\Tests\Mocks;
+namespace EqualizeDigital\AccessibilityChecker\Tests\TestHelpers\Mocks;
 
 use Exception;
 use stdClass;

--- a/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
+++ b/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Test the BootstrapCLI command loader.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Tests\Mocks\Mock_WP_CLI as WP_CLI;
+use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
+
+/**
+ * Test cases to verify that the BootstrapCLI command loader can register the commands.
+ */
+class BootstrapCLITest extends WP_UnitTestCase {
+
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * Makes the mock available and sets the constant like WP_CLI would in a real environment.
+	 */
+	protected function setUp(): void {
+		require_once dirname( __DIR__, 3 ) . '/Mocks/Mock_WP_CLI.php';
+		// since this is a synthetic run on WP-CLI, we need to define WP_CLI.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+		parent::setUp();
+	}
+
+	/**
+	 * Test the bootstrap CLI command.
+	 */
+	public function test_bootstrap_cli_command() {
+		$commands      = WP_CLI::get_root_command();
+		$command_count = count( $commands->get_subcommands() );
+
+		$bootstrap_cli = new BootstrapCLI( new WP_CLI() );
+		$bootstrap_cli->register();
+
+		$commands            = WP_CLI::get_root_command();
+		$command_count_after = count( $commands->get_subcommands() );
+
+		// check if the number of commands has increased after register is called.
+		$this->assertGreaterThan( $command_count, $command_count_after );
+	}
+
+	/**
+	 * Test the bootstrap CLI command with a mock that throws an exception when
+	 * adding commands.
+	 */
+	public function test_bootstrap_cli_command_with_exception() {
+		WP_CLI::set_add_command_should_throw( true );
+
+		$bootstrap_cli = new BootstrapCLI( new WP_CLI() );
+
+		ob_start();
+		$bootstrap_cli->register();
+		$output = ob_get_clean();
+
+		// check if the output contains the expected exception message.
+		$this->assertStringStartsWith( 'Warning: Failed to register command', $output );
+	}
+}

--- a/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
+++ b/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
@@ -5,7 +5,7 @@
  * @package Accessibility_Checker
  */
 
-use EqualizeDigital\AccessibilityChecker\Tests\Mocks\Mock_WP_CLI as WP_CLI;
+use EqualizeDigital\AccessibilityChecker\Tests\TestHelpers\Mocks\Mock_WP_CLI as WP_CLI;
 use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 
 /**
@@ -20,8 +20,6 @@ class BootstrapCLITest extends WP_UnitTestCase {
 	 * Makes the mock available and sets the constant like WP_CLI would in a real environment.
 	 */
 	protected function setUp(): void {
-		require_once dirname( __DIR__, 3 ) . '/Mocks/Mock_WP_CLI.php';
-		// since this is a synthetic run on WP-CLI, we need to define WP_CLI.
 		if ( ! defined( 'WP_CLI' ) ) {
 			define( 'WP_CLI', true );
 		}

--- a/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
+++ b/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
@@ -29,6 +29,16 @@ class BootstrapCLITest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set the should_throw flag back to false after each test.
+	 * 
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		WP_CLI::set_add_command_should_throw( false );
+		parent::tearDown();
+	}
+
+	/**
 	 * Test the bootstrap CLI command.
 	 */
 	public function test_bootstrap_cli_command() {

--- a/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
+++ b/tests/phpunit/includes/classes/WPCLI/BootstrapCLITest.php
@@ -30,7 +30,7 @@ class BootstrapCLITest extends WP_UnitTestCase {
 
 	/**
 	 * Set the should_throw flag back to false after each test.
-	 * 
+	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {

--- a/tests/phpunit/includes/classes/WPCLI/Commands/DeleteStatsTest.php
+++ b/tests/phpunit/includes/classes/WPCLI/Commands/DeleteStatsTest.php
@@ -71,7 +71,7 @@ class DeleteStatsTest extends WP_UnitTestCase {
 		$this->delete_stats->__invoke( [ $post_id ], [] );
 		$output = ob_get_clean();
 
-		$this->assertStringStartsWith( 'Success: Stats of ' . $post_id . ' deleted!', $output );
+		$this->assertStringStartsWith( 'Success: Stats of ' . $post_id . ' deleted', $output );
 
 		// make sure the issue is actually deleted from the database.
 		$stats_after = $wpdb->get_results( "SELECT * FROM $table_name WHERE postid = $post_id" ); // phpcs:ignore WordPress.DB -- Querying for testing purposes.

--- a/tests/phpunit/includes/classes/WPCLI/Commands/DeleteStatsTest.php
+++ b/tests/phpunit/includes/classes/WPCLI/Commands/DeleteStatsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Test cases for the delete-stats command.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Tests\TestHelpers\DatabaseHelpers;
+use EqualizeDigital\AccessibilityChecker\Tests\TestHelpers\Mocks\Mock_WP_CLI;
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\DeleteStats;
+
+/**
+ * Test cases to verify that the delete-stats command can delete the stats.
+ */
+class DeleteStatsTest extends WP_UnitTestCase {
+
+	/**
+	 * Set up the class under test and the database.
+	 */
+	protected function setUp(): void {
+		$this->delete_stats = new DeleteStats( new Mock_WP_CLI() );
+		DatabaseHelpers::create_table();
+		parent::setUp();
+	}
+
+	/**
+	 * Drop the table to clean up after tests.
+	 */
+	protected function tearDown(): void {
+		DatabaseHelpers::drop_table();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test the delete stats command errors if the post doesn't exist.
+	 */
+	public function test_delete_stats_command_errors_when_post_does_not_exist() {
+		$non_existent_id = 132456789;
+
+		ob_start();
+		$this->delete_stats->__invoke( [ $non_existent_id ], [] );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Error: Post ID ' . $non_existent_id . ' does not exist', $output );
+	}
+
+	/**
+	 * Test the delete stats command errors if no post ID is passed.
+	 */
+	public function test_delete_stats_command_errors_when_no_id_is_passed() {
+		ob_start();
+		$this->delete_stats->__invoke( [], [] );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Error: No Post ID provided.', $output );
+	}
+
+	/**
+	 * Test the delete stats command deletes the stats.
+	 */
+	public function test_delete_stats_command_deletes_stats() {
+		$post_id = $this->factory()->post->create();
+		DatabaseHelpers::insert_test_issue_to_db( get_post( $post_id ) );
+
+		global $wpdb;
+		$table_name   = $wpdb->prefix . 'accessibility_checker';
+		$stats_before = $wpdb->get_results( "SELECT * FROM $table_name WHERE postid = $post_id" ); // phpcs:ignore WordPress.DB -- Querying for testing purposes.
+		$this->assertEquals( 1, count( $stats_before ) );
+
+		ob_start();
+		$this->delete_stats->__invoke( [ $post_id ], [] );
+		$output = ob_get_clean();
+
+		$this->assertStringStartsWith( 'Success: Stats of ' . $post_id . ' deleted!', $output );
+
+		// make sure the issue is actually deleted from the database.
+		$stats_after = $wpdb->get_results( "SELECT * FROM $table_name WHERE postid = $post_id" ); // phpcs:ignore WordPress.DB -- Querying for testing purposes.
+		$this->assertEmpty( $stats_after );
+	}
+}

--- a/tests/phpunit/includes/classes/WPCLI/Commands/GetSiteStatsTest.php
+++ b/tests/phpunit/includes/classes/WPCLI/Commands/GetSiteStatsTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Test cases for the get-site-stats command.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Tests\TestHelpers\DatabaseHelpers;
+use EqualizeDigital\AccessibilityChecker\Tests\TestHelpers\Mocks\Mock_WP_CLI;
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\GetSiteStats;
+
+/**
+ * Test cases to verify that the get-site-stats command operates correctly in various situations.
+ */
+class GetSiteStatsTest extends WP_UnitTestCase {
+
+	/**
+	 * Set the WP_CLI constant, create property of the class under test
+	 * and create the database.
+	 */
+	protected function setUp(): void {
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		$this->get_site_stats = new GetSiteStats( new Mock_WP_CLI() );
+
+		DatabaseHelpers::create_table();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Drop the table to clean up after tests.
+	 */
+	protected function tearDown(): void {
+		DatabaseHelpers::drop_table();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test the get site stats command can complete when run.
+	 */
+	public function test_get_site_stats_command_can_complete() {
+		ob_start();
+		$this->get_site_stats->__invoke( [], [] );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Success: {', $output );
+	}
+
+	/**
+	 * Test the get site stats command can return filtered stats for one key or multiple keys.
+	 */
+	public function test_get_site_stats_command_can_return_filtered_stats() {
+
+		ob_start();
+		$this->get_site_stats->__invoke( [], [ 'stat' => 'rule_count' ] );
+		$stats = ob_get_clean();
+
+		$this->assertStringContainsString( 'Success: {', $stats );
+
+		$this->assertStringContainsString( 'Success: {', $stats );
+
+		$stats_array = json_decode(
+			html_entity_decode(
+				str_replace( 'Success: ', '', $stats )
+			),
+			true
+		);
+
+		$this->assertEquals( 1, count( $stats_array ) );
+		$this->assertArrayHasKey( 'rule_count', $stats_array );
+
+		ob_start();
+		$this->get_site_stats->__invoke( [], [ 'stat' => 'rule_count,tests_count' ] );
+		$stats = ob_get_clean();
+
+		$this->assertStringContainsString( 'Success: {', $stats );
+
+		$stats_array = json_decode(
+			html_entity_decode(
+				str_replace( 'Success: ', '', $stats )
+			),
+			true
+		);
+
+		$this->assertEquals( 2, count( $stats_array ) );
+		$this->assertArrayHasKey( 'rule_count', $stats_array );
+		$this->assertArrayHasKey( 'tests_count', $stats_array );
+	}
+
+	/**
+	 * Test the get site stats command errors if the requested stat key doesn't exist.
+	 */
+	public function test_get_site_stats_command_errors_when_stat_key_does_not_exist() {
+		ob_start();
+		$this->get_site_stats->__invoke( [], [ 'stat' => 'non_existent_key' ] );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Error: Stat key: non_existent_key not found in stats.', $output );
+	}
+
+	/**
+	 * Test the get site stats command can clear the cache.
+	 */
+	public function test_get_site_stats_command_can_clear_cache() {
+		ob_start();
+		$this->get_site_stats->__invoke( [], [] );
+		$stats_initial = ob_get_clean();
+
+		DatabaseHelpers::insert_test_issue_to_db( get_post( $this->factory()->post->create() ) );
+
+		ob_start();
+		$this->get_site_stats->__invoke( [], [ 'clear-cache' => true ] );
+		$stats_after_clear = ob_get_clean();
+
+		$this->assertNotEquals( $stats_initial, $stats_after_clear );
+	}
+}

--- a/tests/phpunit/includes/classes/WPCLI/Commands/GetStatsTest.php
+++ b/tests/phpunit/includes/classes/WPCLI/Commands/GetStatsTest.php
@@ -65,24 +65,6 @@ class GetStatsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the get stats command errors if it can't get the stats like if the
-	 * database is broken.
-	 */
-	public function test_get_stats_command_errors_when_issues_query_cant_complete() {
-
-		$post_id = $this->factory()->post->create();
-
-		ob_start();
-		$this->get_stats->__invoke( [ $post_id ], [] );
-		$stats = ob_get_clean();
-
-		$this->drop_table();
-
-		// check we have the expected error.
-		$this->assertEquals( 'Error: Post ID ' . $post_id . ' does not exist.', $stats );
-	}
-
-	/**
 	 * Test the get stats command can complete when no stats exist for a post.
 	 */
 	public function test_get_stats_command_completes_when_no_stats_exist_for_post() {

--- a/tests/phpunit/includes/classes/WPCLI/Commands/GetStatsTest.php
+++ b/tests/phpunit/includes/classes/WPCLI/Commands/GetStatsTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Test the GetStats command.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Update_Database;
+use EqualizeDigital\AccessibilityChecker\Tests\Mocks\Mock_WP_CLI;
+use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
+use EqualizeDigital\AccessibilityChecker\WPCLI\Command\GetStats;
+
+/**
+ * Test cases to verify that the GetStats command can get the stats.
+ */
+class GetStatsTest extends WP_UnitTestCase {
+
+	/**
+	 * Sets up the mock and injects it into the class under test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		require_once dirname( __DIR__, 4 ) . '/Mocks/Mock_WP_CLI.php';
+		// since this is a synthetic run on WP-CLI, we need to define WP_CLI.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		$wp_cli = new Mock_WP_CLI();
+
+		( new BootstrapCLI( $wp_cli ) )->register();
+		$this->get_stats = new GetStats( $wp_cli );
+
+		// create database tables if they don't exist.
+		( new Update_Database() )->edac_update_database();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Drop the table to clean up after tests.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		$this->drop_table();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test the get stats command errors if the post doesn't exist/
+	 */
+	public function test_get_stats_command_errors_when_post_does_not_exist() {
+
+		$non_existent_id = 132456789;
+
+		ob_start();
+		$this->get_stats->__invoke( [ $non_existent_id ], [] );
+		$stats = ob_get_clean();
+
+		// check we have the expected error.
+		$this->assertEquals( 'Error: Post ID ' . $non_existent_id . ' does not exist.', $stats );
+	}
+
+	/**
+	 * Test the get stats command errors if it can't get the stats like if the
+	 * database is broken.
+	 */
+	public function test_get_stats_command_errors_when_issues_query_cant_complete() {
+
+		$post_id = $this->factory()->post->create();
+
+		ob_start();
+		$this->get_stats->__invoke( [ $post_id ], [] );
+		$stats = ob_get_clean();
+
+		$this->drop_table();
+
+		// check we have the expected error.
+		$this->assertEquals( 'Error: Post ID ' . $post_id . ' does not exist.', $stats );
+	}
+
+	/**
+	 * Test the get stats command can complete when no stats exist for a post.
+	 */
+	public function test_get_stats_command_completes_when_no_stats_exist_for_post() {
+
+		$post_id = $this->factory()->post->create();
+
+		ob_start();
+		$this->get_stats->__invoke( [ $post_id ], [] );
+		$stats = ob_get_clean();
+
+		$this->assertStringStartsWith( 'Success: Either the post is not yet scanned or all tests passed', $stats );
+	}
+
+	/**
+	 * Test the get stats command can get stats for a post can get the stats.
+	 */
+	public function test_get_stats_command_returns_results_when_stats_exist_for_post() {
+		$post_id = $this->factory()->post->create();
+		$post    = get_post( $post_id );
+
+		$this->insert_issue_to_db( $post );
+
+		ob_start();
+		$this->get_stats->__invoke( [ $post_id ], [] );
+		$stats = ob_get_clean();
+
+		$this->assertStringStartsWith( 'Success: {', $stats );
+	}
+
+	/**
+	 * Insert a record to the database for a given post.
+	 *
+	 * @param WP_Post $post The post to insert the record for.
+	 *
+	 * @return void
+	 */
+	private function insert_issue_to_db( WP_Post $post ): void {
+
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		$wpdb->insert( // phpcs:ignore WordPress.DB -- using direct query for testing.
+			$table_name,
+			[
+				'postid'        => $post->ID,
+				'siteid'        => get_current_blog_id(),
+				'type'          => $post->post_type,
+				'rule'          => 'empty_paragraph_tag',
+				'ruletype'      => 'warning',
+				'object'        => '<p></p>',
+				'recordcheck'   => 1,
+				'user'          => get_current_user_id(),
+				'ignre'         => 0,
+				'ignre_user'    => null,
+				'ignre_date'    => null,
+				'ignre_comment' => null,
+				'ignre_global'  => 0,
+			]
+		);
+	}
+
+	/**
+	 * Drops the table for the plugin if it exists.
+	 *
+	 * Used for cleanup after tests.
+	 *
+	 * @return void
+	 */
+	private function drop_table() {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $table_name ); // phpcs:ignore WordPress.DB -- query for a unit test.
+	}
+}


### PR DESCRIPTION
This adds a setup to handle WP-Cli commands and adds a pair of commands to start with. It scopes them under a `accessibility-checker` command scope.

- delete-stats request a post ID passed as the first positional argument
  - Delete stats for post with ID 123: `wp accessibility-checker delete-stats 123`
- `get-stats` accepts a post ID passed as first positional argument
  - Get stats for post with ID 123: `wp accessibility-checker get-stats 123`
- `get-site-stats` accepts no paramiters
  - Get the stats for all the scanned pages on the site: `wp accessibility-checker get-site-stats` 

Closes: #674 