### PR TITLE
Add a class on the settings page container when pro callout will show

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.14.0
+ * Version:           1.14.1
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.14.0' );
+	define( 'EDAC_VERSION', '1.14.1' );
 }
 
 // Current database version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-checker",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.",
   "author": "Equalize Digital",
   "license": "GPL-2.0+",

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -45,7 +45,7 @@ $settings_tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : $d
 $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items, 'slug' ), true ) !== false ) ? $settings_tab : $default_tab;
 ?>
 
-<div class="wrap edac-settings">
+<div class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
 
 	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,9 @@ No, Accessibility Checker runs completely on your server and does not require yo
 
 == Changelog ==
 
+= 1.14.1 =
+* Fixed: Prevent settings page layout issue
+
 = 1.14.0 =
 * Added: Option to move front-end highlighter to opposite side of the window
 * Fixed: Prevent image from overspilling container in issue view

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -820,6 +820,11 @@
 
 .edac-settings {
   max-width: 800px;
+
+  &.pro-callout-wrapper {
+    max-width: fit-content;
+  }
+
   .edac-description {
     font-size: 13px;
   }


### PR DESCRIPTION
Adds an extra class to settings page wrapper for when pro callout will appear that can extend the container, preventing cramped settings fields in new styles.