### PR TITLE
William/688/prevent underlined text from detecting elements that are inside links checks 3 levels deep

### DIFF
--- a/src/pageScanner/rules/underlined-text.js
+++ b/src/pageScanner/rules/underlined-text.js
@@ -10,10 +10,28 @@ export default {
 	impact: 'moderate',
 	selector: '*:not(a):not(html):not(head):not(body)',
 	matches: ( element ) => {
-		return (
-			! element.hasAttribute( 'href' ) ||
-			element.tagName.toLowerCase() === 'u'
-		);
+		// U tags we will always check.
+		if ( element.tagName.toLowerCase() === 'u' ) {
+			return true;
+		}
+
+		// Traverse up the dom 3 levels and check if the element is inside an anchor.
+		let parent = element.parentNode;
+		let isInsideAnchor = false;
+		for ( let i = 0; i < 3; i++ ) {
+			// can't go further up the dom if the parent is the html element.
+			if ( parent.tagName.toLowerCase() === 'html' ) {
+				break;
+			}
+			if ( parent && parent.tagName.toLowerCase() === 'a' ) {
+				isInsideAnchor = true;
+				break;
+			}
+			parent = parent.parentNode;
+		}
+
+		// If in an anchor, don't check underline.
+		return ! isInsideAnchor;
 	},
 	tags: [ 'wcag324', 'wcag21aa', 'cat.text', 'custom' ],
 	metadata: {

--- a/src/pageScanner/rules/underlined-text.js
+++ b/src/pageScanner/rules/underlined-text.js
@@ -8,6 +8,7 @@
 export default {
 	id: 'underlined_text',
 	impact: 'moderate',
+	selector: '*:not(a):not(html):not(head):not(body)',
 	matches: ( element ) => {
 		return (
 			! element.hasAttribute( 'href' ) ||


### PR DESCRIPTION
This PR adds some checks in the 'matches' value of the underlined_text rule definition. The check are on the parent node (as high as 3 levels) for anchors and if it finds one won't check to flag an underline since flagging them if inside anchors is a false positive.

Closes: #688 