### PR TITLE
Purge the post data if the saved post is in or is moving to trash

### DIFF
--- a/includes/validate.php
+++ b/includes/validate.php
@@ -94,6 +94,10 @@ function edac_save_post( $post_ID, $post, $update ) {
 
 	// Post in, or going to, trash.
 	if ( 'trash' === $post->post_status ) {
+		// Gutenberg does not fire the `wp_trash_post` action when moving posts to the
+		// trash. Instead it uses `rest_delete_{$post_type}` which passes a different shape
+		// so instead of hooking in there for every post type supported the data gets
+		// purged here instead which produces the same result.
 		Purge_Post_Data::delete_post( $post_ID );
 		return;
 	}

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -7,6 +7,7 @@
 
 use EDAC\Admin\Helpers;
 use EDAC\Admin\Insert_Rule_Data;
+use EDAC\Admin\Purge_Post_Data;
 
 /**
  * Oxygen Builder on save
@@ -68,11 +69,6 @@ function edac_save_post( $post_ID, $post, $update ) {
 		return;
 	}
 
-	// Ignore posts in, or going to, trash.
-	if ( 'trash' === $post->post_status ) {
-		return;
-	}
-
 	// ignore revisions.
 	if ( wp_is_post_revision( $post_ID ) ) {
 		return;
@@ -94,6 +90,12 @@ function edac_save_post( $post_ID, $post, $update ) {
 		if ( wp_verify_nonce( $inline_edit, 'inlineeditnonce' ) ) {
 			return;
 		}
+	}
+
+	// Post in, or going to, trash.
+	if ( 'trash' === $post->post_status ) {
+		Purge_Post_Data::delete_post( $post_ID );
+		return;
 	}
 
 	edac_validate( $post_ID, $post, $action = 'save' );


### PR DESCRIPTION
This PR calls the method to delete issues when a post is trashed during the validate method at the point it would early bail since post is trashed.

I moved the trash bail later in the method to ensure that any other quicker bail checks can run before it runs database queries for deleting issues.

This is needed here because Gutenberg editor does not fire the `wp_trash_post` hook because it uses rest API which updates a post with trash status where as classic editor and the quick actions in post lists invoke the actual trash functions. Deleting via rest does have a different action we could bind to - `rest_delete_{$post_type}` but using it is less clean than the way `wp_trash_post` works so I decided to use the method in this PR to solve this instead.