### PR TITLE
Fix: Don't flag .avif as missing trascript or video present

### DIFF
--- a/includes/classes/class-edac-dom.php
+++ b/includes/classes/class-edac-dom.php
@@ -136,9 +136,7 @@ class EDAC_Dom extends simple_html_dom {
 			$elements = array_filter(
 				$elements_with_src,
 				function ( $element ) use ( $extensions ) {
-					$count = 0;
-					str_ireplace( $extensions, '', $element->getAttribute( 'src' ), $count );
-					return $count > 0;
+					return is_item_using_matching_extension( $element->getAttribute( 'href' ), $extensions );
 				}
 			);
 		}

--- a/includes/classes/class-edac-dom.php
+++ b/includes/classes/class-edac-dom.php
@@ -161,9 +161,7 @@ class EDAC_Dom extends simple_html_dom {
 			$elements = array_filter(
 				$elements_with_href,
 				function ( $element ) use ( $extensions ) {
-					$href      = $element->getAttribute( 'href' );
-					$extension = pathinfo( $href, PATHINFO_EXTENSION );
-					return in_array( '.' . $extension, $extensions, true );
+					return is_item_using_matching_extension( $element->getAttribute( 'href' ), $extensions );
 				}
 			);
 		}

--- a/includes/classes/class-edac-dom.php
+++ b/includes/classes/class-edac-dom.php
@@ -136,7 +136,7 @@ class EDAC_Dom extends simple_html_dom {
 			$elements = array_filter(
 				$elements_with_src,
 				function ( $element ) use ( $extensions ) {
-					return is_item_using_matching_extension( $element->getAttribute( 'href' ), $extensions );
+					return edac_is_item_using_matching_extension( $element->getAttribute( 'href' ), $extensions );
 				}
 			);
 		}
@@ -159,7 +159,7 @@ class EDAC_Dom extends simple_html_dom {
 			$elements = array_filter(
 				$elements_with_href,
 				function ( $element ) use ( $extensions ) {
-					return is_item_using_matching_extension( $element->getAttribute( 'href' ), $extensions );
+					return edac_is_item_using_matching_extension( $element->getAttribute( 'href' ), $extensions );
 				}
 			);
 		}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -970,7 +970,7 @@ function edac_get_file_opened_as_binary( string $filename ) {
 
 /**
  * Generate a summary statistic list item.
- * 
+ *
  * @since 1.14.0
  *
  * @param string $item_class     The base CSS class for the list item.
@@ -989,4 +989,19 @@ function edac_generate_summary_stat( string $item_class, int $count, string $lab
             </div>
             <div class="edac-panel-number-label">' . $label . '</div>
         </li>';
+}
+
+/**
+ * Check if an element has an extension that matches the provided list.
+ *
+ * @since 1.15.0
+ *
+ * @param string $item A file path or URL to check.
+ * @param array  $extensions An array of extensions to check for.
+ *
+ * @return bool
+ */
+function is_item_using_matching_extension( string $item, array $extensions ): bool {
+	$extension = pathinfo( $item, PATHINFO_EXTENSION );
+	return in_array( '.' . $extension, $extensions, true );
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -999,7 +999,7 @@ function edac_generate_summary_stat( string $item_class, int $count, string $lab
  * @param string $item A file path or URL to check.
  * @param array  $extensions An array of extensions to check for.
  *
- * @return bool
+ * @return bool True if the item has an extension that matches the list, false otherwise.
  */
 function edac_is_item_using_matching_extension( string $item, array $extensions ): bool {
 	$extension = pathinfo( $item, PATHINFO_EXTENSION );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1001,7 +1001,7 @@ function edac_generate_summary_stat( string $item_class, int $count, string $lab
  *
  * @return bool
  */
-function is_item_using_matching_extension( string $item, array $extensions ): bool {
+function edac_is_item_using_matching_extension( string $item, array $extensions ): bool {
 	$extension = pathinfo( $item, PATHINFO_EXTENSION );
 	return in_array( '.' . $extension, $extensions, true );
 }

--- a/includes/rules/video_present.php
+++ b/includes/rules/video_present.php
@@ -65,7 +65,7 @@ function edac_rule_video_present( $content, $post ) { // phpcs:ignore -- $post i
 				continue;
 			}
 
-			if ( is_item_using_matching_extension( $src_text, $file_extensions ) ) {
+			if ( edac_is_item_using_matching_extension( $src_text, $file_extensions ) ) {
 				$errors[] = $element->outertext;
 			}
 		}

--- a/includes/rules/video_present.php
+++ b/includes/rules/video_present.php
@@ -65,10 +65,8 @@ function edac_rule_video_present( $content, $post ) { // phpcs:ignore -- $post i
 				continue;
 			}
 
-			foreach ( $file_extensions as $file_extension ) {
-				if ( strpos( strtolower( $src_text ), $file_extension ) ) {
-					$errors[] = $element->outertext;
-				}
+			if ( is_item_using_matching_extension( $src_text, $file_extensions ) ) {
+				$errors[] = $element->outertext;
 			}
 		}
 	}


### PR DESCRIPTION
This PR adjusts how file extensions are checked in some rules so that `avif` does not get checked by them since it is not a video.

The reason this was happening was due to the way file extensions were being checked. They were matching `avi` in `avif`. I have created a helper that checks the extension matches the full extension and not just part of it.

Fixes: #598 