### PR TITLE
Enahcement: Image inputs with alt text shouldn't flag for missing_form_label

### DIFF
--- a/includes/rules/missing_form_label.php
+++ b/includes/rules/missing_form_label.php
@@ -22,6 +22,12 @@ function edac_rule_missing_form_label( $content, $post ) { // phpcs:ignore -- $p
 		if ( in_array( $field->getAttribute( 'type' ), [ 'submit', 'hidden', 'button', 'reset' ], true ) ) {
 			continue;
 		}
+
+		// Not an error if it's an image input with an alt.
+		if ( 'image' === $field->getAttribute( 'type' ) && ! empty( $field->getAttribute( 'alt' ) ) ) {
+			continue;
+		}
+
 		if ( ! ac_input_has_label( $field, $dom ) ) {
 			$errors[] = $field->outertext;
 		}


### PR DESCRIPTION
This PR adds a check inside of the missing_form_label that will prevent an error being flagged for an input with type of 'image' if it has non-empty alt text. A screen reader will use the alt text even when there is no label.

Fixes: #610 