### PR TITLE
Fixed: Allow empty_link rule to detect actually empty links

### DIFF
--- a/includes/rules/empty_link.php
+++ b/includes/rules/empty_link.php
@@ -45,6 +45,14 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 				// does not have a name.
 
 				$image = $link->find( 'img' );
+				$input = $link->find( 'input' );
+				$i     = $link->find( 'i' );
+
+				// If there's no image, input or i tag it's just an empty link and should be flagged.
+				if ( empty( $image ) && empty( $input ) && empty( $i ) ) {
+					$error = $a_tag_code;
+				}
+
 				if ( ! $error && isset( $image[0] ) && empty( trim( $image[0]->getAttribute( 'alt' ) ) ) ) {
 
 					// The first image inside the link does not have an alt.
@@ -52,7 +60,6 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 					$error = $a_tag_code;
 				}
 
-				$input = $link->find( 'input' );
 				if ( ! $error && isset( $input[0] ) && empty( trim( $input[0]->getAttribute( 'value' ) ) ) ) {
 
 					// The first input inside the link does not have a value.
@@ -60,7 +67,6 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 					$error = $a_tag_code;
 				}
 
-				$i = $link->find( 'i' );
 				if ( ! $error &&
 					isset( $i[0] ) &&
 					empty( trim( $i[0]->getAttribute( 'title' ) ) ) &&

--- a/includes/rules/empty_link.php
+++ b/includes/rules/empty_link.php
@@ -45,7 +45,7 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 				// does not have a name.
 
 				$image = $link->find( 'img' );
-				if ( ! $error && isset( $input[0] ) && empty( trim( $image[0]->getAttribute( 'alt' ) ) ) ) {
+				if ( ! $error && isset( $image[0] ) && empty( trim( $image[0]->getAttribute( 'alt' ) ) ) ) {
 
 					// The first image inside the link does not have an alt.
 					// Throw error.
@@ -53,7 +53,7 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 				}
 
 				$input = $link->find( 'input' );
-				if ( ! $error && isset( $input[0] ) && empty( trim( $image[0]->getAttribute( 'value' ) ) ) ) {
+				if ( ! $error && isset( $input[0] ) && empty( trim( $input[0]->getAttribute( 'value' ) ) ) ) {
 
 					// The first input inside the link does not have a value.
 					// Throw error.
@@ -61,9 +61,10 @@ function edac_rule_empty_link( $content, $post ) { // phpcs:ignore -- $post is r
 				}
 
 				$i = $link->find( 'i' );
-				if ( ! $error && isset( $input[0] ) &&
-				empty( trim( $i[0]->getAttribute( 'title' ) ) ) &&
-				empty( trim( $i[0]->getAttribute( 'aria-label' ) ) )
+				if ( ! $error &&
+					isset( $i[0] ) &&
+					empty( trim( $i[0]->getAttribute( 'title' ) ) ) &&
+					empty( trim( $i[0]->getAttribute( 'aria-label' ) ) )
 				) {
 
 					// The first i inside the link does not have a title &

--- a/tests/phpunit/includes/rules/EmptyLinkTest.php
+++ b/tests/phpunit/includes/rules/EmptyLinkTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Tests the empty_link rule.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Some test cases for the empty_link rule.
+ *
+ * @group rules
+ */
+class EmptyLinkTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that a link with no content, no aria-label, no title, no id, no name, and no alt text throws an error.
+	 */
+	public function test_empty_link() {
+
+		$expected_error = '<a href="http://example.com"></a>';
+
+		$not_expected_error = '<a href="http://example.com">Some content</a>';
+
+
+		$dom = new EDAC_Dom();
+		$dom->load( $expected_error . PHP_EOL . $not_expected_error );
+
+		$errors = edac_rule_empty_link( [ 'html' => $dom ], null );
+
+		$this->assertContains( $expected_error, $errors );
+		$this->assertNotContains( $not_expected_error, $errors );
+	}
+
+	/**
+	 * Test that a link with no content, no aria-label, no title, no id, no name, and no alt text throws an error.
+	 */
+	public function test_empty_link_with_img() {
+		$expected_errors = [
+			'<a href="http://example.com"><img src="http://example.com/image.jpg" alt=""></a>',
+			'<a href="http://example.com"><img src="http://example.com/image.jpg" alt=" "></a>',
+		];
+
+		$not_expected_error = '<a href="http://example.com"><img src="http://example.com/image.jpg" alt="A filled alt"></a>';
+
+		$dom = new EDAC_Dom();
+		$dom->load( implode( PHP_EOL, $expected_errors ) . PHP_EOL . $not_expected_error );
+
+		$errors = edac_rule_empty_link( [ 'html' => $dom ], null );
+
+		foreach ( $expected_errors as $expected_error ) {
+			$this->assertContains( $expected_error, $errors );
+		}
+
+		$this->assertNotContains( $not_expected_error, $errors );
+	}
+
+	/**
+	 * Test that a link with no content, no aria-label, no title, no id, no name, and no alt text throws an error.
+	 */
+	public function test_empty_link_with_input() {
+
+		$expected_errors = [
+			'<a href="http://example.com"><input type="text"></a>',
+			'<a href="http://example.com"><input type="text" value=""></a>',
+			'<a href="http://example.com"><input type="text" value=" "></a>', // whitespace should be stripped, this is still empty.
+		];
+
+		$not_expected_error = '<a href="http://example.com"><input type="text" value="Some value"></a>';
+
+		$dom = new EDAC_Dom();
+		$dom->load( implode( PHP_EOL, $expected_errors ) . PHP_EOL . $not_expected_error );
+
+		$errors = edac_rule_empty_link( [ 'html' => $dom ], null );
+
+		foreach ( $expected_errors as $expected_error ) {
+			$this->assertContains( $expected_error, $errors );
+		}
+		$this->assertNotContains( $not_expected_error, $errors );
+	}
+
+	/**
+	 * Test that a link with no content, no aria-label, no title, no id, no name, and no alt text throws an error.
+	 */
+	public function test_empty_link_with_i() {
+		$expected_errors = [
+			'<a href="http://example.com"><i></i></a>',
+			'<a href="http://example.com"><i title=""></i></a>',
+			'<a href="http://example.com"><i aria-label=""></i></a>',
+			'<a href="http://example.com"><i title=" "></i></a>', // whitespace should be stripped, this is still empty.
+			'<a href="http://example.com"><i aria-label=" "></i></a>', // whitespace should be stripped, this is still empty.
+		];
+
+		$not_expected_errors = [
+			'<a href="http://example.com"><i title="Some title"></i></a>',
+			'<a href="http://example.com"><i aria-label="A label"></i></a>',
+			'<a href="http://example.com"><i title="Some title" aria-label="A label"></i></a>',
+		];
+
+		$dom = new EDAC_Dom();
+		$dom->load( implode( PHP_EOL, $expected_errors ) . PHP_EOL . implode( PHP_EOL, $not_expected_errors ) );
+
+		$errors = edac_rule_empty_link( [ 'html' => $dom ], null );
+
+		foreach ( $expected_errors as $expected_error ) {
+			$this->assertContains( $expected_error, $errors );
+		}
+		foreach ( $not_expected_errors as $not_expected_error ) {
+			$this->assertNotContains( $not_expected_error, $errors );
+		}
+	}
+}


### PR DESCRIPTION
This PR makes is so that empty links are flagged appropriately by:

* Correcting some variables that were being checked
* Flagging an error if it's empty plain text and there is no `img`, `input` or `i` tags for further checks

Tests were also added to confirm the behaviour of the rule matches the intention against some test data.

Fixes: #697 