### PR TITLE
Inline some single use variables at function returns

### DIFF
--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -120,9 +120,7 @@ class Helpers {
 			}
 		}
 
-		$formatted_date = $datetime->format( $format );
-
-		return $formatted_date;
+		return $datetime->format( $format );
 	}
 
 	/**

--- a/admin/class-issues-query.php
+++ b/admin/class-issues-query.php
@@ -125,9 +125,7 @@ class Issues_Query {
 	 * @return string $sql .
 	 */
 	public function get_sql() {
-		$sql = $this->query['select'] . ' ' . $this->query['from'] . ' ' . $this->query['where_base'] . ' ' . $this->query['filters'] . ' ' . $this->query['limit'];
-
-		return $sql;
+		return $this->query['select'] . ' ' . $this->query['from'] . ' ' . $this->query['where_base'] . ' ' . $this->query['filters'] . ' ' . $this->query['limit'];
 	}
 
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -31,9 +31,8 @@ function edac_compare_strings( $string1, $string2 ) {
 		$content = str_ireplace( $remove_text, '', $content );
 		$content = wp_strip_all_tags( $content );
 		$content = trim( $content, " \t\n\r\0\x0B\xC2\xA0" );
-		$content = html_entity_decode( $content );
 
-		return $content;
+		return html_entity_decode( $content );
 	};
 
 	return $prepare_strings( $string1 ) === $prepare_strings( $string2 );
@@ -138,8 +137,7 @@ function edac_ordinal( $number ) {
 function edac_simple_dom_remove_child( simple_html_dom_node $parent_node ) {
 	$parent_node->innertext = '';
 
-	$error = $parent_node->save();
-	return $error;
+	return $parent_node->save();
 }
 
 /**
@@ -210,9 +208,7 @@ function edac_is_gutenberg_active() {
 		return true;
 	}
 
-	$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
-
-	return $use_block_editor;
+	return ( get_option( 'classic-editor-replace' ) === 'no-replace' );
 }
 
 /**
@@ -275,9 +271,7 @@ function edac_custom_post_types() {
 	$output   = 'names'; // names or objects, note names is the default.
 	$operator = 'and'; // Options 'and' or 'or'.
 
-	$post_types = get_post_types( $args, $output, $operator );
-
-	return $post_types;
+	return get_post_types( $args, $output, $operator );
 }
 
 /**
@@ -477,8 +471,8 @@ function edac_generate_nonce( $secret, $timeout_seconds = 120 ) {
 
 	$time     = time();
 	$max_time = $time + $timeout_seconds;
-	$nonce    = $salt . ',' . $max_time . ',' . sha1( $salt . $secret . $max_time );
-	return $nonce;
+
+	return $salt . ',' . $max_time . ',' . sha1( $salt . $secret . $max_time );
 }
 
 /**
@@ -970,7 +964,7 @@ function edac_get_file_opened_as_binary( string $filename ) {
 
 /**
  * Generate a summary statistic list item.
- * 
+ *
  * @since 1.14.0
  *
  * @param string $item_class     The base CSS class for the list item.


### PR DESCRIPTION
This PR inlines variables at the return statement if they existed only to be returned. None of these seemed to aid in readability in my view so I swapped every instance that was detected.

There were 2 other instances inside the `simple_html_dom.php` file that I did not modify here since that package is a cloned 3rd party file.