### PR TITLE
PHP 8.4 deprecation notice fix for implicitly nullable Meta_Boxes

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -29,7 +29,7 @@ class Admin {
 	 *
 	 * @param Meta_Boxes|null $meta_boxes Meta boxes instance.
 	 */
-	public function __construct( Meta_Boxes $meta_boxes = null ) {
+	public function __construct( Meta_Boxes $meta_boxes ) {
 		$this->meta_boxes = $meta_boxes;
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -27,7 +27,7 @@ class Admin {
 	/**
 	 * Class constructor for injecting dependencies.
 	 *
-	 * @param Meta_Boxes|null $meta_boxes Meta boxes instance.
+	 * @param Meta_Boxes $meta_boxes Meta boxes instance.
 	 */
 	public function __construct( Meta_Boxes $meta_boxes ) {
 		$this->meta_boxes = $meta_boxes;


### PR DESCRIPTION
This PR avoids making the Meta_Boxes class injected into the Admin class implicitly nullable. Since it can never be null, the default null value is removed instead of making the type hint nullable.

Fixes: #706 