### PR TITLE
Add a retry logic on some flaky tests that rely on httpbin

### DIFF
--- a/tests/phpunit/helper-functions/GetFileOpenedAsBinaryTest.php
+++ b/tests/phpunit/helper-functions/GetFileOpenedAsBinaryTest.php
@@ -22,6 +22,11 @@ class GetFileOpenedAsBinaryTest extends WP_UnitTestCase {
 
 		$fh = edac_get_file_opened_as_binary( $file );
 
+		// since this external service can be flaky we try again if it fails.
+		if ( ! $fh ) {
+			$fh = edac_get_file_opened_as_binary( $file );
+		}
+
 		$this->assertNotFalse( $fh );
 		fclose( $fh );
 	}

--- a/tests/phpunit/helper-functions/UrlExistsTest.php
+++ b/tests/phpunit/helper-functions/UrlExistsTest.php
@@ -16,8 +16,13 @@ class UrlExistsTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_url_exists() {
-		$url = 'https://httpbin.org/status/200';
-		$this->assertTrue( edac_url_exists( $url, 20 ) );
+		$url        = 'https://httpbin.org/status/200';
+		$url_exists = edac_url_exists( $url, 10 );
+		// this test url is flaky, so we try again one extra time if it fails.
+		if ( ! $url_exists ) {
+			$url_exists = edac_url_exists( $url, 20 );
+		}
+		$this->assertTrue( $url_exists );
 	}
 
 	/**


### PR DESCRIPTION
I added a retry inside the tests that rely on working external URL checks to combat flakiness that I have seen. 

If the code changes in the function that would cause the test to actually fail they will still fail with the retry logic - but retrying it can hopefully reduce false CI failings that happen in CI from time to time.