### PR TITLE
Add a basic PR template 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!-- Always provide a short description -->
+
+## Checklist
+
+- [ ] PR is linked to the main issue in the repo
+- [ ] Tests are added that cover changes


### PR DESCRIPTION
Adds a simple PR template with some checkboxes to remind about tagging PRs with the associated issue and about adding tests.