### PR TITLE
Fixed: background size style placement

### DIFF
--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1398,8 +1398,8 @@
           color: #ffffff;
 
           &-error {
-            background-size: 1rem 1rem;
             background: $color-green url('.././images/error%20icon%20white.png') no-repeat calc(0% + 5px) 50%;
+            background-size: 1rem 1rem;
 
             &.has-errors {
               background-color: $color-red;
@@ -1408,8 +1408,8 @@
           }
 
           &-contrast {
-            background-size: 1rem 1rem;
             background: $color-green url('.././images/contrast%20icon%20white.png') no-repeat calc(0% + 5px) 50%;
+            background-size: 1rem 1rem;
 
             &.has-errors {
               background-color: $color-red;
@@ -1418,12 +1418,12 @@
           }
 
           &-warning {
-            background-size: 1rem 1rem;
             background: $color-green url('.././images/warning%20icon%20white.png') no-repeat calc(0% + 5px) 50%;
+            background-size: 1rem 1rem;
 
             &.has-warning {
-                background-size: 1rem 1rem;
                 background: $color-yellow url('.././images/warning%20icon%20navy.png') no-repeat calc(0% + 5px) 50%;
+                background-size: 1rem 1rem;
                 color: $color-blue-dark;
             }
 


### PR DESCRIPTION
This PR fixes the EDAC widget icon background size.

Before:
![Screenshot 2024-07-15 at 3 43 22 PM](https://github.com/user-attachments/assets/f7f46809-7734-4021-bce2-2814ce476c93)

After:
![Screenshot 2024-07-15 at 3 48 19 PM](https://github.com/user-attachments/assets/ad93f91b-3041-4ab0-911b-2a9f907f7c02)
