### PR TITLE
Fix: When creating new post in Gutenberg the JS checks were not run till page reload

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -95,7 +95,7 @@ class Enqueue_Admin {
 				$pro = is_plugin_active( 'accessibility-checker-pro/accessibility-checker-pro.php' ) && EDAC_KEY_VALID;
 
 				if ( EDAC_DEBUG || strpos( EDAC_VERSION, '-beta' ) !== false ) {
-					$debug = true;
+					$debug = true; // @codeCoverageIgnore
 				} else {
 					$debug = false;
 				}

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -47,7 +47,6 @@ class Enqueue_Admin {
 	 */
 	public static function maybe_enqueue_admin_and_editor_app_scripts() {
 
-
 		global $pagenow;
 		$post_types        = get_option( 'edac_post_types' );
 		$current_post_type = get_post_type();
@@ -75,7 +74,6 @@ class Enqueue_Admin {
 			$post_id = is_object( $post ) ? $post->ID : null;
 			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', [ 'jquery' ], EDAC_VERSION, false );
 
-
 			wp_localize_script(
 				'edac',
 				'edac_script_vars',
@@ -87,9 +85,7 @@ class Enqueue_Admin {
 				]
 			);
 
-
 			if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
-
 
 				// Is this posttype setup to be checked?
 				$post_types        = get_option( 'edac_post_types' );

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -88,7 +88,7 @@ class Enqueue_Admin {
 			);
 
 
-			if ( 'post.php' === $pagenow ) {
+			if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 
 
 				// Is this posttype setup to be checked?

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Test cases for the Enqueue_Admin class.
+ *
+ * @package accessibility-checker
+ */
+
+use EDAC\Admin\Enqueue_Admin;
+
+/**
+ * Tests for functionality of the Enqueue_Admin class.
+ */
+class EnqueueAdminTest extends WP_UnitTestCase {
+
+	/**
+	 * Holds the instance of the Enqueue_Admin class.
+	 *
+	 * @var Enqueue_Admin the instance of the Enqueue_Admin class.
+	 */
+	private $enqueue_admin;
+
+	/**
+	 * Setup the option, global wp_scripts and the Enqueue_Admin instance.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		update_option( 'edac_post_types', [ 'post', 'page' ] );
+
+		global $wp_scripts;
+		$wp_scripts = new \WP_Scripts();
+
+		$this->enqueue_admin = new Enqueue_Admin();
+	}
+
+	/**
+	 * Clean up the option, global wp_scripts and the Enqueue_Admin instance.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		delete_option( 'edac_post_types' );
+
+		global $wp_scripts;
+		unset( $wp_scripts );
+
+		unset( $this->enqueue_admin );
+	}
+
+	/**
+	 * Test that the base script is enqueued in the admin on non-editor pages.
+	 *
+	 * @return void
+	 */
+	public function testEnqueueBaseScriptInAdminNonEditorPage() {
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'edac-editor-app', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that the base script and editor script is enqueued in the editor for an existing page.
+	 *
+	 * @return void
+	 */
+	public function testEnqueueBaseAndEditorScriptsInAdminEditorExisting() {
+
+		global $post;
+		$post = $this->factory()->post->create_and_get();
+
+		global $pagenow;
+		$pagenow = 'post.php';
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'edac-editor-app', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that the base script and editor script is enqueued in the editor for a new page.
+	 *
+	 * @return void
+	 */
+	public function testEnqueueBaseAndEditorScriptsInAdminEditorNew() {
+		global $post;
+		$post = $this->factory()->post->create_and_get();
+
+		global $pagenow;
+		$pagenow = 'post-new.php';
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'edac-editor-app', 'enqueued' ) );
+	}
+}


### PR DESCRIPTION
This PR adds an extra `$pagenow` value to check of `post-new.php` when determining if the editor script should be added.

Gutenberg new post page us `post-new.php` but when editing a post it is `post.php`. The latter of which would load the script while the former would not.

Fixes: #716 

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes
