### PR TITLE
Add framework to handle various different fixes that the plugin can apply

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -20,7 +20,6 @@
  */
 
 use EDAC\Inc\Plugin;
-use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
@@ -185,19 +184,3 @@ function edac_include_rules_files() {
 	}
 }
 add_action( 'init', 'edac_include_rules_files' );
-
-/**
- * Init the FixesManager.
- *
- * This is done on the plugins_loaded hook with a priority of 20 to ensure that fixes that
- * rely on running early, like on init or before init, can be hooked in and ready to go.
- * Fixes should be registered to the manager using the the plugins_loaded hook with a
- * priority of less than 20.
- *
- * @return void
- */
-function edac_init_fixes_manager() {
-	$fixes_manager = FixesManager::get_instance();
-	$fixes_manager->register_fixes();
-}
-add_action( 'plugins_loaded', 'edac_init_fixes_manager', 20 );

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -20,6 +20,7 @@
  */
 
 use EDAC\Inc\Plugin;
+use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
@@ -184,3 +185,19 @@ function edac_include_rules_files() {
 	}
 }
 add_action( 'init', 'edac_include_rules_files' );
+
+/**
+ * Init the FixesManager.
+ *
+ * This is done on the plugins_loaded hook with a priority of 20 to ensure that fixes that
+ * rely on running early, like on init or before init, can be hooked in and ready to go.
+ * Fixes should be registered to the manager using the the plugins_loaded hook with a
+ * priority of less than 20.
+ *
+ * @return void
+ */
+function edac_init_fixes_manager() {
+	$fixes_manager = FixesManager::get_instance();
+	$fixes_manager->register_fixes();
+}
+add_action( 'plugins_loaded', 'edac_init_fixes_manager', 20 );

--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -58,6 +58,31 @@ class FixesPage implements PageInterface {
 
 		$this->register_settings_sections();
 		$this->register_fields_and_settings();
+
+		add_filter( 'edac_filter_admin_scripts_slugs', [ $this, 'add_slug_to_admin_scripts' ] );
+		add_filter( 'edac_filter_remove_admin_notices_screens', [ $this, 'add_slug_to_admin_notices' ] );
+	}
+
+	/**
+	 * Add the fixes slug to the admin scripts.
+	 *
+	 * @param array $slugs The slugs that are already added.
+	 * @return array
+	 */
+	public function add_slug_to_admin_scripts( $slugs ) {
+		$slugs[] = 'accessibility_checker_' . self::PAGE_TAB_SLUG;
+		return $slugs;
+	}
+
+	/**
+	 * Add the fixes slug to the admin notices.
+	 *
+	 * @param array $slugs The slugs that are already added.
+	 * @return array
+	 */
+	public function add_slug_to_admin_notices( $slugs ) {
+		$slugs[] = 'accessibility-checker_page_accessibility_checker_' . self::PAGE_TAB_SLUG;
+		return $slugs;
 	}
 
 	/**

--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -51,8 +51,9 @@ class FixesPage implements PageInterface {
 			__( 'Accessibility Checker Settings', 'accessibility-checker' ),
 			__( 'Accessibility Fixes', 'accessibility-checker' ),
 			$this->settings_capability,
-			'accessibility_checker_fixes',
+			'accessibility_checker_' . self::PAGE_TAB_SLUG,
 			[ $this, 'render_page' ],
+			1
 		);
 
 		$this->register_settings_sections();

--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Admin page that holds the list of fix options.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage;
+
+/**
+ * Registers the Fixes page and it's settings.
+ *
+ * Sections and settings are passed through filters so that other plugins can add their own.
+ *
+ * @since 1.16.0
+ */
+class FixesPage implements PageInterface {
+
+	/**
+	 * The capability required to access the settings page.
+	 *
+	 * @var string
+	 */
+	private $settings_capability;
+
+	const PAGE_TAB_SLUG = 'fixes';
+
+	/**
+	 * The settings page slug which all sections, settings and fields are registered to.
+	 *
+	 * @var string
+	 */
+	const SETTINGS_SLUG = 'edac_settings_fixes';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $settings_capability The capability required to access the settings page.
+	 */
+	public function __construct( $settings_capability ) {
+		$this->settings_capability = $settings_capability;
+	}
+
+	/**
+	 * Add the page to the admin menu, setup it's tabs and filter in for the content.
+	 */
+	public function add_page() {
+
+		add_submenu_page(
+			'accessibility_checker',
+			__( 'Accessibility Checker Settings', 'accessibility-checker' ),
+			__( 'Fixes', 'accessibility-checker' ),
+			$this->settings_capability,
+			'accessibility_checker_fixes',
+			[ $this, 'render_page' ],
+		);
+
+		$this->register_settings_sections();
+		$this->register_fields_and_settings();
+	}
+
+	/**
+	 * Render the page.
+	 */
+	public function render_page() {
+		include_once EDAC_PLUGIN_DIR . 'partials/admin-page/fixes-page.php';
+	}
+
+	/**
+	 * Register the settings sections for this options page.
+	 *
+	 * Sections are passed through a filter so that other plugins can add their own.
+	 */
+	public function register_settings_sections() {
+
+		/**
+		 * Filter the sections that are registered for the fixes settings page.
+		 *
+		 * @since 1.16.0
+		 *
+		 * @param array $sections The sections that are to be registered for the fixes settings page. Must have the id as the key and an array with a title and callback.
+		 */
+		$sections = apply_filters(
+			'edac_filter_fixes_settings_sections',
+			[
+				'edac_fixes_general' => [
+					'title'    => __( 'General Settings', 'accessibility-checker' ),
+					'callback' => [ $this, 'fixes_section_general_cb' ],
+				],
+			]
+		);
+
+		foreach ( $sections as $section_id => $section ) {
+			if ( ! is_string( $section_id ) || ! isset( $section['title'], $section['callback'] ) ) {
+				continue;
+			}
+
+			// The callback must be callable otherwise it will throw an error.
+			if ( ! is_callable( $section['callback'] ) ) {
+				continue;
+			}
+
+			add_settings_section(
+				$section_id,
+				$section['title'],
+				$section['callback'],
+				self::SETTINGS_SLUG,
+			);
+		}
+	}
+
+	/**
+	 * Register the settings fields and settings for this options page.
+	 *
+	 * It passed through a filter so that other plugins can add their own settings.
+	 */
+	public function register_fields_and_settings() {
+		/**
+		 * Filter the fields that are registered for the fixes settings page.
+		 *
+		 * @since 1.16.0
+		 *
+		 * @param array $fields The fields that are to be registered for the fixes settings page.
+		 */
+		$fields = apply_filters( 'edac_filter_fixes_settings_fields', [] );
+
+		foreach ( $fields as $field_id => $field ) {
+
+			$field_type = $field['type'] ?? 'checkbox';
+			$sanitizer  = $field['sanitize_callback'] ?? [ $this, 'sanitize_checkbox' ];
+
+			add_settings_field(
+				$field_id,
+				$field['label'],
+				$field['callback'] ?? [ $this, $field_type ],
+				self::SETTINGS_SLUG,
+				$field['section'] ?? 'edac_fixes_general',
+				[
+					'name'        => $field_id,
+					'labelledby'  => $field_id,
+					'description' => $field['description'] ?? '',
+				]
+			);
+
+			register_setting( self::SETTINGS_SLUG, $field_id, $sanitizer );
+		}
+	}
+
+	/**
+	 * Callback for the general settings section that renders a description for it.
+	 */
+	public function fixes_section_general_cb() {
+		echo '<p>' . esc_html__( 'General settings for the fixes.', 'accessibility-checker' ) . '</p>';
+	}
+
+	/**
+	 * Render a checkbox input.
+	 *
+	 * @param array $args The arguments for the checkbox. This is expected to have a name and a description.
+	 */
+	public static function checkbox( $args ) {
+
+		// We need a name and a description or the checkbox is useless.
+		if ( ! isset( $args['name'], $args['description'] ) ) {
+			return;
+		}
+
+		$option_value = get_option( $args['name'] );
+		?>
+		<label>
+			<input
+				type="checkbox"
+				value="1"
+				id="<?php echo esc_attr( $args['name'] ); ?>"
+				name="<?php echo esc_attr( $args['name'] ); ?>"
+				<?php checked( 1, $option_value ); ?>
+			/>
+			<?php echo esc_html( $args['description'] ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Sanitize a checkbox input.
+	 *
+	 * @param mixed $input The input to sanitize.
+	 * @return int
+	 */
+	public function sanitize_checkbox( $input ) {
+		return isset( $input ) ? 1 : 0;
+	}
+}

--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -49,7 +49,7 @@ class FixesPage implements PageInterface {
 		add_submenu_page(
 			'accessibility_checker',
 			__( 'Accessibility Checker Settings', 'accessibility-checker' ),
-			__( 'Fixes', 'accessibility-checker' ),
+			__( 'Accessibility Fixes', 'accessibility-checker' ),
 			$this->settings_capability,
 			'accessibility_checker_fixes',
 			[ $this, 'render_page' ],

--- a/admin/AdminPage/PageInterface.php
+++ b/admin/AdminPage/PageInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Interface for managing admin pages.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage;
+
+interface PageInterface {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $settings_capability The capability required to access the settings page.
+	 */
+	public function __construct( $settings_capability );
+
+	/**
+	 * Add the page to the admin menu and register any settings.
+	 */
+	public function add_page();
+
+	/**
+	 * Render the page.
+	 */
+	public function render_page();
+}

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -59,12 +59,15 @@ class Admin_Notices {
 	public function edac_remove_admin_notices() {
 
 		$current_screen = get_current_screen();
-		$screens        = [
-			'toplevel_page_accessibility_checker',
-			'accessibility-checker_page_accessibility_checker_issues',
-			'accessibility-checker_page_accessibility_checker_ignored',
-			'accessibility-checker_page_accessibility_checker_settings',
-		];
+		$screens        = apply_filters(
+			'edac_filter_remove_admin_notices_screens',
+			[
+				'toplevel_page_accessibility_checker',
+				'accessibility-checker_page_accessibility_checker_issues',
+				'accessibility-checker_page_accessibility_checker_ignored',
+				'accessibility-checker_page_accessibility_checker_settings',
+			]
+		);
 
 		/**
 		 * Filter the screens where admin notices should be removed.

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -51,12 +51,15 @@ class Enqueue_Admin {
 		$post_types        = get_option( 'edac_post_types' );
 		$current_post_type = get_post_type();
 		$page              = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
-		$enabled_pages     = [
-			'accessibility_checker',
-			'accessibility_checker_settings',
-			'accessibility_checker_issues',
-			'accessibility_checker_ignored',
-		];
+		$enabled_pages     = apply_filters(
+			'edac_filter_admin_scripts_slugs',
+			[
+				'accessibility_checker',
+				'accessibility_checker_settings',
+				'accessibility_checker_issues',
+				'accessibility_checker_ignored',
+			]
+		);
 
 		if (
 			(

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "doctrine/instantiator": "^1.3.1",
         "wp-phpunit/wp-phpunit": "*",
         "phpstan/phpstan": "^1.11",
-		"phpstan/extension-installer": "^1.4",
+        "phpstan/extension-installer": "^1.4",
         "szepeviktor/phpstan-wordpress": "^1.3"
     },
     "require": {
@@ -61,14 +61,15 @@
             "includes/deprecated/"
         ],
         "psr-4": {
-            "EqualizeDigital\\AccessibilityChecker\\": "includes/classes/"
+            "EqualizeDigital\\AccessibilityChecker\\": "includes/classes/",
+			"EqualizeDigital\\AccessibilityChecker\\Admin\\": "admin/"
         }
     },
     "autoload-dev": {
         "classmap": [],
-		"psr-4": {
-			"EqualizeDigital\\AccessibilityChecker\\Tests\\TestHelpers\\": "tests/phpunit/TestHelpers/"
-		}
+        "psr-4": {
+            "EqualizeDigital\\AccessibilityChecker\\Tests\\TestHelpers\\": "tests/phpunit/TestHelpers/"
+        }
     },
     "scripts": {
         "lint": [

--- a/includes/classes/Fixes/FixInterface.php
+++ b/includes/classes/Fixes/FixInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Interface for creating fixes for the Accessibility Checker.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes;
+
+/**
+ * Interface for creating fixes for the Accessibility Checker.
+ *
+ * @since 1.16.0
+ */
+interface FixInterface {
+
+	/**
+	 * Get the slug for the fix.
+	 *
+	 * @return string This is the key that fixes are registered with. It must be unique.
+	 */
+	public static function get_slug(): string;
+
+	/**
+	 * Get the type for the fix.
+	 *
+	 * @return string The type of fix. Either 'backend', 'frontend' or everywhere.
+	 */
+	public static function get_type(): string;
+
+	/**
+	 * Register anything needed for the fix.
+	 *
+	 * Fixes are responsible for implementing their own 'run' method and binding it in here
+	 * if they are not just simple hooks.
+	 */
+	public function register(): void;
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -54,10 +54,10 @@ class FixesManager {
 		$fixes = apply_filters( 'edac_filter_fixes', [] );
 		foreach ( $fixes as $fix ) {
 			if ( is_subclass_of( $fix, '\EqualizeDigital\AccessibilityChecker\Fixes\FixInterface' ) ) {
-				if ( ! isset( $this->fixes[ $fix_class::get_slug() ] ) ) {
+				if ( ! isset( $this->fixes[ $fix::get_slug() ] ) ) {
 					$fix_class = new $fix();
 					$fix_class->register();
-					$this->fixes[ $fix_class::get_slug() ] = $fix_class;
+					$this->fixes[ $fix::get_slug() ] = $fix_class;
 				}
 			}
 		}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Manager class for fixes.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes;
+
+/**
+ * Manager class for fixes.
+ *
+ * @since 1.16.0
+ */
+class FixesManager {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var FixesManager|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * The fixes.
+	 *
+	 * @var array
+	 */
+	private $fixes = [];
+
+	/**
+	 * Private constructor to prevent direct instantiation.
+	 */
+	private function __construct() {
+		// stub.
+	}
+
+	/**
+	 * Get the single instance of the class.
+	 *
+	 * @return FixesManager
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Load the fixes.
+	 */
+	private function load_fixes() {
+		$fixes = apply_filters( 'edac_filter_fixes', [] );
+		foreach ( $fixes as $fix ) {
+			if ( is_subclass_of( $fix, '\EqualizeDigital\AccessibilityChecker\Fixes\FixInterface' ) ) {
+				if ( ! isset( $this->fixes[ $fix_class::get_slug() ] ) ) {
+					$fix_class = new $fix();
+					$fix_class->register();
+					$this->fixes[ $fix_class::get_slug() ] = $fix_class;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get a fix by its slug.
+	 *
+	 * @param string $slug The fix slug.
+	 *
+	 * @return FixInterface|null
+	 */
+	public function get_fix( $slug ) {
+		return isset( $this->fixes[ $slug ] ) ? $this->fixes[ $slug ] : null;
+	}
+
+	/**
+	 * Register the fixes.
+	 */
+	public function register_fixes() {
+		$this->load_fixes();
+
+		foreach ( $this->fixes as $fix ) {
+			if ( 'backend' === $fix::get_type() && is_admin() ) {
+				$fix->register();
+			} elseif ( 'frontend' === $fix::get_type() && ! is_admin() ) {
+				$fix->register();
+			} elseif ( 'everywhere' === $fix::get_type() ) {
+				$fix->register();
+			}
+		}
+	}
+}

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -10,6 +10,7 @@ namespace EDAC\Inc;
 use EDAC\Admin\Admin;
 use EDAC\Admin\Meta_Boxes;
 use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
+use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 /**
  * Main plugin functionality class.
@@ -31,6 +32,8 @@ class Plugin {
 		// The REST api must load if admin or not.
 		$rest_api = new REST_Api();
 		$rest_api->init_hooks();
+
+		$this->register_fixes_manager();
 
 		// When WP CLI is enabled, load the CLI commands.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -59,5 +62,29 @@ class Plugin {
 
 		$frontend_validate = new Frontend_Validate();
 		$frontend_validate->init_hooks();
+	}
+
+	/**
+	 * Register the FixesManager.
+	 *
+	 * @return void
+	 */
+	public function register_fixes_manager() {
+		add_action( 'plugins_loaded', [ $this, 'init_fixes_manager' ], 20 );
+	}
+
+	/**
+	 * Init the FixesManager.
+	 *
+	 * This is done on the plugins_loaded hook with a priority of 20 to ensure that fixes that
+	 * rely on running early, like on init or before init, can be hooked in and ready to go.
+	 * Fixes should be registered to the manager using the the plugins_loaded hook with a
+	 * priority of less than 20.
+	 *
+	 * @return void
+	 */
+	public function init_fixes_manager() {
+		$fixes_manager = FixesManager::get_instance();
+		$fixes_manager->register_fixes();
 	}
 }

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -7,6 +7,7 @@
 
 use EDAC\Admin\Purge_Post_Data;
 use EDAC\Inc\Accessibility_Statement;
+use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 
 /**
  * Check if user can ignore or can manage options
@@ -68,6 +69,9 @@ function edac_add_options_page() {
 		'edac_display_options_page'
 		// The submenu doesn't typically require a separate icon.
 	);
+
+	$fixes_page = new FixesPage( $settings_capability );
+	$fixes_page->add_page();
 }
 
 /**

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -16,6 +16,6 @@
 		?>
 	</form>
 	<?php if ( EDAC_KEY_VALID === false ) { ?>
-		<div><?php include 'pro-callout.php'; ?></div>
+		<div><?php include EDAC_PLUGIN_DIR . 'partials/pro-callout.php'; ?></div>
 	<?php } ?>
 </div>

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Accessibility Checker pluign file.
+ *
+ * @package Accessibility_Checker
+ */
+
+?>
+
+<div class="edac-settings-general <?php echo EDAC_KEY_VALID ? '' : 'edac-show-pro-callout'; ?>">
+	<form action="options.php" method="post">
+		<?php
+		settings_fields( 'edac_settings_fixes' );
+		do_settings_sections( 'edac_settings_fixes' );
+		submit_button();
+		?>
+	</form>
+	<?php if ( EDAC_KEY_VALID === false ) { ?>
+		<div><?php include 'pro-callout.php'; ?></div>
+	<?php } ?>
+</div>

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -6,16 +6,21 @@
  */
 
 ?>
+<div class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
+	<h1><?php esc_html_e( 'Accessibility Fixes', 'accessibility-checker' ); ?></h1>
 
-<div class="edac-settings-general <?php echo EDAC_KEY_VALID ? '' : 'edac-show-pro-callout'; ?>">
-	<form action="options.php" method="post">
-		<?php
-		settings_fields( 'edac_settings_fixes' );
-		do_settings_sections( 'edac_settings_fixes' );
-		submit_button();
-		?>
-	</form>
-	<?php if ( EDAC_KEY_VALID === false ) { ?>
-		<div><?php include EDAC_PLUGIN_DIR . 'partials/pro-callout.php'; ?></div>
-	<?php } ?>
+	<div class="tab-content">
+		<div class="edac-settings-general <?php echo EDAC_KEY_VALID ? '' : 'edac-show-pro-callout'; ?>">
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( 'edac_settings_fixes' );
+				do_settings_sections( 'edac_settings_fixes' );
+				submit_button();
+				?>
+			</form>
+			<?php if ( EDAC_KEY_VALID === false ) { ?>
+				<div><?php include EDAC_PLUGIN_DIR . 'partials/pro-callout.php'; ?></div>
+			<?php } ?>
+		</div>
+	</div>
 </div>


### PR DESCRIPTION
This PR introduces a framework to manage various fixes that the plugin can apply to users sites. There are no actual fixes added yet in this PR as it just puts the framework in place for adding the fixes.

- A settings page is added, initially supporting just checkbox type options
- Filters exist to add sections to the options page and register settings to any section on it
- Actions (will be) added where the fixes will have to be run or triggered.

## Checklist

- [x] PR is linked to a card
- [ ] Tests are added that cover changes
