### PR TITLE
added: aria label to the disable styles button

### DIFF
--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -107,6 +107,8 @@ class Enqueue_Frontend {
 				]
 			);
 
+			wp_set_script_translations( 'edac-frontend-highlighter-app', 'accessibility-checker' );
+
 		}
 	}
 }

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -4,6 +4,7 @@
 import { computePosition, autoUpdate } from '@floating-ui/dom';
 import { createFocusTrap } from 'focus-trap';
 import { isFocusable } from 'tabbable';
+import { __ } from '@wordpress/i18n';
 
 class AccessibilityCheckerHighlight {
 	/**
@@ -356,7 +357,7 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
 					<div>
-						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="Disable Page Styles">Disable Styles</button>
+						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'text-domain' ) }</button>
 					</div>
 				</div>
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -356,7 +356,7 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
 					<div>
-						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite">Disable Styles</button>
+						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="Disable Page Styles">Disable Styles</button>
 					</div>
 				</div>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const CssMinimizerPlugin = require( 'css-minimizer-webpack-plugin' );
 
 module.exports = {
-	mode: 'none', //development | production
+	mode: 'production', //development | production
 	watch: false,
 	entry: {
 		admin: [


### PR DESCRIPTION
This PR adds `aria-label="Disable Page Styles"` to the disable styles button to provide more context to screen readers. It adds the ability to translate strings in the JavaScript file.

Fixes: #362 

## Checklist

- [x] PR is linked to the main issue in the repo
