### PR TITLE
updated: highlight button aria-label to be unique and added aria-haspopup equal to dialog

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -124,7 +124,7 @@ class AccessibilityCheckerHighlight {
 
 		for ( const element of allElements ) {
 			if ( element.outerHTML.replace( /\W/g, '' ) === htmlToFind.replace( /\W/g, '' ) ) {
-				const tooltip = this.addTooltip( element, value, index );
+				const tooltip = this.addTooltip( element, value, index, this.issues.length );
 
 				this.issues[ index ].tooltip = tooltip.tooltip;
 
@@ -244,13 +244,13 @@ class AccessibilityCheckerHighlight {
 	 * @return {Object} - information about the tooltip
 	 */
 	/* eslint-disable no-unused-vars */
-	addTooltip( element, value, index ) {
+	addTooltip( element, value, index, totalItems ) {
 		// Create the tooltip.
 		const tooltip = document.createElement( 'button' );
 		tooltip.classList = 'edac-highlight-btn edac-highlight-btn-' + value.rule_type;
-		tooltip.ariaLabel = value.rule_title;
-		tooltip.ariaExpanded = 'false';
-		//tooltip.ariaControls = 'edac-highlight-tooltip-' + value.id;
+		tooltip.setAttribute( 'aria-label', `Open details for ${ value.rule_title }, ${ index + 1 } of ${ totalItems }` );
+		tooltip.setAttribute( 'aria-expanded', 'false' );
+		tooltip.setAttribute( 'aria-haspopup', 'dialog' );
 
 		//add data-id to the tooltip/button so we can find it later.
 		tooltip.dataset.id = value.id;


### PR DESCRIPTION
This PR improves the accessibility of the highlight buttons.

- Added unique aria-label
- Added `aria-haspopup="dialog"`
- Switch to the `setAttribute` method to ensure attributes are added correctly
- Cleaned up commented code

<img width="1035" alt="Screenshot 2024-08-15 at 10 22 02 PM" src="https://github.com/user-attachments/assets/39f9679e-add2-44eb-8061-0b368598c452">


Fixes #218 
Card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7667317750

## Checklist

- [x] PR is linked to the main issue in the repo
