### PR TITLE
updated: scan stats passed percentage default value

### DIFF
--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -182,7 +182,7 @@ class Scans_Stats {
 		}
 		$data['rules_passed'] = $this->rule_count - $data['rules_failed'];
 
-		$data['passed_percentage'] = 0;
+		$data['passed_percentage'] = 100;
 		if ( $data['posts_scanned'] > 0 && $tests_count > 0 ) {
 			$data['passed_percentage'] = round( ( $data['rules_passed'] / $this->rule_count ) * 100, 2 );
 		}


### PR DESCRIPTION
The PR updates the site stats `passed_percentage` default value to 100.

![2024-08-29 16 33 30](https://github.com/user-attachments/assets/1ece0539-8681-43aa-89cd-2ad231017ac5)

![Screenshot 2024-08-29 at 4 36 37 PM](https://github.com/user-attachments/assets/b9ddd080-f8fa-4a80-8a2f-cd931f942d16)

Issue: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7698264126
