### PR TITLE
Added: Fix for adding skip links when they are not there

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -16,6 +16,9 @@ namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage;
  */
 class FixesPage implements PageInterface {
 
+	use FixesSettingType\Checkbox;
+	use FixesSettingType\Text;
+
 	/**
 	 * The capability required to access the settings page.
 	 *
@@ -177,42 +180,5 @@ class FixesPage implements PageInterface {
 	 */
 	public function fixes_section_general_cb() {
 		echo '<p>' . esc_html__( 'General settings for the fixes.', 'accessibility-checker' ) . '</p>';
-	}
-
-	/**
-	 * Render a checkbox input.
-	 *
-	 * @param array $args The arguments for the checkbox. This is expected to have a name and a description.
-	 */
-	public static function checkbox( $args ) {
-
-		// We need a name and a description or the checkbox is useless.
-		if ( ! isset( $args['name'], $args['description'] ) ) {
-			return;
-		}
-
-		$option_value = get_option( $args['name'] );
-		?>
-		<label>
-			<input
-				type="checkbox"
-				value="1"
-				id="<?php echo esc_attr( $args['name'] ); ?>"
-				name="<?php echo esc_attr( $args['name'] ); ?>"
-				<?php checked( 1, $option_value ); ?>
-			/>
-			<?php echo esc_html( $args['description'] ); ?>
-		</label>
-		<?php
-	}
-
-	/**
-	 * Sanitize a checkbox input.
-	 *
-	 * @param mixed $input The input to sanitize.
-	 * @return int
-	 */
-	public function sanitize_checkbox( $input ) {
-		return isset( $input ) ? 1 : 0;
 	}
 }

--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -168,6 +168,7 @@ class FixesPage implements PageInterface {
 					'name'        => $field_id,
 					'labelledby'  => $field_id,
 					'description' => $field['description'] ?? '',
+					'condition'   => $field['condition'] ?? '',
 				]
 			);
 

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * A class with methods to handle settings checkboxes for on the fixes page.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesSettingType;
+
+/**
+ * A trait to handle settings checkboxes for on the fixes page.
+ */
+trait Checkbox {
+
+	/**
+	 * Render a checkbox input.
+	 *
+	 * @param array $args The arguments for the checkbox. This is expected to have a name and a description.
+	 */
+	public static function checkbox( $args ) {
+
+		// We need a name and a description or the checkbox is useless.
+		if ( ! isset( $args['name'], $args['description'] ) ) {
+			return;
+		}
+
+		$option_value = get_option( $args['name'] );
+		?>
+		<label>
+			<input
+				type="checkbox"
+				value="1"
+				id="<?php echo esc_attr( $args['name'] ); ?>"
+				name="<?php echo esc_attr( $args['name'] ); ?>"
+				<?php checked( 1, $option_value ); ?>
+			/>
+			<?php echo esc_html( $args['description'] ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Sanitize a checkbox input.
+	 *
+	 * @param mixed $input The input to sanitize.
+	 * @return int
+	 */
+	public function sanitize_checkbox( $input ) {
+		return isset( $input ) ? 1 : 0;
+	}
+}

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -33,6 +33,7 @@ trait Checkbox {
 				id="<?php echo esc_attr( $args['name'] ); ?>"
 				name="<?php echo esc_attr( $args['name'] ); ?>"
 				<?php checked( 1, $option_value ); ?>
+				<?php echo isset( $args['condition'] ) ? 'data-condition="' . esc_attr( $args['condition'] ) . '"' : ''; ?>
 			/>
 			<?php echo esc_html( $args['description'] ); ?>
 		</label>

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * A class with methods to handle settings checkboxes for on the fixes page.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesSettingType;
+
+/**
+ * A trait to handle settings text inputs for on the fixes page.
+ */
+trait Text {
+
+	/**
+	 * Render a text input.
+	 *
+	 * @param array $args The arguments for the text input. This is expected to have a name and a description.
+	 */
+	public static function text( $args ) {
+		// We need a name and a description or the text field is useless.
+		if ( ! isset( $args['name'], $args['description'] ) ) {
+			return;
+		}
+
+		$option_value = get_option( $args['name'] );
+		?>
+		<label
+			for="<?php echo esc_attr( $args['name'] ); ?>"
+			style="display: block; margin-bottom: 6px;"
+		>
+			<?php echo esc_html( $args['description'] ); ?>
+		</label>
+		<input
+			type="text"
+			id="<?php echo esc_attr( $args['name'] ); ?>"
+			name="<?php echo esc_attr( $args['name'] ); ?>"
+			value="<?php echo esc_attr( $option_value ); ?>"
+			<?php echo isset( $args['condition'] ) ? 'data-condition="' . esc_attr( $args['condition'] ) . '"' : ''; ?>
+		/>
+		<?php
+	}
+
+	/**
+	 * Sanitize a text input.
+	 *
+	 * @param mixed $input The input to sanitize.
+	 * @return string
+	 */
+	public function sanitize_text( $input ) {
+		return sanitize_text_field( $input );
+	}
+}

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -80,7 +80,7 @@ class SkipLinkFix implements FixInterface {
 					'label'       => esc_html__( 'Disable Skip Link Bundled Styles', 'accessibility-checker' ),
 					'type'        => 'checkbox',
 					'labelledby'  => 'disable_skip_link_styles',
-					'description' => esc_html__( 'Disable output of the bundled styles, you will need to provide your own style rules if you enable this.', 'accessibility-checker' ),
+					'description' => esc_html__( 'Disable output of the bundled styles. This makes the "Always Visible Skip Link" setting above irrelevent.', 'accessibility-checker' ),
 					'condition'   => 'edac_fix_add_skip_link',
 				];
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -88,6 +88,23 @@ class SkipLinkFix implements FixInterface {
 				width: 1px;
 				word-wrap: normal !important;
 			}
+			.edac-skip-link:focus {
+				background-color: #ddd;
+				clip: auto !important;
+				-webkit-clip-path: none;
+				clip-path: none;
+				color: #444;
+				display: block;
+				font-size: 1em;
+				height: auto;
+				left: 5px;
+				line-height: normal;
+				padding: 15px 23px 14px;
+				text-decoration: none;
+				top: 5px;
+				width: auto;
+				z-index: 100000;
+			}
 		</style>
 		<?php
 	}

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -12,7 +12,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 /**
  * Allows the user to add a skip link to the site if their theme does not already include them.
  *
- * @since x.x.x
+ * @since 1.16.0
  */
 class SkipLinkFix implements FixInterface {
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -127,7 +127,7 @@ class SkipLinkFix implements FixInterface {
 	public function add_skip_link_styles() {
 		?>
 		<style id="edac-fix-skip-link-styles">
-			.edac-skip-link {
+			.edac-bypass-block {
 				border: 0;
 				clip: rect(1px, 1px, 1px, 1px);
 				clip-path: inset(50%);
@@ -139,22 +139,48 @@ class SkipLinkFix implements FixInterface {
 				width: 1px;
 				word-wrap: normal !important;
 			}
-			.edac-skip-link:focus {
+			.admin-bar .edac-bypass-block {
+				top: 37px;
+			}
+			@media screen and (max-width: 782px) {
+				.admin-bar .edac-bypass-block {
+					top: 51px;
+				}
+			}
+
+			.edac-bypass-block:focus-within,
+			.edac-bypass-block-always-visible {
 				background-color: #ddd;
 				clip: auto !important;
 				-webkit-clip-path: none;
 				clip-path: none;
-				color: #444;
 				display: block;
-				font-size: 1em;
+				font-size: 1rem;
 				height: auto;
 				left: 5px;
 				line-height: normal;
-				padding: 15px 23px 14px;
-				text-decoration: none;
+				padding: 8px 22px 10px;
 				top: 5px;
 				width: auto;
 				z-index: 100000;
+			}
+
+			.edac-bypass-block > a {
+				display: block;
+				margin: 0.5rem 0;
+				color: #444;
+				text-decoration: underline;
+			}
+
+			.edac-bypass-block > a:hover,
+			.edac-bypass-block > a:focus {
+				text-decoration: none;
+				color: #0073aa;
+			}
+
+			.edac-bypass-block > a:focus {
+				outline: 2px solid #000;
+				outline-offset: 2px;
 			}
 		</style>
 		<?php
@@ -168,13 +194,26 @@ class SkipLinkFix implements FixInterface {
 	public function add_skip_link() {
 
 		$targets_string = get_option( 'edac_fix_add_skip_link_target_id', '' );
-		if ( ! $targets_string ) {
+
+		$nav_targets_string = get_option( 'edac_fix_add_skip_link_nav_target_id', '' );
+
+		if ( ! $targets_string && ! $nav_targets_string ) {
 			return;
 		}
 		?>
 		<template id="skip-link-template">
-			<a class="edac-skip-link" href=""><?php esc_html_e( 'Skip to content', 'accessibility-checker' ); ?></a>
-			<?php $this->add_skip_link_styles(); ?>
+			<div class="edac-bypass-block <?php echo get_option( 'edac_fix_add_skip_link_always_visible', false ) ? 'edac-bypass-block-always-visible' : ''; ?>">
+				<?php if ( $targets_string ) : ?>
+					<a class="edac-skip-link--content" href=""><?php esc_html_e( 'Skip to content', 'accessibility-checker' ); ?></a>
+				<?php endif; ?>
+				<?php
+				if ( $nav_targets_string ) :
+					$nav_target = ltrim( trim( $nav_targets_string ), '#' );
+					?>
+					<a class="edac-skip-link--navigation" href="#<?php echo esc_attr( $nav_target ); ?>"><?php esc_html_e( 'Skip to navigation', 'accessibility-checker' ); ?></a>
+				<?php endif; ?>
+				<?php get_option( 'edac_fix_disable_skip_link_styles', false ) ? '' : $this->add_skip_link_styles(); ?>
+			</div>
 		</template>
 
 		<?php

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -65,7 +65,6 @@ class SkipLinkFix implements FixInterface {
 
 		if ( get_option( 'edac_fix_add_skip_link', false ) ) {
 			add_action( 'wp_body_open', [ $this, 'add_skip_link' ] );
-			remove_action( 'wp_footer', 'the_block_template_skip_link' );
 		}
 	}
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Skip Link Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Allows the user to add a skip link to the site if their theme does not already include them.
+ *
+ * @since x.x.x
+ */
+class SkipLinkFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'skip-link';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the skip link fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+				$fields['edac_fix_add_skip_link'] = [
+					'label'       => esc_html__( 'Add Skip Link', 'accessibility-checker' ),
+					'type'        => 'checkbox',
+					'labelledby'  => 'add_skip_link',
+					'description' => esc_html__( 'Add a skip link to all of your site pages.', 'accessibility-checker' ),
+				];
+
+				$fields['edac_fix_add_skip_link_target_id'] = [
+					'label'             => esc_html__( 'Skip Link Target ID', 'accessibility-checker' ),
+					'type'              => 'text',
+					'labelledby'        => 'skip_link_target_id',
+					'description'       => esc_html__( 'The ID for the skip links to target.', 'accessibility-checker' ),
+					'sanitize_callback' => 'sanitize_text_field',
+					'condition'         => 'edac_fix_add_skip_link',
+				];
+
+				return $fields;
+			}
+		);
+
+		if ( get_option( 'edac_fix_add_skip_link', false ) ) {
+			add_action( 'wp_head', [ $this, 'add_skip_link_styles' ] );
+			add_action( 'wp_body_open', [ $this, 'add_skip_link' ] );
+		}
+	}
+
+	/**
+	 * Injects the style rules for the skip link.
+	 *
+	 * @return void
+	 */
+	public function add_skip_link_styles() {
+		?>
+		<style id="edac-fix-skip-link-styles">
+			.edac-skip-link {
+				border: 0;
+				clip: rect(1px, 1px, 1px, 1px);
+				clip-path: inset(50%);
+				height: 1px;
+				margin: -1px;
+				overflow: hidden;
+				padding: 0;
+				position: absolute !important;
+				width: 1px;
+				word-wrap: normal !important;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Adds the skip link code to the page.
+	 *
+	 * @return void
+	 */
+	public function add_skip_link() {
+
+		$target = get_option( 'edac_fix_add_skip_link_target_id', '' );
+		if ( ! $target ) {
+			return;
+		}
+
+		// If $target starts with '#', remove it.
+		$target = ltrim( $target, '#' );
+		?>
+		<a class="edac-skip-link" href="#<?php echo esc_attr( $target ); ?>"><?php esc_html_e( 'Skip to content', 'accessibility-checker' ); ?></a>
+		<?php
+	}
+}

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -74,12 +74,12 @@ class SkipLinkFix implements FixInterface {
 			$targets_list = explode( ',', $targets_string );
 
 			foreach ( $targets_list as $target ) {
-				// trim whitespace the target.
-				$trimmed = trim( ltrim( $target, '#' ) );
+				// trim whitespace and any leading '#'.
+				$trimmed = ltrim( trim( $target ), '#' );
 				if ( empty( $trimmed ) ) {
 					continue;
 				}
-				$targets[] = '#' . trim( ltrim( $target, '#' ) );
+				$targets[] = '#' . $trimmed;
 			}
 			add_filter(
 				'edac_filter_frontend_fixes_data',

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -44,19 +44,44 @@ class SkipLinkFix implements FixInterface {
 			'edac_filter_fixes_settings_fields',
 			function ( $fields ) {
 				$fields['edac_fix_add_skip_link'] = [
-					'label'       => esc_html__( 'Add Skip Link', 'accessibility-checker' ),
+					'label'       => esc_html__( 'Enable Skip Link', 'accessibility-checker' ),
 					'type'        => 'checkbox',
 					'labelledby'  => 'add_skip_link',
 					'description' => esc_html__( 'Add a skip link to all of your site pages.', 'accessibility-checker' ),
+				];
+
+				$fields['edac_fix_add_skip_link_always_visible'] = [
+					'label'       => esc_html__( 'Always Visible Skip Link', 'accessibility-checker' ),
+					'type'        => 'checkbox',
+					'labelledby'  => 'add_skip_link_always_visible',
+					'description' => esc_html__( 'Make the skip link always visible.', 'accessibility-checker' ),
+					'condition'   => 'edac_fix_add_skip_link',
 				];
 
 				$fields['edac_fix_add_skip_link_target_id'] = [
 					'label'             => esc_html__( 'Skip Link Target ID', 'accessibility-checker' ),
 					'type'              => 'text',
 					'labelledby'        => 'skip_link_target_id',
-					'description'       => esc_html__( 'The ID for the skip links to target. Enter multiple ids seporated by commas and it will cascade through the list to find the appropriate one for that page.', 'accessibility-checker' ),
+					'description'       => esc_html__( 'The ID for the skip links to target the main content, starting with "#". Enter multiple ids seporated by commas and it will cascade through the list to find the appropriate one for that page if you have several different main content areas on your site.', 'accessibility-checker' ),
 					'sanitize_callback' => 'sanitize_text_field',
 					'condition'         => 'edac_fix_add_skip_link',
+				];
+
+				$fields['edac_fix_add_skip_link_nav_target_id'] = [
+					'label'             => esc_html__( 'Skip Link Target ID', 'accessibility-checker' ),
+					'type'              => 'text',
+					'labelledby'        => 'skip_link_nav_target_id',
+					'description'       => esc_html__( 'ID attribute for the navigation, starting with "#"', 'accessibility-checker' ),
+					'sanitize_callback' => 'sanitize_text_field',
+					'condition'         => 'edac_fix_add_skip_link',
+				];
+
+				$fields['edac_fix_disable_skip_link_styles'] = [
+					'label'       => esc_html__( 'Disable Skip Link Bundled Styles', 'accessibility-checker' ),
+					'type'        => 'checkbox',
+					'labelledby'  => 'disable_skip_link_styles',
+					'description' => esc_html__( 'Disable output of the bundled styles, you will need to provide your own style rules if you enable this.', 'accessibility-checker' ),
+					'condition'   => 'edac_fix_add_skip_link',
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -161,7 +161,7 @@ class SkipLinkFix implements FixInterface {
 
 			.edac-bypass-block:focus-within,
 			.edac-bypass-block-always-visible {
-				background-color: #ddd;
+				background-color: #ededed;
 				clip: auto !important;
 				-webkit-clip-path: none;
 				clip-path: none;

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -179,7 +179,7 @@ class SkipLinkFix implements FixInterface {
 			.edac-bypass-block > a:hover,
 			.edac-bypass-block > a:focus {
 				text-decoration: none;
-				color: #0073aa;
+				color: #006595;
 			}
 
 			.edac-bypass-block > a:focus {

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -40,6 +40,20 @@ class SkipLinkFix implements FixInterface {
 	 * @return void
 	 */
 	public function register(): void {
+
+		add_filter(
+			'edac_filter_fixes_settings_sections',
+			function ( $sections ) {
+				$sections['skip_link'] = [
+					'title'       => esc_html__( 'Skip Link', 'accessibility-checker' ),
+					'description' => esc_html__( 'Add a skip link to all of your site pages.', 'accessibility-checker' ),
+					'callback'    => [ $this, 'skip_link_section_callback' ],
+				];
+
+				return $sections;
+			}
+		);
+
 		add_filter(
 			'edac_filter_fixes_settings_fields',
 			function ( $fields ) {
@@ -48,6 +62,7 @@ class SkipLinkFix implements FixInterface {
 					'type'        => 'checkbox',
 					'labelledby'  => 'add_skip_link',
 					'description' => esc_html__( 'Add a skip link to all of your site pages.', 'accessibility-checker' ),
+					'section'     => 'skip_link',
 				];
 
 				$fields['edac_fix_add_skip_link_always_visible'] = [
@@ -55,6 +70,7 @@ class SkipLinkFix implements FixInterface {
 					'type'        => 'checkbox',
 					'labelledby'  => 'add_skip_link_always_visible',
 					'description' => esc_html__( 'Make the skip link always visible.', 'accessibility-checker' ),
+					'section'     => 'skip_link',
 					'condition'   => 'edac_fix_add_skip_link',
 				];
 
@@ -64,6 +80,7 @@ class SkipLinkFix implements FixInterface {
 					'labelledby'        => 'skip_link_target_id',
 					'description'       => esc_html__( 'The ID for the skip links to target the main content, starting with "#". Enter multiple ids seporated by commas and it will cascade through the list to find the appropriate one for that page if you have several different main content areas on your site.', 'accessibility-checker' ),
 					'sanitize_callback' => 'sanitize_text_field',
+					'section'           => 'skip_link',
 					'condition'         => 'edac_fix_add_skip_link',
 				];
 
@@ -73,6 +90,7 @@ class SkipLinkFix implements FixInterface {
 					'labelledby'        => 'skip_link_nav_target_id',
 					'description'       => esc_html__( 'ID attribute for the navigation, starting with "#"', 'accessibility-checker' ),
 					'sanitize_callback' => 'sanitize_text_field',
+					'section'           => 'skip_link',
 					'condition'         => 'edac_fix_add_skip_link',
 				];
 
@@ -81,6 +99,7 @@ class SkipLinkFix implements FixInterface {
 					'type'        => 'checkbox',
 					'labelledby'  => 'disable_skip_link_styles',
 					'description' => esc_html__( 'Disable output of the bundled styles. This makes the "Always Visible Skip Link" setting above irrelevent.', 'accessibility-checker' ),
+					'section'     => 'skip_link',
 					'condition'   => 'edac_fix_add_skip_link',
 				];
 
@@ -187,6 +206,17 @@ class SkipLinkFix implements FixInterface {
 				outline-offset: 2px;
 			}
 		</style>
+		<?php
+	}
+
+	/**
+	 * Callback for the skip link section.
+	 *
+	 * @return void
+	 */
+	public function skip_link_section_callback() {
+		?>
+		<p><?php esc_html_e( 'Settings related to the skip link fixes.', 'accessibility-checker' ); ?></p>
 		<?php
 	}
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -54,7 +54,7 @@ class SkipLinkFix implements FixInterface {
 					'label'             => esc_html__( 'Skip Link Target ID', 'accessibility-checker' ),
 					'type'              => 'text',
 					'labelledby'        => 'skip_link_target_id',
-					'description'       => esc_html__( 'The ID for the skip links to target.', 'accessibility-checker' ),
+					'description'       => esc_html__( 'The ID for the skip links to target. Enter multiple ids seporated by commas and it will cascade through the list to find the appropriate one for that page.', 'accessibility-checker' ),
 					'sanitize_callback' => 'sanitize_text_field',
 					'condition'         => 'edac_fix_add_skip_link',
 				];

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -65,6 +65,7 @@ class SkipLinkFix implements FixInterface {
 
 		if ( get_option( 'edac_fix_add_skip_link', false ) ) {
 			add_action( 'wp_body_open', [ $this, 'add_skip_link' ] );
+			remove_action( 'wp_footer', 'the_block_template_skip_link' );
 		}
 	}
 
@@ -121,7 +122,7 @@ class SkipLinkFix implements FixInterface {
 			const edacSkipLinkTargets = <?php echo wp_json_encode( $targets ); ?>;
 
 			const findFirstLinkOutsideContainer = (containerSelector) => {
-				const links = document.querySelectorAll('body a');
+				const links = document.querySelectorAll('body a:not(.ab-item)');
 				for (const link of links) {
 					if (!link.closest(containerSelector)) {
 						return link;

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -168,6 +168,7 @@ class SkipLinkFix implements FixInterface {
 				const foundTarget = edacSkipLinkTargets.find(target => document.querySelector(target));
 
 				if (!foundTarget) {
+					console.log( '<?php esc_html_e( 'EDAC: Did not find a matching target ID on the page for the skip link.', 'accessibility-checker' ); ?>' );
 					return;
 				}
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -139,14 +139,6 @@ class SkipLinkFix implements FixInterface {
 				width: 1px;
 				word-wrap: normal !important;
 			}
-			.admin-bar .edac-bypass-block {
-				top: 37px;
-			}
-			@media screen and (max-width: 782px) {
-				.admin-bar .edac-bypass-block {
-					top: 51px;
-				}
-			}
 
 			.edac-bypass-block:focus-within,
 			.edac-bypass-block-always-visible {
@@ -163,6 +155,18 @@ class SkipLinkFix implements FixInterface {
 				top: 5px;
 				width: auto;
 				z-index: 100000;
+			}
+
+			.admin-bar .edac-bypass-block,
+			.admin-bar .edac-bypass-block:focus-within {
+				top: 37px;
+			}
+
+			@media screen and (max-width: 782px) {
+				.admin-bar .edac-bypass-block,
+				.admin-bar .edac-bypass-block:focus-within {
+					top: 51px;
+				}
 			}
 
 			.edac-bypass-block > a {
@@ -215,7 +219,6 @@ class SkipLinkFix implements FixInterface {
 				<?php get_option( 'edac_fix_disable_skip_link_styles', false ) ? '' : $this->add_skip_link_styles(); ?>
 			</div>
 		</template>
-
 		<?php
 	}
 }

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -120,9 +120,20 @@ class SkipLinkFix implements FixInterface {
 
 			const edacSkipLinkTargets = <?php echo wp_json_encode( $targets ); ?>;
 
+			const findFirstLinkOutsideContainer = (containerSelector) => {
+				const links = document.querySelectorAll('body a');
+				for (const link of links) {
+					if (!link.closest(containerSelector)) {
+						return link;
+					}
+				}
+				return null;
+			};
+
 			const tryDetectSkipLink = () => {
+
 				// get the very first link on the page.
-				const firstLink = document.querySelector('a');
+				firstLink = findFirstLinkOutsideContainer('#wpadminbar');
 
 				// does the first link point to an anchor on the page?
 				if (firstLink && firstLink.href && firstLink.href.indexOf('#') !== -1) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -7,6 +7,8 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
+
 /**
  * Manager class for fixes.
  *
@@ -51,7 +53,12 @@ class FixesManager {
 	 * Load the fixes.
 	 */
 	private function load_fixes() {
-		$fixes = apply_filters( 'edac_filter_fixes', [] );
+		$fixes = apply_filters(
+			'edac_filter_fixes',
+			[
+				SkipLinkFix::class,
+			]
+		);
 		foreach ( $fixes as $fix ) {
 			if ( is_subclass_of( $fix, '\EqualizeDigital\AccessibilityChecker\Fixes\FixInterface' ) ) {
 				if ( ! isset( $this->fixes[ $fix::get_slug() ] ) ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -34,7 +34,7 @@ class FixesManager {
 	 * Private constructor to prevent direct instantiation.
 	 */
 	private function __construct() {
-		// stub.
+		$this->maybe_enqueue_frontend_scripts();
 	}
 
 	/**
@@ -47,6 +47,26 @@ class FixesManager {
 			self::$instance = new self();
 		}
 		return self::$instance;
+	}
+
+	/**
+	 * Maybe enqueue the frontend scripts.
+	 */
+	private function maybe_enqueue_frontend_scripts() {
+		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
+		if ( ! is_admin() ) {
+			add_action(
+				'wp_enqueue_scripts',
+				function () {
+					wp_enqueue_script( 'edac-frontend-fixes', EDAC_PLUGIN_URL . 'build/frontendFixes.bundle.js', [], EDAC_VERSION, true );
+					wp_localize_script(
+						'edac-frontend-fixes',
+						'edac_frontend_fixes',
+						apply_filters( 'edac_filter_frontend_fixes_data', [] )
+					);
+				}
+			);
+		}
 	}
 
 	/**

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -6,7 +6,7 @@
  */
 
 ?>
-<div class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
+<div id="edac-fixes-page" class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
 	<h1><?php esc_html_e( 'Accessibility Fixes', 'accessibility-checker' ); ?></h1>
 
 	<div class="tab-content">

--- a/src/admin/fixes-page/conditional-disable-settings.js
+++ b/src/admin/fixes-page/conditional-disable-settings.js
@@ -22,9 +22,7 @@ const setInputStates = () => {
 };
 
 export const initFixesInputStateHandler = () => {
-	document.addEventListener( 'DOMContentLoaded', () => {
-		setInputStates();
-	} );
+	setInputStates();
 
 	// Find all checkboxes inside the form.
 	const checkboxes = document.querySelectorAll( '.edac-settings form input[type="checkbox"]' );

--- a/src/admin/fixes-page/conditional-disable-settings.js
+++ b/src/admin/fixes-page/conditional-disable-settings.js
@@ -1,0 +1,37 @@
+const setInputStates = () => {
+	const elements = document.querySelectorAll( '[data-condition]' );
+
+	elements.forEach( ( element ) => {
+		const conditionId = element.getAttribute( 'data-condition' );
+
+		const conditionElement = document.getElementById( conditionId );
+
+		if ( conditionElement ) {
+			if ( conditionElement.tagName.toLowerCase() === 'input' ) {
+				if ( ( conditionElement.type === 'text' && conditionElement.value.trim() !== '' ) ||
+					( conditionElement.type === 'checkbox' && conditionElement.checked ) ) {
+					element.disabled = false;
+					element.closest( 'tr' ).classList.remove( 'edac_fix_disabled' );
+				} else {
+					element.disabled = true;
+					element.closest( 'tr' ).classList.add( 'edac_fix_disabled' );
+				}
+			}
+		}
+	} );
+};
+
+export const initFixesInputStateHandler = () => {
+	document.addEventListener( 'DOMContentLoaded', () => {
+		setInputStates();
+	} );
+
+	// Find all checkboxes inside the form.
+	const checkboxes = document.querySelectorAll( '.edac-settings form input[type="checkbox"]' );
+	checkboxes.forEach( ( checkbox ) => {
+		checkbox.addEventListener( 'change', () => {
+			setInputStates();
+		} );
+	} );
+};
+

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -4,6 +4,7 @@ import {
 	clearAllTabsAndPanelState,
 	initSummaryTabKeyboardAndClickHandlers,
 } from './summary/summary-tab-input-event-handlers';
+import { initFixesInputStateHandler } from './fixes-page/conditional-disable-settings';
 
 // eslint-disable-next-line camelcase
 const edacScriptVars = edac_script_vars;
@@ -12,6 +13,10 @@ const edacScriptVars = edac_script_vars;
 	'use strict';
 
 	jQuery( function() {
+		if ( document.getElementById( 'edac-fixes-page' ) ) {
+			initFixesInputStateHandler();
+		}
+
 		// Accessibility Statement disable
 		jQuery(
 			'input[type=checkbox][name=edac_add_footer_accessibility_statement]'

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1930,3 +1930,10 @@
   }
 
 }
+
+#edac-fixes-page {
+	.edac_fix_disabled {
+		opacity: 0.5;
+		display: none !important;
+	}
+}

--- a/src/frontendFixes/Fixes/skipLinkFix.js
+++ b/src/frontendFixes/Fixes/skipLinkFix.js
@@ -55,7 +55,7 @@ const SkipLinkFixInit = () => {
 
 	const skipLink = skipLinkTemplate.content.cloneNode( true );
 	// set the href to the first target.
-	skipLink.querySelector( '.edac-skip-link' ).href = foundTarget;
+	skipLink.querySelector( '.edac-skip-link--content' ).href = foundTarget;
 	document.body.prepend( skipLink );
 };
 

--- a/src/frontendFixes/Fixes/skipLinkFix.js
+++ b/src/frontendFixes/Fixes/skipLinkFix.js
@@ -45,17 +45,20 @@ const SkipLinkFixInit = () => {
 	}
 
 	// try to find one the targets on the page.
-	const foundTarget = window.edac_frontend_fixes.skip_link.targets.find( ( target ) => document.querySelector( target ) );
+	const foundMainTarget = window.edac_frontend_fixes.skip_link.targets.find( ( target ) => document.querySelector( target ) );
 
-	if ( ! foundTarget ) {
+	if ( ! foundMainTarget ) {
 		// eslint-disable-next-line
 		console.log( __( 'EDAC: Did not find a matching target ID on the page for the skip link.', 'accessibility-checker' ) );
-		return;
 	}
 
 	const skipLink = skipLinkTemplate.content.cloneNode( true );
-	// set the href to the first target.
-	skipLink.querySelector( '.edac-skip-link--content' ).href = foundTarget;
+	// set the href to the first target if found or remove it if not.
+	if ( foundMainTarget ) {
+		skipLink.querySelector( '.edac-skip-link--content' ).href = foundMainTarget;
+	} else {
+		skipLink.querySelector( '.edac-skip-link--content' ).remove();
+	}
 	document.body.prepend( skipLink );
 };
 

--- a/src/frontendFixes/Fixes/skipLinkFix.js
+++ b/src/frontendFixes/Fixes/skipLinkFix.js
@@ -1,0 +1,62 @@
+import { __ } from '@wordpress/i18n';
+
+const findFirstLinkOutsideContainer = ( containerSelector ) => {
+	const links = document.querySelectorAll( 'body a:not(.ab-item)' );
+	for ( const link of links ) {
+		if ( ! link.closest( containerSelector ) ) {
+			return link;
+		}
+	}
+	return null;
+};
+
+const tryDetectSkipLink = () => {
+	// get the very first link on the page.
+	const firstLink = findFirstLinkOutsideContainer( '#wpadminbar' );
+
+	// does the first link point to an anchor on the page?
+	if ( firstLink && firstLink.href && firstLink.href.indexOf( '#' ) !== -1 ) {
+		// if it does, then does that anchor id exist on the page?
+		const anchorTarget = firstLink.href.split( '#' )[ 1 ];
+		const anchor = document.getElementById( anchorTarget );
+		if ( anchor ) {
+			// if it does, then we don't need to add a skip link.
+			return true;
+		}
+		return false;
+	}
+	return false;
+};
+
+const SkipLinkFixInit = () => {
+	const skipLinkTemplate = document.getElementById( 'skip-link-template' );
+	if ( ! skipLinkTemplate ) {
+		return;
+	}
+
+	if ( ! window.edac_frontend_fixes.skip_link.targets ) {
+		return;
+	}
+
+	const skipLinkFound = tryDetectSkipLink();
+
+	if ( skipLinkFound ) {
+		return;
+	}
+
+	// try to find one the targets on the page.
+	const foundTarget = window.edac_frontend_fixes.skip_link.targets.find( ( target ) => document.querySelector( target ) );
+
+	if ( ! foundTarget ) {
+		// eslint-disable-next-line
+		console.log( __( 'EDAC: Did not find a matching target ID on the page for the skip link.', 'accessibility-checker' ) );
+		return;
+	}
+
+	const skipLink = skipLinkTemplate.content.cloneNode( true );
+	// set the href to the first target.
+	skipLink.querySelector( '.edac-skip-link' ).href = foundTarget;
+	document.body.prepend( skipLink );
+};
+
+export default SkipLinkFixInit;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -1,0 +1,8 @@
+const edacFrontendFixes = window.edac_frontend_fixes || {};
+
+if ( edacFrontendFixes.skip_link.enabled ) {
+	// lazy inport the module
+	import( /* webpackChunkName: "skip-link" */ './Fixes/skipLinkFix' ).then( ( skipLinkFix ) => {
+		skipLinkFix.default();
+	} );
+}

--- a/tests/phpunit/helper-functions/GetFileOpenedAsBinaryTest.php
+++ b/tests/phpunit/helper-functions/GetFileOpenedAsBinaryTest.php
@@ -18,7 +18,7 @@ class GetFileOpenedAsBinaryTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_file_opened_as_binary() {
-		$file = 'https://httpbin.org/image/webp';
+		$file = 'https://via.placeholder.com/100/000000/FFFFFF/?text=testimage';
 
 		$fh = edac_get_file_opened_as_binary( $file );
 
@@ -37,7 +37,7 @@ class GetFileOpenedAsBinaryTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_file_not_opened_as_binary() {
-		$file = 'https://httpbin.org/status/404';
+		$file = 'https://postman-echo.com/status/404';
 
 		$fh = edac_get_file_opened_as_binary( $file );
 

--- a/tests/phpunit/helper-functions/GetFileOpenedAsBinaryTest.php
+++ b/tests/phpunit/helper-functions/GetFileOpenedAsBinaryTest.php
@@ -13,25 +13,6 @@
 class GetFileOpenedAsBinaryTest extends WP_UnitTestCase {
 
 	/**
-	 * Test if file gets retrieved and opened as binary.
-	 *
-	 * @group external-http
-	 */
-	public function test_file_opened_as_binary() {
-		$file = 'https://via.placeholder.com/100/000000/FFFFFF/?text=testimage';
-
-		$fh = edac_get_file_opened_as_binary( $file );
-
-		// since this external service can be flaky we try again if it fails.
-		if ( ! $fh ) {
-			$fh = edac_get_file_opened_as_binary( $file );
-		}
-
-		$this->assertNotFalse( $fh );
-		fclose( $fh );
-	}
-
-	/**
 	 * Test if file is not opened as binary.
 	 *
 	 * @group external-http

--- a/tests/phpunit/helper-functions/UrlExistsTest.php
+++ b/tests/phpunit/helper-functions/UrlExistsTest.php
@@ -16,7 +16,7 @@ class UrlExistsTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_url_exists() {
-		$url        = 'https://httpbin.org/status/200';
+		$url        = 'https://postman-echo.com/status/200';
 		$url_exists = edac_url_exists( $url, 10 );
 		// this test url is flaky, so we try again one extra time if it fails.
 		if ( ! $url_exists ) {
@@ -31,9 +31,9 @@ class UrlExistsTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_url_does_not_exist() {
-		$url = 'https://httpbin.org/status/404';
+		$url = 'https://postman-echo.com/status/404';
 		$this->assertFalse( edac_url_exists( $url ) );
-		$url = 'https://httpbin.org/status/418';
+		$url = 'https://postman-echo.com/status/418';
 		$this->assertFalse( edac_url_exists( $url ) );
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,12 +27,26 @@ module.exports = {
 			'./src/emailOptIn/index.js',
 			'./src/emailOptIn/sass/email-opt-in.scss',
 		],
+		frontendFixes: [
+			'./src/frontendFixes/index.js',
+		],
 
 	},
-
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				specificScript: {
+					test: /[\\/]src[\\/]frontendFixes[\\/]/,
+					name: 'frontendFixes',
+					chunks: 'all',
+				},
+			},
+		},
+	},
 	output: {
 		filename: '[name].bundle.js',
 		path: path.resolve( __dirname, 'build' ),
+		chunkFilename: 'chunks/[name].[chunkhash].js', // Store split bundles in 'chunks' directory
 	},
 
 	module: {


### PR DESCRIPTION
This PR adds a _fix_ to the plugin that users can add a skip link to their pages with.

* It provides a checkbox to enable the feature and a text input to type in the target ID
* The target ID field access a comma separated list of possible IDs to target. The list can include the `#` or not and it will be handled appropriately.
* When enabled it inlines some JS that will attempt to detect if there is a valid skip link already and if so do nothing
  * If no skip link is found it will attempt to find one of the IDs referenced in the targets list.
  * If it finds an ID then it will clone a skip link and some styles for it from a `<template>` tag added to the page.

If you are using a FSE enabled theme like Twenty Twenty-Four then it has some features to add a skip links that lives outside the theme so for testing you will need to remove it and add an ID to target. With Twenty Twenty-Four this code works but you may have to tweak `main` tag to something else if you have a different theme being tested.

```php
remove_action( 'wp_footer', 'the_block_template_skip_link' );
add_action('wp_footer', function () {
	?>
<script>
	// find the first main tag on the page and add id of 'main-content' if it doesn't have one.
	if ( ! document.querySelector( 'main' ).id ) {
		document.querySelector( 'main' ).id = 'main-content';
	}

	// find the first nav on the page and add id of 'main-navigation' if it doesn't have one.
	if ( ! document.querySelector( 'nav' ).id ) {
		document.querySelector( 'nav' ).id = 'main-navigation';
	}
</script>
	<?php
} );
```

## Checklist

- [x] PR is linked to the main issue in the repo (or via card ID in the branch name)
- [ ] Tests are added that cover changes
