### PR TITLE
Fix: add lang and dir attributes to html element

### DIFF
--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Skip Link Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Allows the user to add the post title to their read more links.
+ *
+ * @since 1.16.0
+ */
+class HTMLLangAndDirFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'lang_and_dir';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the lang and dir attributes on the html element.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_add_lang_and_dir'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Add "lang" and "dir" attribributes', 'accessibility-checker' ),
+					'labelledby'  => 'add_read_more_title',
+					'description' => esc_html__( 'Adds "lang" and "dir" attribributes to the HTML element on pages.', 'accessibility-checker' ),
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix for adding the lang and dir attributes to the html element.
+	 *
+	 * This incudes a filter to add them via php but also binds some data that can be used in
+	 * JS for themes that do not have the language_attributes function in the correct place.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_add_read_more_title', false ) ) {
+			return;
+		}
+
+		// Add the lang and dir attributes to the html element via filter.
+		add_filter( 'language_attributes', [ $this, 'maybe_add_lang_and_dir' ] );
+
+		// Some themes may not have the language_attributes() function where it's meant to be so add so some JS is also
+		// added that can add the attributes if they are still missing.
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data['lang_and_dir'] = [
+					'enabled' => true,
+					'lang'    => get_bloginfo( 'language' ),
+					'dir'     => is_rtl() ? 'rtl' : 'ltr',
+				];
+				return $data;
+			}
+		);
+	}
+
+	/**
+	 * Add the lang and dir attributes to the html element.
+	 *
+	 * @param string $output The language attributes.
+	 * @return string
+	 */
+	public function maybe_add_lang_and_dir( $output ): string {
+		$language  = get_bloginfo( 'language' );
+		$direction = is_rtl() ? 'rtl' : 'ltr';
+
+		$additional_atts = '';
+
+		if ( strpos( $output, 'lang=' ) === false ) {
+			$additional_atts = ' lang="' . esc_attr( $language ) . '"';
+		}
+
+		if ( strpos( $output, 'dir=' ) === false ) {
+			$additional_atts .= ' dir="' . esc_attr( $direction ) . '"';
+		}
+
+		return $output . $additional_atts;
+	}
+}

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -47,7 +47,7 @@ class HTMLLangAndDirFix implements FixInterface {
 					'type'        => 'checkbox',
 					'label'       => esc_html__( 'Add "lang" and "dir" attribributes', 'accessibility-checker' ),
 					'labelledby'  => 'add_read_more_title',
-					'description' => esc_html__( 'Adds "lang" and "dir" attribributes to the HTML element on pages.', 'accessibility-checker' ),
+					'description' => esc_html__( 'Add Site Language and text direction to the HTML element.', 'accessibility-checker' ),
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -64,7 +64,7 @@ class HTMLLangAndDirFix implements FixInterface {
 	 * @return void
 	 */
 	public function run() {
-		if ( ! get_option( 'edac_fix_add_read_more_title', false ) ) {
+		if ( ! get_option( 'edac_fix_add_lang_and_dir', false ) ) {
 			return;
 		}
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -106,36 +106,43 @@ class SkipLinkFix implements FixInterface {
 				return $fields;
 			}
 		);
+	}
 
-		if ( get_option( 'edac_fix_add_skip_link', false ) ) {
-			add_action( 'wp_body_open', [ $this, 'add_skip_link' ] );
-
-			$targets_string = get_option( 'edac_fix_add_skip_link_target_id', '' );
-			if ( ! $targets_string ) {
-				return;
-			}
-
-			$targets_list = explode( ',', $targets_string );
-
-			foreach ( $targets_list as $target ) {
-				// trim whitespace and any leading '#'.
-				$trimmed = ltrim( trim( $target ), '#' );
-				if ( empty( $trimmed ) ) {
-					continue;
-				}
-				$targets[] = '#' . $trimmed;
-			}
-			add_filter(
-				'edac_filter_frontend_fixes_data',
-				function ( $data ) use ( $targets ) {
-					$data['skip_link'] = [
-						'enabled' => true,
-						'targets' => $targets,
-					];
-					return $data;
-				}
-			);
+	/**
+	 * Run the fix for adding the skip link to the site.
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_add_skip_link', false ) ) {
+			return null;
 		}
+
+		add_action( 'wp_body_open', [ $this, 'add_skip_link' ] );
+
+		$targets_string = get_option( 'edac_fix_add_skip_link_target_id', '' );
+		if ( ! $targets_string ) {
+			return;
+		}
+
+		$targets_list = explode( ',', $targets_string );
+
+		foreach ( $targets_list as $target ) {
+			// trim whitespace and any leading '#'.
+			$trimmed = ltrim( trim( $target ), '#' );
+			if ( empty( $trimmed ) ) {
+				continue;
+			}
+			$targets[] = '#' . $trimmed;
+		}
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) use ( $targets ) {
+				$data['skip_link'] = [
+					'enabled' => true,
+					'targets' => $targets,
+				];
+				return $data;
+			}
+		);
 	}
 
 	/**
@@ -161,7 +168,7 @@ class SkipLinkFix implements FixInterface {
 
 			.edac-bypass-block:focus-within,
 			.edac-bypass-block-always-visible {
-				background-color: #ededed;
+				background-color: #ececec;
 				clip: auto !important;
 				-webkit-clip-path: none;
 				clip-path: none;

--- a/includes/classes/Fixes/FixInterface.php
+++ b/includes/classes/Fixes/FixInterface.php
@@ -35,4 +35,11 @@ interface FixInterface {
 	 * if they are not just simple hooks.
 	 */
 	public function register(): void;
+
+	/**
+	 * Run the fix.
+	 *
+	 * This will be called in admin only, frontend only or everywhere depending on the fix type.
+	 */
+	public function run();
 }

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -7,6 +7,7 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 
 /**
@@ -77,6 +78,7 @@ class FixesManager {
 			'edac_filter_fixes',
 			[
 				SkipLinkFix::class,
+				HTMLLangAndDirFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -84,9 +84,7 @@ class FixesManager {
 		foreach ( $fixes as $fix ) {
 			if ( is_subclass_of( $fix, '\EqualizeDigital\AccessibilityChecker\Fixes\FixInterface' ) ) {
 				if ( ! isset( $this->fixes[ $fix::get_slug() ] ) ) {
-					$fix_class = new $fix();
-					$fix_class->register();
-					$this->fixes[ $fix::get_slug() ] = $fix_class;
+					$this->fixes[ $fix::get_slug() ] = ( new $fix() );
 				}
 			}
 		}
@@ -110,13 +108,23 @@ class FixesManager {
 		$this->load_fixes();
 
 		foreach ( $this->fixes as $fix ) {
-			if ( 'backend' === $fix::get_type() && is_admin() ) {
-				$fix->register();
-			} elseif ( 'frontend' === $fix::get_type() && ! is_admin() ) {
-				$fix->register();
-			} elseif ( 'everywhere' === $fix::get_type() ) {
-				$fix->register();
-			}
+			$fix->register();
+			$this->maybe_run_fix( $fix );
+		}
+	}
+
+	/**
+	 * Maybe run a fix depending on current context.
+	 *
+	 * @param FixInterface $fix The fix to maybe run.
+	 */
+	public function maybe_run_fix( $fix ) {
+		if ( 'backend' === $fix::get_type() && is_admin() ) {
+			$fix->run();
+		} elseif ( 'frontend' === $fix::get_type() && ! is_admin() ) {
+			$fix->run();
+		} elseif ( 'everywhere' === $fix::get_type() ) {
+			$fix->run();
 		}
 	}
 }

--- a/src/frontendFixes/Fixes/langAndDirFix.js
+++ b/src/frontendFixes/Fixes/langAndDirFix.js
@@ -1,0 +1,23 @@
+const LangAndDirFixData = window.edac_frontend_fixes?.lang_and_dir || {
+	enabled: false,
+};
+
+const LangAndDirFix = () => {
+	if ( ! LangAndDirFixData.enabled ) {
+		return;
+	}
+
+	const HTMLElement = document.querySelector( 'html' );
+	const lang = HTMLElement.getAttribute( 'lang' );
+	const dir = HTMLElement.getAttribute( 'dir' );
+
+	if ( ! lang || lang !== LangAndDirFixData.lang ) {
+		HTMLElement.setAttribute( 'lang', LangAndDirFixData.lang );
+	}
+
+	if ( ! dir || dir !== LangAndDirFixData.dir ) {
+		HTMLElement.setAttribute( 'dir', LangAndDirFixData.dir );
+	}
+};
+
+export default LangAndDirFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -6,3 +6,10 @@ if ( edacFrontendFixes.skip_link.enabled ) {
 		skipLinkFix.default();
 	} );
 }
+
+if ( edacFrontendFixes.lang_and_dir.enabled ) {
+	// lazy inport the module
+	import( /* webpackChunkName: "aria-hidden" */ './Fixes/langAndDirFix' ).then( ( langAndDirFix ) => {
+		langAndDirFix.default();
+	} );
+}


### PR DESCRIPTION
This PR adds a _fix_ that users can toggle on to include the `lang` and `dir` attributes on the root `html` element.

The fix uses a filter on `language_attribute` to add them but includes an additional JS fallback for themes which do not have the `language_attributes()` function in the correct place.

Note: This is based from the skip-link fix which is why the diff currently looks so large. It does also include some changes to how the fixes manager registers and invokes fixes - namely the inclusion of a `run` method requirement inside of fixes to separate settings and registration code from actual runner code.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
