### PR TITLE
Added: remove tab index fix

### DIFF
--- a/includes/classes/Fixes/Fix/TabindexFix.php
+++ b/includes/classes/Fixes/Fix/TabindexFix.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tabindex Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Handles the removal of tabindex attributes from focusable elements.
+ *
+ * @since 1.16.0
+ */
+class TabindexFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'remove_tabindex';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers the settings field for the tabindex removal fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_remove_tabindex'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Remove Tab Index', 'accessibility-checker' ),
+					'labelledby'  => 'remove_tabindex',
+					'description' => esc_html__( 'Remove tabindex from focusable elements.', 'accessibility-checker' ),
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Executes the tabindex removal fix on the frontend.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_remove_tabindex', false ) ) {
+			return;
+		}
+
+		// Adds the tabindex removal data to be used in JS if necessary.
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data['tabindex'] = [
+					'enabled' => true,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -9,6 +9,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 
 /**
  * Manager class for fixes.
@@ -79,6 +80,7 @@ class FixesManager {
 			[
 				SkipLinkFix::class,
 				HTMLLangAndDirFix::class,
+				TabindexFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -56,7 +56,7 @@ class FixesManager {
 	 */
 	private function maybe_enqueue_frontend_scripts() {
 		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			add_action(
 				'wp_enqueue_scripts',
 				function () {

--- a/src/frontendFixes/Fixes/tabindexFix.js
+++ b/src/frontendFixes/Fixes/tabindexFix.js
@@ -1,0 +1,37 @@
+const RemoveTabindexFixData = window.edac_frontend_fixes?.tabindex || {
+	enabled: false,
+};
+
+const TabindexFix = () => {
+	if ( ! RemoveTabindexFixData.enabled ) {
+		return;
+	}
+
+	// Remove tabindex from elements that are natively focusable
+	const focusable = document.querySelectorAll( 'input, a, select, textarea, button' );
+	focusable.forEach( ( element ) => {
+		// Skip anchor tags without an href attribute or those with role="button" as they are not natively focusable
+		if ( element.tagName === 'A' && ( ! element.hasAttribute( 'href' ) || element.getAttribute( 'role' ) === 'button' ) ) {
+			return;
+		}
+
+		// Remove the tabindex if present
+		if ( element.hasAttribute( 'tabindex' ) ) {
+			element.removeAttribute( 'tabindex' );
+		}
+	} );
+
+	// Add tabindex to elements that appear active but are not natively focusable.
+	// Select all <div> elements with a role of "button" or <a> elements with role="button" without href or tabindex
+	const elementsToFocus = document.querySelectorAll(
+		'div[role="button"]:not([tabindex]), a[role="button"]:not([tabindex]):not([href])'
+	);
+
+	// Loop through each element and add tabindex="0" to make it focusable
+	elementsToFocus.forEach( ( element ) => {
+		element.setAttribute( 'tabindex', '0' );
+		element.classList.add( 'edac-focusable' );
+	} );
+};
+
+export default TabindexFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -1,21 +1,21 @@
 const edacFrontendFixes = window.edac_frontend_fixes || {};
 
 if ( edacFrontendFixes.skip_link.enabled ) {
-	// lazy inport the module
+	// lazy import the module
 	import( /* webpackChunkName: "skip-link" */ './Fixes/skipLinkFix' ).then( ( skipLinkFix ) => {
 		skipLinkFix.default();
 	} );
 }
 
 if ( edacFrontendFixes.lang_and_dir.enabled ) {
-	// lazy inport the module
+	// lazy import the module
 	import( /* webpackChunkName: "aria-hidden" */ './Fixes/langAndDirFix' ).then( ( langAndDirFix ) => {
 		langAndDirFix.default();
 	} );
 }
 
 if ( edacFrontendFixes.tabindex.enabled ) {
-	// lazy inport the module
+	// lazy import the module
 	import( /* webpackChunkName: "tabindex" */ './Fixes/tabindexFix' ).then( ( tabindexFix ) => {
 		tabindexFix.default();
 	} );

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -13,3 +13,10 @@ if ( edacFrontendFixes.lang_and_dir.enabled ) {
 		langAndDirFix.default();
 	} );
 }
+
+if ( edacFrontendFixes.tabindex.enabled ) {
+	// lazy inport the module
+	import( /* webpackChunkName: "tabindex" */ './Fixes/tabindexFix' ).then( ( tabindexFix ) => {
+		tabindexFix.default();
+	} );
+}


### PR DESCRIPTION
This PR adds a fix for removing the `tabindex` attribute.

## Added setting
![Screenshot 2024-09-04 at 12 03 16 PM](https://github.com/user-attachments/assets/20a99ba6-c031-4fb5-9948-efb1fe82f3a0)

## Proof of functionality
![2024-09-04 12 06 28](https://github.com/user-attachments/assets/5ca19619-0596-4f80-afd4-db386bf257a0)

## Usecases for testing

### Example 1: Removing tabindex from Elements that are Natively Focusable

```html
<!-- Input element with unnecessary tabindex -->
<input type="text" tabindex="5" placeholder="Input with unnecessary tabindex">

<!-- Anchor tag with href, tabindex should be removed -->
<a href="#" tabindex="3">Focusable link with href</a>

<!-- Select element with tabindex that should be removed -->
<select tabindex="4">
    <option>Option 1</option>
    <option>Option 2</option>
</select>

<!-- Textarea element with tabindex that should be removed -->
<textarea tabindex="2" placeholder="Textarea with unnecessary tabindex"></textarea>

<!-- Button with unnecessary tabindex -->
<button tabindex="1">Button with unnecessary tabindex</button>
```

### Example 2: Adding tabindex to Elements that Appear Active but are Not Natively Focusable

```html
<!-- Div with role="button" without tabindex; should have tabindex added -->
<div role="button" onclick="alert('Clicked!')">Div styled as a button without tabindex</div>

<!-- Anchor tag with role="button" but no href or tabindex; should have tabindex added -->
<a role="button" onclick="alert('Clicked!')">Anchor styled as a button without href or tabindex</a>
```

### Example 3: Ignored Elements

```html
<!-- Anchor tag without href should be ignored for tabindex removal -->
<a role="button" tabindex="5">Anchor styled as a button with tabindex (no href)</a>

<!-- Div with role="button" but already has tabindex; should be ignored for tabindex addition -->
<div role="button" tabindex="0" onclick="alert('Clicked!')">Div styled as button with tabindex already set</div>
```

Card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7652429491
