### PR TITLE
Add a fix class for adding post title to read more links

### DIFF
--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -108,6 +108,11 @@ class ReadMoreAddTitleFix implements FixInterface {
 
 		global $id;
 
+		// If the $text already contains the title, we won't add it again.
+		if ( str_contains( strtolower( $text ), strtolower( get_the_title( $id ) ) ) ) {
+			return $link;
+		}
+
 		return str_replace(
 			$text,
 			$text . ' ' . $this->generate_read_more_string( $id ),
@@ -124,6 +129,15 @@ class ReadMoreAddTitleFix implements FixInterface {
 	public function add_title_link_to_excerpts( $excerpt ): string {
 		if ( has_excerpt() && ! is_attachment() ) {
 			global $id;
+
+			$post_title = get_the_title( $id );
+
+			// If the last part of the excerpt contains the post title, we won't add it again.
+			$exceprt_fragment = strtolower( substr( $excerpt, ( -100 - strlen( $post_title ) ) ) );
+			if ( str_contains( $exceprt_fragment, strtolower( $post_title ) ) ) {
+				return $excerpt;
+			}
+
 			$excerpt .= ' ' . $this->generate_read_more_string( $id, true );
 		}
 

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -7,6 +7,7 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 /**
@@ -88,6 +89,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 		if ( ! get_option( 'edac_fix_add_read_more_title', false ) ) {
 			return;
 		}
+
 		add_action( 'the_content_more_link', [ $this, 'add_title_to_read_more' ], 100, 2 );
 		add_filter( 'get_the_excerpt', [ $this, 'add_title_link_to_excerpts' ], 100 );
 		add_filter( 'excerpt_more', [ $this, 'add_title_to_excerpt_more' ], 100 );
@@ -151,7 +153,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 	 */
 	public function add_title_to_excerpt_more(): string {
 		global $id;
-		return '&hellip;' . $this->generate_read_more_string( $id );
+		return '&hellip; <a href="' . get_the_permalink( $id ) . '">' . $this->generate_read_more_string( $id ) . '</a>';
 	}
 
 
@@ -198,6 +200,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 	 * @return void
 	 */
 	public function read_more_section_callback() {
+		FixesManager::maybe_show_accessibility_ready_conflict_notice();
 		?>
 		<p><?php esc_html_e( 'This fix adds the post title to the "Read More" links in post lists at the "More" block and in excerpts.', 'accessibility-checker' ); ?></p>
 		<?php

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Skip Link Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Allows the user to add the post title to their read more links.
+ *
+ * @since 1.16.0
+ */
+class ReadMoreAddTitleFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'read_more';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'everywhere';
+	}
+
+	/**
+	 * Registers everything needed for the skip link fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+
+		add_filter(
+			'edac_filter_fixes_settings_sections',
+			function ( $sections ) {
+				$sections['read_more_links'] = [
+					'title'       => esc_html__( 'Read More links', 'accessibility-checker' ),
+					'description' => esc_html__( 'Add the post title and links ', 'accessibility-checker' ),
+					'callback'    => [ $this, 'read_more_section_callback' ],
+				];
+
+				return $sections;
+			}
+		);
+
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_add_read_more_title'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Add Post Title to "Read More"', 'accessibility-checker' ),
+					'labelledby'  => 'add_read_more_title',
+					'description' => esc_html__( 'Adds the post title to the "Read More" links in post lists if your theme outputs those.', 'accessibility-checker' ),
+					'section'     => 'read_more_links',
+				];
+
+				$fields['edac_fix_add_read_more_title_screen_reader_only'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Make the title for screen readers only', 'accessibility-checker' ),
+					'labelledby'  => 'add_read_more_title_screen_reader_only',
+					'description' => esc_html__( 'Wraps the post title added to the link with styles making it for screen readers only.', 'accessibility-checker' ),
+					'condition'   => 'edac_fix_add_read_more_title',
+					'section'     => 'read_more_links',
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_add_read_more_title', false ) ) {
+			return;
+		}
+		add_action( 'the_content_more_link', [ $this, 'add_title_to_read_more' ], 100, 2 );
+		add_filter( 'get_the_excerpt', [ $this, 'add_title_link_to_excerpts' ], 100 );
+		add_filter( 'excerpt_more', [ $this, 'add_title_to_excerpt_more' ], 100 );
+
+		if ( get_option( 'edac_fix_add_read_more_title_screen_reader_only', false ) ) {
+			add_action( 'wp_head', [ $this, 'add_screen_reader_styles' ] );
+		}
+	}
+
+	/**
+	 * Add the post title to the read more link.
+	 *
+	 * @param string $link The read more link.
+	 * @param string $text The link text.
+	 * @return string
+	 */
+	public function add_title_to_read_more( $link, $text ): string {
+
+		global $id;
+
+		return str_replace(
+			$text,
+			$text . ' ' . $this->generate_read_more_string( $id ),
+			$link
+		);
+	}
+
+	/**
+	 * Add the post title to the excerpt.
+	 *
+	 * @param string $excerpt The excerpt.
+	 * @return string
+	 */
+	public function add_title_link_to_excerpts( $excerpt ): string {
+		if ( has_excerpt() && ! is_attachment() ) {
+			global $id;
+			$excerpt .= ' ' . $this->generate_read_more_string( $id, true );
+		}
+
+		return $excerpt;
+	}
+
+	/**
+	 * Add the post title to the excerpt more link.
+	 *
+	 * @return string
+	 */
+	public function add_title_to_excerpt_more(): string {
+		global $id;
+		return '&hellip;' . $this->generate_read_more_string( $id );
+	}
+
+
+	/**
+	 * Add the screen reader styles.
+	 *
+	 * @return void
+	 */
+	public function add_screen_reader_styles() {
+		?>
+		<style>
+			.edac-screen-reader-text {
+				position: absolute;
+				clip: rect(1px, 1px, 1px, 1px);
+				clip-path: polygon(0 0, 0 0, 0 0);
+				height: 1px;
+				width: 1px;
+				overflow: hidden;
+				white-space: nowrap;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Generate the read more string to add to the links.
+	 *
+	 * @param int  $id The post ID.
+	 * @param bool $never_use_screen_reader Whether to never use the screen reader styles.
+	 * @return string
+	 */
+	private function generate_read_more_string( $id, $never_use_screen_reader = false ) {
+
+		return sprintf(
+			'<span class="edac-content-more-title%s">%s</span>',
+			! $never_use_screen_reader && get_option( 'edac_fix_add_read_more_title_screen_reader_only', false ) ? ' edac-screen-reader-text' : '',
+			wp_kses_post( get_the_title( $id ) )
+		);
+	}
+
+	/**
+	 * Callback for the read more section.
+	 *
+	 * @return void
+	 */
+	public function read_more_section_callback() {
+		?>
+		<p><?php esc_html_e( 'This fix adds the post title to the "Read More" links in post lists at the "More" block and in excerpts.', 'accessibility-checker' ); ?></p>
+		<?php
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ReadMoreAddTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 
 /**
@@ -54,20 +55,29 @@ class FixesManager {
 	 * Maybe enqueue the frontend scripts.
 	 */
 	private function maybe_enqueue_frontend_scripts() {
-		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
-		if ( ! is_admin() ) {
-			add_action(
-				'wp_enqueue_scripts',
-				function () {
-					wp_enqueue_script( 'edac-frontend-fixes', EDAC_PLUGIN_URL . 'build/frontendFixes.bundle.js', [], EDAC_VERSION, true );
-					wp_localize_script(
-						'edac-frontend-fixes',
-						'edac_frontend_fixes',
-						apply_filters( 'edac_filter_frontend_fixes_data', [] )
-					);
-				}
-			);
+
+		if (
+			is_admin() ||
+			( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+			( defined( 'DOING_AJAX' ) && DOING_AJAX ) ||
+			( defined( 'DOING_CRON' ) && DOING_CRON ) ||
+			( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		) {
+			return;
 		}
+
+		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
+		add_action(
+			'wp_enqueue_scripts',
+			function () {
+				wp_enqueue_script( 'edac-frontend-fixes', EDAC_PLUGIN_URL . 'build/frontendFixes.bundle.js', [], EDAC_VERSION, true );
+				wp_localize_script(
+					'edac-frontend-fixes',
+					'edac_frontend_fixes',
+					apply_filters( 'edac_filter_frontend_fixes_data', [] )
+				);
+			}
+		);
 	}
 
 	/**
@@ -79,6 +89,7 @@ class FixesManager {
 			[
 				SkipLinkFix::class,
 				HTMLLangAndDirFix::class,
+				ReadMoreAddTitleFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -7,11 +7,9 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
-use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ReadMoreAddTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
-use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 
 /**
  * Manager class for fixes.
@@ -66,9 +64,9 @@ class FixesManager {
 			( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 		) {
 			return;
-    }
+		}
 
-    // Consider adding this only if we can determine at least 1 of the fixes are enabled.
+		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
 		add_action(
 			'wp_enqueue_scripts',
 			function () {
@@ -90,10 +88,8 @@ class FixesManager {
 			'edac_filter_fixes',
 			[
 				SkipLinkFix::class,
-				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				ReadMoreAddTitleFix::class,
-				TabindexFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -26,6 +26,13 @@ class FixesManager {
 	private static $instance = null;
 
 	/**
+	 * Whether the theme has the accessibility-ready tag.
+	 *
+	 * @var bool|null
+	 */
+	private static $theme_is_accessibility_ready = null;
+
+	/**
 	 * The fixes.
 	 *
 	 * @var array
@@ -37,6 +44,8 @@ class FixesManager {
 	 */
 	private function __construct() {
 		$this->maybe_enqueue_frontend_scripts();
+
+		self::$theme_is_accessibility_ready = self::is_theme_accessibility_ready();
 	}
 
 	/**
@@ -138,6 +147,38 @@ class FixesManager {
 			$fix->run();
 		} elseif ( 'everywhere' === $fix::get_type() ) {
 			$fix->run();
+		}
+	}
+
+	/**
+	 * Check if the theme is accessibility ready.
+	 *
+	 * True if the theme has the tag, false otherwise.
+	 *
+	 * @return bool
+	 */
+	public static function is_theme_accessibility_ready() {
+		if ( null !== self::$theme_is_accessibility_ready ) {
+			return self::$theme_is_accessibility_ready;
+		}
+
+		$theme = wp_get_theme();
+		$tags  = $theme->get( 'Tags' );
+
+		self::$theme_is_accessibility_ready = in_array( 'accessibility-ready', $tags, true );
+		return self::$theme_is_accessibility_ready;
+	}
+
+	/**
+	 * Maybe show a notice if the theme is accessibility-ready.
+	 */
+	public static function maybe_show_accessibility_ready_conflict_notice() {
+		if ( self::is_theme_accessibility_ready() ) {
+			?>
+			<span class="edac-notice--accessibility-ready-conflict">
+				<?php esc_html_e( 'This setting is not recommended for themes that are already accessibility-ready.', 'accessibility-checker' ); ?>
+			</span>
+			<?php
 		}
 	}
 }

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -88,8 +88,10 @@ class FixesManager {
 			'edac_filter_fixes',
 			[
 				SkipLinkFix::class,
+				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				ReadMoreAddTitleFix::class,
+				TabindexFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1936,4 +1936,11 @@
 		opacity: 0.5;
 		display: none !important;
 	}
+
+	.edac-notice {
+		&--accessibility-ready-conflict {
+			font-style: italic;
+			font-weight: 600;
+		}
+	}
 }


### PR DESCRIPTION
This adds it to the normal read more, the excerpt and the excerpt more.

Note: This does not work with the query loop block as they explicitly override anything from the filter if someone has filled in the read more text element in the block settings. See: https://github.com/WordPress/gutenberg/blob/abf72c95b1da1b8f6709858bb750e1d56782c27d/packages/block-library/src/post-excerpt/index.php#L39C5-L47C5

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
