### PR TITLE
added: Fix that can remove target="_blank" from links

### DIFF
--- a/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
+++ b/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Prevents links from opening in new windows.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Prevents links from opening in new windows.
+ *
+ * @since 1.16.0
+ */
+class PreventLinksOpeningNewWindowFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'prevent-links-opening-new-windows';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+				$fields['edac_fix_prevent_links_opening_in_new_windows'] = [
+					'label'       => esc_html__( 'Links Opening New Windows', 'accessibility-checker' ),
+					'type'        => 'checkbox',
+					'labelledby'  => 'prevent_links_opening_in_new_windows',
+					'description' => esc_html__( 'Prevents links from opening in a new window.', 'accessibility-checker' ),
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix for adding the comment and search form labels.
+	 */
+	public function run(): void {
+		if ( ! get_option( 'edac_fix_prevent_links_opening_in_new_windows', false ) ) {
+			return;
+		}
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data['prevent_links_opening_in_new_window'] = [
+					'enabled' => true,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\PreventLinksOpeningNewWindowFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
@@ -83,6 +84,7 @@ class FixesManager {
 				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				TabindexFix::class,
+				PreventLinksOpeningNewWindowFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/src/frontendFixes/Fixes/preventLinksOpeningNewWindowFix.js
+++ b/src/frontendFixes/Fixes/preventLinksOpeningNewWindowFix.js
@@ -1,0 +1,9 @@
+const preventLinksOpeningNewWindowFix = () => {
+	const links = document.querySelectorAll( 'a[target="_blank"]' );
+	links.forEach( ( link ) => {
+		link.removeAttribute( 'target' );
+		link.classList.add( 'edac-removed-target-blank' );
+	} );
+};
+
+export default preventLinksOpeningNewWindowFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -23,7 +23,7 @@ if ( edacFrontendFixes?.tabindex?.enabled ) {
 
 if ( edacFrontendFixes?.prevent_links_opening_in_new_window?.enabled ) {
 	// lazy import the module
-	import( /* webpackChunkName: "prevent-links-opening-in-new-window" */ './Fixes/preventLinksOpeningNewWindowFix' ).then( ( preventLinksOpeningInNewWindow ) => {
-		preventLinksOpeningInNewWindow.preventLinksOpeningNewWindowFix();
+	import( /* webpackChunkName: "prevent-links-opening-in-new-window" */ './Fixes/preventLinksOpeningNewWindowFix' ).then( ( preventLinksOpeningNewWindowFix ) => {
+		preventLinksOpeningNewWindowFix.default();
 	} );
 }

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -20,3 +20,10 @@ if ( edacFrontendFixes.tabindex.enabled ) {
 		tabindexFix.default();
 	} );
 }
+
+if ( edacFrontendFixes?.prevent_links_opening_in_new_window?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "prevent-links-opening-in-new-window" */ './Fixes/preventLinksOpeningNewWindowFix' ).then( ( preventLinksOpeningInNewWindow ) => {
+		preventLinksOpeningInNewWindow.preventLinksOpeningNewWindowFix();
+	} );
+}

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -1,20 +1,20 @@
 const edacFrontendFixes = window.edac_frontend_fixes || {};
 
-if ( edacFrontendFixes.skip_link.enabled ) {
+if ( edacFrontendFixes?.skip_link?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "skip-link" */ './Fixes/skipLinkFix' ).then( ( skipLinkFix ) => {
 		skipLinkFix.default();
 	} );
 }
 
-if ( edacFrontendFixes.lang_and_dir.enabled ) {
+if ( edacFrontendFixes?.lang_and_dir?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "aria-hidden" */ './Fixes/langAndDirFix' ).then( ( langAndDirFix ) => {
 		langAndDirFix.default();
 	} );
 }
 
-if ( edacFrontendFixes.tabindex.enabled ) {
+if ( edacFrontendFixes?.tabindex?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "tabindex" */ './Fixes/tabindexFix' ).then( ( tabindexFix ) => {
 		tabindexFix.default();


### PR DESCRIPTION
Adds a fix that can be used to remove all target="_blank" values from links on a page.

This fix runs before ANWW runs so it removes the new window opening links before it detects and operates on them.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
