### PR TITLE
added: force underline fix

### DIFF
--- a/includes/classes/Fixes/Fix/LinkUnderline.php
+++ b/includes/classes/Fixes/Fix/LinkUnderline.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tabindex Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Handles the removal of tabindex attributes from focusable elements.
+ *
+ * @since 1.16.0
+ */
+class LinkUnderline implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'link_underline';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers the settings field for the tabindex removal fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_force_link_underline'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Force Link Underline', 'accessibility-checker' ),
+					'labelledby'  => 'force_link_underline',
+					'description' => esc_html__( 'Force underline on non-navigation links.', 'accessibility-checker' ),
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Executes the tabindex removal fix on the frontend.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_force_link_underline', false ) ) {
+			return;
+		}
+
+		// Adds the tabindex removal data to be used in JS if necessary.
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				/**
+				 * Filters the target element selector for forcing underlines.
+				 *
+				 * This filter allows customization of the target elements that should have 
+				 * forced underlines applied. By default, the selector is set to 'a'.
+				 *
+				 * @since 1.16.0
+				 *
+				 * @hook edac_fix_underline_target
+				 *
+				 * @param string $el The target element selector. Default is 'a'.
+				 *
+				 * @return string Modified target element selector.
+				 */
+				$target = apply_filters( 'edac_fix_underline_target', 'a' );
+
+				$data['underline'] = [
+					'enabled' => true,
+					'target'  => $target,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -11,6 +11,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\LinkUnderline;
 
 /**
  * Manager class for fixes.
@@ -83,6 +84,7 @@ class FixesManager {
 				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				TabindexFix::class,
+				LinkUnderline::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessibility-checker",
-  "version": "1.3.27",
+  "version": "1.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "accessibility-checker",
-      "version": "1.3.27",
+      "version": "1.15.1",
       "hasInstallScript": true,
       "license": "GPL-2.0+",
       "devDependencies": {
@@ -7163,9 +7163,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001565",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+      "version": "1.0.30001658",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001658.tgz",
+      "integrity": "sha512-N2YVqWbJELVdrnsW5p+apoQyYt51aBMSsBZki1XZEfeBCexcM/sf4xiAHcXQBkuOwJBXtWF7aW1sYX6tKebPHw==",
       "dev": true,
       "funding": [
         {
@@ -29764,9 +29764,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001565",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+      "version": "1.0.30001658",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001658.tgz",
+      "integrity": "sha512-N2YVqWbJELVdrnsW5p+apoQyYt51aBMSsBZki1XZEfeBCexcM/sf4xiAHcXQBkuOwJBXtWF7aW1sYX6tKebPHw==",
       "dev": true
     },
     "capital-case": {

--- a/src/frontendFixes/Fixes/underlineFix.js
+++ b/src/frontendFixes/Fixes/underlineFix.js
@@ -1,0 +1,50 @@
+const ForceUnderlineFixData = window.edac_frontend_fixes?.underline || {
+	enabled: false,
+};
+
+const ForceUnderlineFix = () => {
+	if ( ! ForceUnderlineFixData.enabled ) {
+		return;
+	}
+
+	// Apply underline to any link that is not within a `nav` element.
+	// Using JavaScript ensures this style takes precedence over conflicting CSS rules.
+	const targets = document.querySelectorAll( ForceUnderlineFixData.target );
+	const originalOutline = targets[ 0 ].style.outlineWidth;
+	const originalOffset = targets[ 0 ].style.outlineOffset;
+	const textColor = targets[ 0 ].style.color;
+	const originalColor = targets[ 0 ].style.outlineColor;
+
+	targets.forEach( function( target ) {
+		if ( ! target.closest( 'nav' ) ) {
+			target.style.textDecoration = 'underline';
+		}
+
+		target.addEventListener( 'mouseenter', function() {
+			target.style.textDecoration = 'none';
+		} );
+
+		target.addEventListener( 'mouseleave', function() {
+			target.style.textDecoration = 'underline';
+		} );
+
+		target.addEventListener( 'focusin', function() {
+			let newOutline = '2px';
+			if ( originalOutline === '2px' ) {
+				newOutline = '4px';
+			}
+			// Increase outline thickness and adjust color and offset to ensure a visible focus indicator.
+			target.style.outlineWidth = newOutline;
+			target.style.outlineColor = textColor;
+			target.style.outlineOffset = '2px';
+		} );
+
+		target.addEventListener( 'focusout', function() {
+			target.style.outlineWidth = originalOutline;
+			target.style.outlineColor = originalColor;
+			target.style.outlineOffset = originalOffset;
+		} );
+	} );
+};
+
+export default ForceUnderlineFix;

--- a/src/frontendFixes/Fixes/underlineFix.js
+++ b/src/frontendFixes/Fixes/underlineFix.js
@@ -10,15 +10,18 @@ const ForceUnderlineFix = () => {
 	// Apply underline to any link that is not within a `nav` element.
 	// Using JavaScript ensures this style takes precedence over conflicting CSS rules.
 	const targets = document.querySelectorAll( ForceUnderlineFixData.target );
-	const originalOutline = targets[ 0 ].style.outlineWidth;
-	const originalOffset = targets[ 0 ].style.outlineOffset;
-	const textColor = targets[ 0 ].style.color;
-	const originalColor = targets[ 0 ].style.outlineColor;
 
 	targets.forEach( function( target ) {
 		if ( ! target.closest( 'nav' ) ) {
 			target.style.textDecoration = 'underline';
 		}
+
+		// Store the original styles in data-* attributes
+		target.setAttribute( 'data-original-outline', target.style.outlineWidth );
+		target.setAttribute( 'data-original-offset', target.style.outlineOffset );
+		target.setAttribute( 'data-original-color', target.style.outlineColor );
+
+		const textColor = target.style.color; // Capture the text color separately
 
 		target.addEventListener( 'mouseenter', function() {
 			target.style.textDecoration = 'none';
@@ -30,7 +33,7 @@ const ForceUnderlineFix = () => {
 
 		target.addEventListener( 'focusin', function() {
 			let newOutline = '2px';
-			if ( originalOutline === '2px' ) {
+			if ( target.style.outlineWidth === '2px' ) {
 				newOutline = '4px';
 			}
 			// Increase outline thickness and adjust color and offset to ensure a visible focus indicator.
@@ -40,9 +43,10 @@ const ForceUnderlineFix = () => {
 		} );
 
 		target.addEventListener( 'focusout', function() {
-			target.style.outlineWidth = originalOutline;
-			target.style.outlineColor = originalColor;
-			target.style.outlineOffset = originalOffset;
+			// Restore the original styles from data-* attributes
+			target.style.outlineWidth = target.getAttribute( 'data-original-outline' );
+			target.style.outlineColor = target.getAttribute( 'data-original-color' );
+			target.style.outlineOffset = target.getAttribute( 'data-original-offset' );
 		} );
 	} );
 };

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -20,3 +20,10 @@ if ( edacFrontendFixes.tabindex.enabled ) {
 		tabindexFix.default();
 	} );
 }
+
+if ( edacFrontendFixes.underline.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "underline" */ './Fixes/underlineFix' ).then( ( underlineFix ) => {
+		underlineFix.default();
+	} );
+}


### PR DESCRIPTION
This PR adds the Force Underline on links Fix.

1. Excludes links inside of `nav` elements
2. Add filter `edac_filter_frontend_fixes_data` to allow for changing the target elements. The default is `a`.

![2024-09-04 16 20 12](https://github.com/user-attachments/assets/245d7317-620a-4cc7-b31e-5a78b51ae396)

Card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7652429605
