### PR TITLE
added: Fix for missing or empty page titles

### DIFF
--- a/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
+++ b/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Fix missing or empty page titles.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Allows the user to add a title to the page <title> tag if empty or missing.
+ *
+ * @since 1.16.0
+ */
+class AddMissingOrEmptyPageTitleFix implements FixInterface {
+
+	/**
+	 * The full title of the page.
+	 *
+	 * @var string
+	 */
+	private $full_title = '';
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'missing_or_empty_page_title';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the lang and dir attributes on the html element.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_add_missing_or_empty_page_title'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Add missing page title', 'accessibility-checker' ),
+					'labelledby'  => 'add_missing_or_empty_page_title',
+					'description' => esc_html__( 'Adds a `<title>` tag to the page if it is missing or empty.', 'accessibility-checker' ),
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix for adding a missing or empty page title.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_add_missing_or_empty_page_title', false ) ) {
+			return;
+		}
+
+		if ( is_admin() ) {
+			return;
+		}
+
+		add_filter( 'document_title', [ $this, 'add_page_title_if_missing_or_empty' ], 100, 2 );
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data[ $this->get_slug() ] = [
+					'enabled'          => true,
+					'title_seporator'  => apply_filters( 'document_title_separator', '-' ),
+					'site_name'        => get_bloginfo( 'name' ),
+					'site_description' => get_bloginfo( 'description' ),
+					'post_title'       => $this->full_title ? $this->full_title : '',
+				];
+				return $data;
+			}
+		);
+	}
+
+	/**
+	 * Add a page title if missing or empty.
+	 *
+	 * Trys to find a method that will create unique titles rather than just using the site title.
+	 *
+	 * @param string $title The title parts.
+	 * @param string $sep The separator.
+	 *
+	 * @return array
+	 */
+	public function add_page_title_if_missing_or_empty( $title, $sep = '-' ) {
+
+		// If we have a title, nothing is needing done.
+		if ( $title && ! empty( $title ) ) {
+			$this->full_title = $title;
+			return $title;
+		}
+
+		// The home page and front page needs special handling.
+		if ( is_home() || is_front_page() ) {
+			$site_and_desc = get_bloginfo( 'name' );
+
+			$description = get_bloginfo( 'description' );
+
+			if ( $description ) {
+				$site_and_desc .= " {$sep} {$description}";
+			}
+
+			// Trim it so that it's not more than 80 characters.
+			if ( strlen( $site_and_desc ) > 80 ) {
+				$site_and_desc = substr( $site_and_desc, 0, 80 ) . '&hellip;';
+			}
+
+			$this->full_title = $site_and_desc;
+			return $this->full_title;
+		}
+
+		// If we have a post title, use it as the title.
+		$post_title = get_the_title();
+		if ( $post_title ) {
+			$this->full_title = $post_title;
+			return $this->full_title;
+		}
+
+		// Try find a heading in the content to use as a title.
+		$content = get_post_field( 'post_content', get_the_ID() );
+		$matches = [];
+		preg_match( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/i', $content, $matches );
+		if ( isset( $matches[1] ) ) {
+			$content_header_title = wp_strip_all_tags( $matches[1] ) . " {$sep} " . get_bloginfo( 'name' );
+			// Trim it so that it's not more than 80 characters.
+			if ( strlen( $content_header_title ) > 80 ) {
+				$content_header_title = substr( $content_header_title, 0, 80 ) . '&hellip;';
+			}
+			$this->full_title = $content_header_title;
+			return $content_header_title;
+		}
+
+		// By this point we haven't been able to find any useful title, will need to rely on JS to find an appropriate title.
+		return $title;
+	}
+}

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Skip Link Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Allows the user to add the post title to their read more links.
+ *
+ * @since 1.16.0
+ */
+class ReadMoreAddTitleFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'read_more';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'everywhere';
+	}
+
+	/**
+	 * Registers everything needed for the skip link fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+
+		add_filter(
+			'edac_filter_fixes_settings_sections',
+			function ( $sections ) {
+				$sections['read_more_links'] = [
+					'title'       => esc_html__( 'Read More links', 'accessibility-checker' ),
+					'description' => esc_html__( 'Add the post title and links ', 'accessibility-checker' ),
+					'callback'    => [ $this, 'read_more_section_callback' ],
+				];
+
+				return $sections;
+			}
+		);
+
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_add_read_more_title'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Add Post Title to "Read More"', 'accessibility-checker' ),
+					'labelledby'  => 'add_read_more_title',
+					'description' => esc_html__( 'Adds the post title to the "Read More" links in post lists if your theme outputs those.', 'accessibility-checker' ),
+					'section'     => 'read_more_links',
+				];
+
+				$fields['edac_fix_add_read_more_title_screen_reader_only'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Make the title for screen readers only', 'accessibility-checker' ),
+					'labelledby'  => 'add_read_more_title_screen_reader_only',
+					'description' => esc_html__( 'Wraps the post title added to the link with styles making it for screen readers only.', 'accessibility-checker' ),
+					'condition'   => 'edac_fix_add_read_more_title',
+					'section'     => 'read_more_links',
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_add_read_more_title', false ) ) {
+			return;
+		}
+		add_action( 'the_content_more_link', [ $this, 'add_title_to_read_more' ], 100, 2 );
+		add_filter( 'get_the_excerpt', [ $this, 'add_title_link_to_excerpts' ], 100 );
+		add_filter( 'excerpt_more', [ $this, 'add_title_to_excerpt_more' ], 100 );
+
+		if ( get_option( 'edac_fix_add_read_more_title_screen_reader_only', false ) ) {
+			add_action( 'wp_head', [ $this, 'add_screen_reader_styles' ] );
+		}
+	}
+
+	/**
+	 * Add the post title to the read more link.
+	 *
+	 * @param string $link The read more link.
+	 * @param string $text The link text.
+	 * @return string
+	 */
+	public function add_title_to_read_more( $link, $text ): string {
+
+		global $id;
+
+		return str_replace(
+			$text,
+			$text . ' ' . $this->generate_read_more_string( $id ),
+			$link
+		);
+	}
+
+	/**
+	 * Add the post title to the excerpt.
+	 *
+	 * @param string $excerpt The excerpt.
+	 * @return string
+	 */
+	public function add_title_link_to_excerpts( $excerpt ): string {
+		if ( has_excerpt() && ! is_attachment() ) {
+			global $id;
+			$excerpt .= ' ' . $this->generate_read_more_string( $id, true );
+		}
+
+		return $excerpt;
+	}
+
+	/**
+	 * Add the post title to the excerpt more link.
+	 *
+	 * @return string
+	 */
+	public function add_title_to_excerpt_more(): string {
+		global $id;
+		return '&hellip;' . $this->generate_read_more_string( $id );
+	}
+
+
+	/**
+	 * Add the screen reader styles.
+	 *
+	 * @return void
+	 */
+	public function add_screen_reader_styles() {
+		?>
+		<style>
+			.edac-screen-reader-text {
+				position: absolute;
+				clip: rect(1px, 1px, 1px, 1px);
+				clip-path: polygon(0 0, 0 0, 0 0);
+				height: 1px;
+				width: 1px;
+				overflow: hidden;
+				white-space: nowrap;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Generate the read more string to add to the links.
+	 *
+	 * @param int  $id The post ID.
+	 * @param bool $never_use_screen_reader Whether to never use the screen reader styles.
+	 * @return string
+	 */
+	private function generate_read_more_string( $id, $never_use_screen_reader = false ) {
+
+		return sprintf(
+			'<span class="edac-content-more-title%s">%s</span>',
+			! $never_use_screen_reader && get_option( 'edac_fix_add_read_more_title_screen_reader_only', false ) ? ' edac-screen-reader-text' : '',
+			wp_kses_post( get_the_title( $id ) )
+		);
+	}
+
+	/**
+	 * Callback for the read more section.
+	 *
+	 * @return void
+	 */
+	public function read_more_section_callback() {
+		?>
+		<p><?php esc_html_e( 'This fix adds the post title to the "Read More" links in post lists at the "More" block and in excerpts.', 'accessibility-checker' ); ?></p>
+		<?php
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -10,6 +10,9 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ReadMoreAddTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddMissingOrEmptyPageTitleFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 
 /**
  * Manager class for fixes.
@@ -92,6 +95,7 @@ class FixesManager {
 				HTMLLangAndDirFix::class,
 				ReadMoreAddTitleFix::class,
 				TabindexFix::class,
+				AddMissingOrEmptyPageTitleFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ReadMoreAddTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 
 /**
@@ -54,20 +55,29 @@ class FixesManager {
 	 * Maybe enqueue the frontend scripts.
 	 */
 	private function maybe_enqueue_frontend_scripts() {
-		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
-		if ( ! is_admin() ) {
-			add_action(
-				'wp_enqueue_scripts',
-				function () {
-					wp_enqueue_script( 'edac-frontend-fixes', EDAC_PLUGIN_URL . 'build/frontendFixes.bundle.js', [], EDAC_VERSION, true );
-					wp_localize_script(
-						'edac-frontend-fixes',
-						'edac_frontend_fixes',
-						apply_filters( 'edac_filter_frontend_fixes_data', [] )
-					);
-				}
-			);
+
+		if (
+			is_admin() ||
+			( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+			( defined( 'DOING_AJAX' ) && DOING_AJAX ) ||
+			( defined( 'DOING_CRON' ) && DOING_CRON ) ||
+			( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		) {
+			return;
 		}
+
+		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
+		add_action(
+			'wp_enqueue_scripts',
+			function () {
+				wp_enqueue_script( 'edac-frontend-fixes', EDAC_PLUGIN_URL . 'build/frontendFixes.bundle.js', [], EDAC_VERSION, true );
+				wp_localize_script(
+					'edac-frontend-fixes',
+					'edac_frontend_fixes',
+					apply_filters( 'edac_filter_frontend_fixes_data', [] )
+				);
+			}
+		);
 	}
 
 	/**
@@ -79,6 +89,7 @@ class FixesManager {
 			[
 				SkipLinkFix::class,
 				HTMLLangAndDirFix::class,
+				ReadMoreAddTitleFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -7,11 +7,9 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
-use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ReadMoreAddTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
-use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 
 /**
  * Manager class for fixes.
@@ -66,9 +64,9 @@ class FixesManager {
 			( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 		) {
 			return;
-    }
+		}
 
-    // Consider adding this only if we can determine at least 1 of the fixes are enabled.
+		// Consider adding this only if we can determine at least 1 of the fixes are enabled.
 		add_action(
 			'wp_enqueue_scripts',
 			function () {
@@ -90,10 +88,8 @@ class FixesManager {
 			'edac_filter_fixes',
 			[
 				SkipLinkFix::class,
-				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				ReadMoreAddTitleFix::class,
-				TabindexFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -88,8 +88,10 @@ class FixesManager {
 			'edac_filter_fixes',
 			[
 				SkipLinkFix::class,
+				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				ReadMoreAddTitleFix::class,
+				TabindexFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/src/frontendFixes/Fixes/missingOrEmptyPageTitleFix.js
+++ b/src/frontendFixes/Fixes/missingOrEmptyPageTitleFix.js
@@ -22,8 +22,11 @@ const MissingOrEmptyPageTitleFix = () => {
 		const header = headers[ i ];
 		if ( header.innerText.trim() !== '' ) {
 			document.title = header.innerText;
-			if ( MissingOrEmptyPageTitle.site_name && MissingOrEmptyPageTitle.site_name.trim() !== '' ) {
-				document.title += ' ' + MissingOrEmptyPageTitle.seporator + ' ' + MissingOrEmptyPageTitle.site_name;
+			if (
+				( MissingOrEmptyPageTitle.site_name && MissingOrEmptyPageTitle.site_name.trim() !== '' ) &&
+				( MissingOrEmptyPageTitle.site_name.trim() !== document.title.trim() )
+			) {
+				document.title += ' ' + MissingOrEmptyPageTitle.title_seporator + ' ' + MissingOrEmptyPageTitle.site_name;
 			}
 			break;
 		}

--- a/src/frontendFixes/Fixes/missingOrEmptyPageTitleFix.js
+++ b/src/frontendFixes/Fixes/missingOrEmptyPageTitleFix.js
@@ -1,0 +1,37 @@
+const MissingOrEmptyPageTitle = window.edac_frontend_fixes?.missing_or_empty_page_title || {
+	enabled: false,
+};
+
+const MissingOrEmptyPageTitleFix = () => {
+	if ( ! MissingOrEmptyPageTitle.enabled ) {
+		return;
+	}
+
+	if ( document.title && document.title.trim() !== '' ) {
+		return;
+	}
+
+	if ( MissingOrEmptyPageTitle.full_title && MissingOrEmptyPageTitle.full_title.trim() !== '' ) {
+		document.title = MissingOrEmptyPageTitle.full_title;
+		return;
+	}
+
+	// try finding the first header element with text content and use it.
+	const headers = document.querySelectorAll( 'h1, .h1, h2, h3, h4, h5, h6' );
+	for ( let i = 0; i < headers.length; i++ ) {
+		const header = headers[ i ];
+		if ( header.innerText.trim() !== '' ) {
+			document.title = header.innerText;
+			if ( MissingOrEmptyPageTitle.site_name && MissingOrEmptyPageTitle.site_name.trim() !== '' ) {
+				document.title += ' ' + MissingOrEmptyPageTitle.seporator + ' ' + MissingOrEmptyPageTitle.site_name;
+			}
+			break;
+		}
+	}
+
+	if ( ! document.title && MissingOrEmptyPageTitle.site_name && MissingOrEmptyPageTitle.site_name.trim() !== '' ) {
+		document.title = MissingOrEmptyPageTitle.site_name;
+	}
+};
+
+export default MissingOrEmptyPageTitleFix;

--- a/src/frontendFixes/Fixes/missingOrEmptyPageTitleFix.js
+++ b/src/frontendFixes/Fixes/missingOrEmptyPageTitleFix.js
@@ -32,7 +32,7 @@ const MissingOrEmptyPageTitleFix = () => {
 		}
 	}
 
-	if ( ! document.title && MissingOrEmptyPageTitle.site_name && MissingOrEmptyPageTitle.site_name.trim() !== '' ) {
+	if ( ! document.title && ( MissingOrEmptyPageTitle.site_name && MissingOrEmptyPageTitle.site_name.trim() !== '' ) ) {
 		document.title = MissingOrEmptyPageTitle.site_name;
 	}
 };

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -20,3 +20,10 @@ if ( edacFrontendFixes.tabindex.enabled ) {
 		tabindexFix.default();
 	} );
 }
+
+if ( edacFrontendFixes.missing_or_empty_page_title.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "missing-or-empty-page-title" */ './Fixes/missingOrEmptyPageTitleFix' ).then( ( missingOrEmptyPageTitleFix ) => {
+		missingOrEmptyPageTitleFix.default();
+	} );
+}


### PR DESCRIPTION
This PR adds a 'Fix' class to try ensure there is never a missing or empty document title.

It has a PHP filter that will run through and try to fill it with post_title followed by a first found header in content and falling back to site title (and description if available).

It also adds some JS handling for situations where the php filter can't find something to add or cases where the title function is not present in a theme. If tries to add post title, followed by finding the first heading on the page and uses the site title as the final choice.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
