### PR TITLE
Add php class to create settings for RemoveTitleIfPrefferedAccessible…

### DIFF
--- a/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
+++ b/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Accessible Name Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Finds elements with a preferred accessible name.
+ *
+ * @since 1.16.0
+ */
+class RemoveTitleIfPrefferedAccessibleNameFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'remove_title_if_preferred_accessible_name';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers the settings field for the accessible name fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+				$fields[ 'edac_fix_' . $this->get_slug() ] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Prefer Accessible Names', 'accessibility-checker' ),
+					'labelledby'  => 'accessible_name',
+					'description' => esc_html__( 'Remove "title" attributes from elements with a preffered accessible name.', 'accessibility-checker' ),
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Outputs the feature flag for the fix on the frontend for JS to use.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_' . $this->get_slug(), false ) ) {
+			return;
+		}
+
+		// Adds the accessible name data to be used in JS if necessary.
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data[ $this->get_slug() ] = [
+					'enabled' => true,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -7,10 +7,11 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
-use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 
 /**
  * Manager class for fixes.
@@ -83,6 +84,7 @@ class FixesManager {
 				CommentSearchLabelFix::class,
 				HTMLLangAndDirFix::class,
 				TabindexFix::class,
+				RemoveTitleIfPrefferedAccessibleNameFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/src/frontendFixes/Fixes/removeTitleIfPrefferedAccessibleNameFix.js
+++ b/src/frontendFixes/Fixes/removeTitleIfPrefferedAccessibleNameFix.js
@@ -1,0 +1,82 @@
+const RemoveTitleIfPreferredAccessibleNameFix = window.edac_frontend_fixes?.remove_title_if_preferred_accessible_name || {
+	enabled: false,
+};
+
+const RemoveTitleIfPreferredAccessibleName = () => {
+	if ( ! RemoveTitleIfPreferredAccessibleNameFix.enabled ) {
+		return;
+	}
+
+	const elementsWithTitle = document.querySelectorAll( 'img[title], a[title], input[title], textarea[title], select[title], button[title]' );
+
+	const imagesWithTitles = document.querySelectorAll( 'img[title]' );
+	imagesWithTitles.forEach( ( element ) => {
+		if ( element.getAttribute( 'title' )?.trim() === '' ) {
+			return;
+		}
+
+		// if the image has a non-empty alt attribute, remove the title attribute
+		if ( element.getAttribute( 'alt' )?.trim() !== '' ) {
+			removeTitle( element );
+			return;
+		}
+		// since the alt is empty put the title in the alt then remove the title.
+		element.setAttribute( 'alt', element.getAttribute( 'title' ) );
+		removeTitle( element );
+	} );
+
+	const linksOrButtonsWithTitles = elementsWithTitle.querySelectorAll( 'a, button' );
+	linksOrButtonsWithTitles.forEach( ( element ) => {
+		if ( element.getAttribute( 'title' )?.trim() === '' ) {
+			return;
+		}
+
+		// if the element has non-empty text content, remove the title attribute
+		if ( element.innerText.trim() !== '' ) {
+			removeTitle( element );
+			return;
+		}
+
+		// element has no text content, check if it has aria-label or aria-labelledby attribute
+		const ariaLabel = element.getAttribute( 'aria-label' );
+		const ariaLabelledBy = element.getAttribute( 'aria-labelledby' );
+		if ( ariaLabel?.trim() !== '' || ariaLabelledBy?.trim() !== '' ) {
+			removeTitle( element );
+			return;
+		}
+
+		// by this point the element has no text content, aria-label or aria-labelledby, move the title to the aria-label then remove the title
+		element.setAttribute( 'aria-label', element.getAttribute( 'title' ) );
+		removeTitle( element );
+	} );
+
+	const inputsWithTitles = elementsWithTitle.querySelectorAll( 'input, textarea, select' );
+	inputsWithTitles.forEach( ( element ) => {
+		if ( element.getAttribute( 'title' )?.trim() === '' ) {
+			return;
+		}
+
+		// check for some associated label or wrapping label.
+		const ariaLabel = element.getAttribute( 'aria-label' );
+		const ariaLabelledBy = element.getAttribute( 'aria-labelledby' );
+		const associatedLabel = element.labels?.[ 0 ]?.innerText;
+		const wrappingLabel = element.closest( 'label' )?.innerText;
+
+		if ( ariaLabel?.trim() !== '' || ariaLabelledBy?.trim() !== '' || associatedLabel?.trim() !== '' || wrappingLabel?.trim() !== '' ) {
+			// there exists a label already, remove the title attribute.
+			removeTitle( element );
+			return;
+		}
+
+		// by this point there is no proper labeling found so move the title to the aria-label then remove the title
+		element.setAttribute( 'aria-label', element.getAttribute( 'title' ) );
+		removeTitle( element );
+	} );
+};
+
+const removeTitle = ( element ) => {
+	element.classList.add( 'edac-removed-title' );
+	element.removeAttribute( 'title' );
+};
+
+export default RemoveTitleIfPreferredAccessibleName;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -1,22 +1,36 @@
 const edacFrontendFixes = window.edac_frontend_fixes || {};
 
-if ( edacFrontendFixes.skip_link.enabled ) {
+if ( edacFrontendFixes?.skip_link?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "skip-link" */ './Fixes/skipLinkFix' ).then( ( skipLinkFix ) => {
 		skipLinkFix.default();
 	} );
 }
 
-if ( edacFrontendFixes.lang_and_dir.enabled ) {
+if ( edacFrontendFixes?.lang_and_dir?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "aria-hidden" */ './Fixes/langAndDirFix' ).then( ( langAndDirFix ) => {
 		langAndDirFix.default();
 	} );
 }
 
-if ( edacFrontendFixes.tabindex.enabled ) {
+if ( edacFrontendFixes?.tabindex?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "tabindex" */ './Fixes/tabindexFix' ).then( ( tabindexFix ) => {
 		tabindexFix.default();
+	} );
+}
+
+if ( edacFrontendFixes?.meta_viewport_scalable?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "meta-viewport-scalable" */ './Fixes/metaViewportScalableFix' ).then( ( metaViewportScalableFix ) => {
+		metaViewportScalableFix.default();
+	} );
+}
+
+if ( edacFrontendFixes?.remove_title_if_preferred_accessible_name?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "remove-title-if-preferred-accessible-name" */ './Fixes/removeTitleIfPrefferedAccessibleNameFix' ).then( ( removeTitleIfPreferredAccessibleNameFix ) => {
+		removeTitleIfPreferredAccessibleNameFix.default();
 	} );
 }


### PR DESCRIPTION
Checks `img`, `a`, `input`, `textarea`, `select` and `button` elements for titles and, if found removes it or moves it to preferred places for screen readers like the alt value or an aria-label

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
…Name Fix