### PR TITLE
added: an early return for nav menus

### DIFF
--- a/src/frontendFixes/Fixes/underlineFix.js
+++ b/src/frontendFixes/Fixes/underlineFix.js
@@ -12,9 +12,13 @@ const ForceUnderlineFix = () => {
 	const targets = document.querySelectorAll( ForceUnderlineFixData.target );
 
 	targets.forEach( function( target ) {
-		if ( ! target.closest( 'nav' ) ) {
-			target.style.textDecoration = 'underline';
+		// Early return if the element is inside a `nav` element or an element with role="navigation"
+		if ( target.closest( 'nav' ) || target.closest( '[role="navigation"]' ) ) {
+			return;
 		}
+
+		// Apply underline style
+		target.style.textDecoration = 'underline';
 
 		// Store the original styles in data-* attributes
 		target.setAttribute( 'data-original-outline', target.style.outlineWidth );


### PR DESCRIPTION
The PR fixes the issue with the underline being applied to navigation links on mouse out. It improves the logic by adding an early return if the element is inside a `nav` or has a `role` of navigation.