### PR TITLE
Delete fix option keys on uninstall

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -154,7 +154,11 @@ class FixesPage implements PageInterface {
 		 */
 		$fields = apply_filters( 'edac_filter_fixes_settings_fields', [] );
 
+		$field_keys = [];
+
 		foreach ( $fields as $field_id => $field ) {
+
+			$field_keys[] = $field_id;
 
 			$field_type = $field['type'] ?? 'checkbox';
 			$sanitizer  = $field['sanitize_callback'] ?? [ $this, 'sanitize_checkbox' ];
@@ -176,6 +180,8 @@ class FixesPage implements PageInterface {
 
 			register_setting( self::SETTINGS_SLUG, $field_id, $sanitizer );
 		}
+
+		update_option( 'edac_fixes_fields', $field_keys );
 	}
 
 	/**

--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -154,11 +154,7 @@ class FixesPage implements PageInterface {
 		 */
 		$fields = apply_filters( 'edac_filter_fixes_settings_fields', [] );
 
-		$field_keys = [];
-
 		foreach ( $fields as $field_id => $field ) {
-
-			$field_keys[] = $field_id;
 
 			$field_type = $field['type'] ?? 'checkbox';
 			$sanitizer  = $field['sanitize_callback'] ?? [ $this, 'sanitize_checkbox' ];
@@ -180,8 +176,6 @@ class FixesPage implements PageInterface {
 
 			register_setting( self::SETTINGS_SLUG, $field_id, $sanitizer );
 		}
-
-		update_option( 'edac_fixes_fields', $field_keys );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -36,7 +36,27 @@ if ( true === (bool) $delete_data ) {
 		'edac_black_friday_2023_notice_dismiss',
 		'edac_fixes_fields',
 	];
-	$fix_options = get_option( 'edac_fixes_fields', [] );
+	$fix_options = [
+		'edac_fix_add_skip_link',
+		'edac_fix_add_skip_link_target_id',
+		'edac_fix_add_skip_link_nav_target_id',
+		'edac_fix_comment_label',
+		'edac_fix_search_label',
+		'edac_fix_add_lang_and_dir',
+		'edac_fix_add_read_more_title',
+		'edac_fix_add_read_more_title_screen_reader_only',
+		'edac_fix_remove_tabindex',
+		'edac_fix_remove_title_if_preferred_accessible_name',
+		'edac_fix_force_link_underline',
+		'edac_fix_meta_viewport_scalable',
+		'edac_fix_prevent_links_opening_in_new_windows',
+		'edac_fix_focus_outline',
+		'edac_fix_focus_outline_color',
+		'edac_fix_add_file_size_and_type_to_linked_files',
+		'edac_fix_block_pdf_uploads',
+		'edac_fix_add_missing_or_empty_page_title',
+		'edac_fix_add_label_to_unlabelled_form_fields',
+	];
 
 	if ( array_merge( $options, $fix_options ) ) {
 		foreach ( $options as $option ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -34,6 +34,7 @@ if ( true === (bool) $delete_data ) {
 		'edac_authorization_username',
 		'edac_gaad_notice_dismiss',
 		'edac_black_friday_2023_notice_dismiss',
+		'edac_fixes_fields',
 	];
 	$fix_options = get_option( 'edac_fixes_fields', [] );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,7 +21,7 @@ if ( true === (bool) $delete_data ) {
 	$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $wpdb->prefix . 'accessibility_checker' ) );
 
 	// delete options.
-	$options = [
+	$options     = [
 		'edac_db_version',
 		'edac_activation_date',
 		'edac_simplified_summary_position',
@@ -35,7 +35,9 @@ if ( true === (bool) $delete_data ) {
 		'edac_gaad_notice_dismiss',
 		'edac_black_friday_2023_notice_dismiss',
 	];
-	if ( $options ) {
+	$fix_options = get_option( 'edac_fixes_fields', [] );
+
+	if ( array_merge( $options, $fix_options ) ) {
 		foreach ( $options as $option ) {
 			delete_option( $option );
 			delete_site_option( $option );


### PR DESCRIPTION
This PR stores options keys so they can be later deleted if the plugin gets uninstalled

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
