### PR TITLE
Set pattern for including css in fixes

### DIFF
--- a/includes/classes/Fixes/Fix/FocusOutlineFix.php
+++ b/includes/classes/Fixes/Fix/FocusOutlineFix.php
@@ -114,7 +114,7 @@ class FocusOutlineFix implements FixInterface {
 	 *
 	 * @return void
 	 */
-	public function css() {
+	public function styles() {
 		$styles = '';
 
 		$focus_color_option = get_option( 'edac_fix_focus_outline_color', false );
@@ -130,9 +130,7 @@ class FocusOutlineFix implements FixInterface {
 
 		ob_start();
 		?>
-		<style id="edac-fix-focus-outline">
 			<?php echo esc_attr( $styles ); ?>
-		</style>
 		<?php
 		$styles = ob_get_clean();
 		wp_add_inline_style( 'edac-frontend-fixes-styles', $styles );

--- a/includes/classes/Fixes/Fix/FocusOutlineFix.php
+++ b/includes/classes/Fixes/Fix/FocusOutlineFix.php
@@ -72,7 +72,7 @@ class FocusOutlineFix implements FixInterface {
 					'description'       => sprintf(
 						// translators: %1$s: a color code wrapped in a <code> tag.
 						__( 'Sets the color for the focus outline. Default is %1$s.', 'accessibility-checker' ),
-						'<code>#005FCC</code>' 
+						'<code>#005FCC</code>'
 					),
 					'sanitize_callback' => 'sanitize_hex_color',
 					'section'           => 'focus_outline',
@@ -95,7 +95,7 @@ class FocusOutlineFix implements FixInterface {
 			return;
 		}
 
-		add_action( 'wp_head', [ $this, 'css' ] );
+		add_action( 'edac_action_enqueue_frontend_fixes_styles', [ $this, 'styles' ] );
 	}
 
 	/**
@@ -128,10 +128,13 @@ class FocusOutlineFix implements FixInterface {
 		}
 		";
 
+		ob_start();
 		?>
 		<style id="edac-fix-focus-outline">
 			<?php echo esc_attr( $styles ); ?>
 		</style>
 		<?php
+		$styles = ob_get_clean();
+		wp_add_inline_style( 'edac-frontend-fixes-styles', $styles );
 	}
 }

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -95,7 +95,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 		add_filter( 'excerpt_more', [ $this, 'add_title_to_excerpt_more' ], 100 );
 
 		if ( get_option( 'edac_fix_add_read_more_title_screen_reader_only', false ) ) {
-			add_action( 'wp_head', [ $this, 'add_screen_reader_styles' ] );
+			add_action( 'edac_action_enqueue_frontend_fixes_styles', [ $this, 'styles' ] );
 		}
 	}
 
@@ -162,9 +162,8 @@ class ReadMoreAddTitleFix implements FixInterface {
 	 *
 	 * @return void
 	 */
-	public function add_screen_reader_styles() {
-		?>
-		<style>
+	public function styles() {
+		$styles = <<<CSS
 			.edac-screen-reader-text {
 				position: absolute;
 				clip: rect(1px, 1px, 1px, 1px);
@@ -174,8 +173,8 @@ class ReadMoreAddTitleFix implements FixInterface {
 				overflow: hidden;
 				white-space: nowrap;
 			}
-		</style>
-		<?php
+		CSS;
+		wp_add_inline_style( 'edac-frontend-fixes-styles', $styles );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -155,7 +155,7 @@ class SkipLinkFix implements FixInterface {
 	 *
 	 * @return void
 	 */
-	public function add_skip_link_styles() {
+	public function styles() {
 		$styles = <<<CSS
 			.edac-bypass-block {
 				border: 0;

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -144,6 +144,10 @@ class SkipLinkFix implements FixInterface {
 				return $data;
 			}
 		);
+
+		if ( ! get_option( 'edac_fix_disable_skip_link_styles', false ) ) {
+			add_action( 'edac_action_enqueue_frontend_fixes_styles', [ $this, 'styles' ] );
+		}
 	}
 
 	/**
@@ -152,8 +156,7 @@ class SkipLinkFix implements FixInterface {
 	 * @return void
 	 */
 	public function add_skip_link_styles() {
-		?>
-		<style id="edac-fix-skip-link-styles">
+		$styles = <<<CSS
 			.edac-bypass-block {
 				border: 0;
 				clip: rect(1px, 1px, 1px, 1px);
@@ -213,8 +216,9 @@ class SkipLinkFix implements FixInterface {
 				outline: 2px solid #000;
 				outline-offset: 2px;
 			}
-		</style>
-		<?php
+		CSS;
+
+		wp_add_inline_style( 'edac-frontend-fixes-styles', $styles );
 	}
 
 	/**
@@ -254,7 +258,6 @@ class SkipLinkFix implements FixInterface {
 					?>
 					<a class="edac-skip-link--navigation" href="#<?php echo esc_attr( $nav_target ); ?>"><?php esc_html_e( 'Skip to navigation', 'accessibility-checker' ); ?></a>
 				<?php endif; ?>
-				<?php get_option( 'edac_fix_disable_skip_link_styles', false ) ? '' : $this->add_skip_link_styles(); ?>
 			</div>
 		</template>
 		<?php

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -94,6 +94,8 @@ class FixesManager {
 					apply_filters( 'edac_filter_frontend_fixes_data', [] )
 				);
 				do_action( 'edac_action_enqueue_frontend_fixes' );
+				wp_enqueue_style( 'edac-frontend-fixes-styles', EDAC_PLUGIN_URL . 'build/css/frontendFixes.bundle.css', [], EDAC_VERSION );
+				do_action( 'edac_action_enqueue_frontend_fixes_styles' );
 			}
 		);
 	}

--- a/src/frontendFixes/sass/frontend-fixes.scss
+++ b/src/frontendFixes/sass/frontend-fixes.scss
@@ -1,0 +1,1 @@
+/* This is a holder file that may contain scss for frontend fixes. It is not inteded to be used generally unless a style is global. Use wp_inline_style() to add styles for individual fixes. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
 		],
 		frontendFixes: [
 			'./src/frontendFixes/index.js',
+			'/src/frontendFixes/sass/frontend-fixes.scss',
 		],
 
 	},


### PR DESCRIPTION
This PR adds a root stylesheet for fixes that gets included which individual fixes can use to target for wp_add_inline_style when they need to include small snippets of CSS for the fix.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
