### PR TITLE
William/7652418924/skip link fix feedback

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -166,11 +166,12 @@ class FixesPage implements PageInterface {
 				self::SETTINGS_SLUG,
 				$field['section'] ?? 'edac_fixes_general',
 				[
-					'name'        => $field_id,
-					'labelledby'  => $field_id,
-					'description' => $field['description'] ?? '',
-					'condition'   => $field['condition'] ?? '',
-					'default'     => $field['default'] ?? '',
+					'name'          => $field_id,
+					'labelledby'    => $field_id,
+					'description'   => $field['description'] ?? '',
+					'condition'     => $field['condition'] ?? '',
+					'required_when' => $field['required_when'] ?? '',
+					'default'       => $field['default'] ?? '',
 				]
 			);
 

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -38,7 +38,6 @@ trait Checkbox {
 			/>
 			<?php echo wp_kses( $args['description'], [ 'code' => [] ] ); ?>
 		</label>
-		</label>
 		<?php
 	}
 

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -34,6 +34,7 @@ trait Checkbox {
 				name="<?php echo esc_attr( $args['name'] ); ?>"
 				<?php checked( 1, $option_value ); ?>
 				<?php echo isset( $args['condition'] ) ? 'data-condition="' . esc_attr( $args['condition'] ) . '"' : ''; ?>
+				<?php echo isset( $args['required_when'] ) ? 'data-required_when="' . esc_attr( $args['required_when'] ) . '"' : ''; ?>
 			/>
 			<?php echo wp_kses( $args['description'], [ 'code' => [] ] ); ?>
 		</label>

--- a/admin/AdminPage/FixesSettingType/Color.php
+++ b/admin/AdminPage/FixesSettingType/Color.php
@@ -38,6 +38,7 @@ trait Color {
 			name="<?php echo esc_attr( $args['name'] ); ?>"
 			value="<?php echo esc_attr( $option_value ); ?>"
 			<?php echo isset( $args['condition'] ) ? 'data-condition="' . esc_attr( $args['condition'] ) . '"' : ''; ?>
+			<?php echo isset( $args['required_when'] ) ? 'data-required_when="' . esc_attr( $args['required_when'] ) . '"' : ''; ?>
 		/>
 		<?php
 	}

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -37,6 +37,7 @@ trait Text {
 			name="<?php echo esc_attr( $args['name'] ); ?>"
 			value="<?php echo esc_attr( $option_value ); ?>"
 			<?php echo isset( $args['condition'] ) ? 'data-condition="' . esc_attr( $args['condition'] ) . '"' : ''; ?>
+			<?php echo isset( $args['required_when'] ) ? 'data-required_when="' . esc_attr( $args['required_when'] ) . '"' : ''; ?>
 		/>
 		<?php
 	}

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -66,7 +66,7 @@ class SkipLinkFix implements FixInterface {
 				];
 
 				$fields['edac_fix_add_skip_link_target_id'] = [
-					'label'             => esc_html__( 'Main Content Target', 'accessibility-checker' ),
+					'label'             => esc_html__( 'Main Content Target (required)', 'accessibility-checker' ),
 					'type'              => 'text',
 					'labelledby'        => 'skip_link_target_id',
 					'description'       => esc_html__( 'Defines the ID(s) of the main content area(s) to be targeted by skip links. Enter multiple IDs separated by commas; the system will cascade through the list to find the appropriate one for each page.', 'accessibility-checker' ),

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -215,7 +215,18 @@ class SkipLinkFix implements FixInterface {
 	 */
 	public function skip_link_section_callback() {
 		?>
-		<p><?php esc_html_e( 'Settings related to the addition and styling of skip links.', 'accessibility-checker' ); ?></p>
+		<p>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					// translators: %1$s: opening anchor tag, %2$s: closing anchor tag.
+					'If your theme is not already adding a skip link that allows keyboard users to bypass the navigation and quickly jump to the main content, enable skip links here. %1$sLearn more about skip links.%2$s</p>',
+					'<a href="' . esc_url( 'https://equalizedigital.com/how-to-make-your-wordpress-site-more-accessible-with-skip-links/' ) . '">',
+					'</a>'
+				)
+			);
+			?>
+		</p>
 		<?php
 	}
 

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -87,15 +87,6 @@ class SkipLinkFix implements FixInterface {
 					'condition'         => 'edac_fix_add_skip_link',
 				];
 
-				$fields['edac_fix_disable_skip_link_styles'] = [
-					'label'       => esc_html__( 'Disable Skip Link Bundled Styles', 'accessibility-checker' ),
-					'type'        => 'checkbox',
-					'labelledby'  => 'disable_skip_link_styles',
-					'description' => esc_html__( 'Disable the default styles for skip links. Note: This makes the "Always Visible Skip Link" setting irrelevant.', 'accessibility-checker' ),
-					'section'     => 'skip_link',
-					'condition'   => 'edac_fix_add_skip_link',
-				];
-
 				return $fields;
 			}
 		);
@@ -256,7 +247,7 @@ class SkipLinkFix implements FixInterface {
 					?>
 					<a class="edac-skip-link--navigation" href="#<?php echo esc_attr( $nav_target ); ?>"><?php esc_html_e( 'Skip to navigation', 'accessibility-checker' ); ?></a>
 				<?php endif; ?>
-				<?php get_option( 'edac_fix_disable_skip_link_styles', false ) ? '' : $this->add_skip_link_styles(); ?>
+				<?php $this->add_skip_link_styles(); ?>
 			</div>
 		</template>
 		<?php

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -82,6 +82,7 @@ class SkipLinkFix implements FixInterface {
 					'sanitize_callback' => 'sanitize_text_field',
 					'section'           => 'skip_link',
 					'condition'         => 'edac_fix_add_skip_link',
+					'required_when'     => 'edac_fix_add_skip_link',
 				];
 
 				$fields['edac_fix_add_skip_link_nav_target_id'] = [

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -65,15 +65,6 @@ class SkipLinkFix implements FixInterface {
 					'section'     => 'skip_link',
 				];
 
-				$fields['edac_fix_add_skip_link_always_visible'] = [
-					'label'       => esc_html__( 'Always Visible Skip Link', 'accessibility-checker' ),
-					'type'        => 'checkbox',
-					'labelledby'  => 'add_skip_link_always_visible',
-					'description' => esc_html__( 'Makes the skip link always visible.', 'accessibility-checker' ),
-					'section'     => 'skip_link',
-					'condition'   => 'edac_fix_add_skip_link',
-				];
-
 				$fields['edac_fix_add_skip_link_target_id'] = [
 					'label'             => esc_html__( 'Main Content Target', 'accessibility-checker' ),
 					'type'              => 'text',
@@ -168,8 +159,7 @@ class SkipLinkFix implements FixInterface {
 				word-wrap: normal !important;
 			}
 
-			.edac-bypass-block:focus-within,
-			.edac-bypass-block-always-visible {
+			.edac-bypass-block:focus-within {
 				background-color: #ececec;
 				clip: auto !important;
 				-webkit-clip-path: none;

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -61,7 +61,7 @@ class SkipLinkFix implements FixInterface {
 					'label'       => esc_html__( 'Enable Skip Link', 'accessibility-checker' ),
 					'type'        => 'checkbox',
 					'labelledby'  => 'add_skip_link',
-					'description' => esc_html__( 'Adds a skip link to all site pages, allowing users to skip directly to the main content.', 'accessibility-checker' ),
+					'description' => esc_html__( 'Add a skip link to all site pages, allowing users to skip directly to the main content.', 'accessibility-checker' ),
 					'section'     => 'skip_link',
 				];
 
@@ -69,7 +69,7 @@ class SkipLinkFix implements FixInterface {
 					'label'             => esc_html__( 'Main Content Target (required)', 'accessibility-checker' ),
 					'type'              => 'text',
 					'labelledby'        => 'skip_link_target_id',
-					'description'       => esc_html__( 'Defines the ID(s) of the main content area(s) to be targeted by skip links. Enter multiple IDs separated by commas; the system will cascade through the list to find the appropriate one for each page.', 'accessibility-checker' ),
+					'description'       => esc_html__( 'Define the ID(s) of the main content area(s) to be targeted by skip links. Enter multiple IDs separated by commas; the system will cascade through the list to find the appropriate one for each page.', 'accessibility-checker' ),
 					'sanitize_callback' => 'sanitize_text_field',
 					'section'           => 'skip_link',
 					'condition'         => 'edac_fix_add_skip_link',
@@ -81,7 +81,7 @@ class SkipLinkFix implements FixInterface {
 					'type'              => 'text',
 					'labelledby'        => 'skip_link_nav_target_id',
 					// translators: %1$s: ampersand character wrapped in a <code> tag.
-					'description'       => sprintf( __( 'Sets the ID attribute of the navigation element, starting with %1$s.', 'accessibility-checker' ), '<code>#</code>' ),
+					'description'       => sprintf( __( 'Set the ID attribute of the navigation element, starting with %1$s. This is useful if your main navigation contains actions that most site visitors would want to take such as login or search features.', 'accessibility-checker' ), '<code>#</code>' ),
 					'sanitize_callback' => 'sanitize_text_field',
 					'section'           => 'skip_link',
 					'condition'         => 'edac_fix_add_skip_link',
@@ -91,7 +91,7 @@ class SkipLinkFix implements FixInterface {
 					'label'       => esc_html__( 'Disable Skip Link Bundled Styles', 'accessibility-checker' ),
 					'type'        => 'checkbox',
 					'labelledby'  => 'disable_skip_link_styles',
-					'description' => esc_html__( 'Disables the default styles for skip links. Note: This makes the "Always Visible Skip Link" setting irrelevant.', 'accessibility-checker' ),
+					'description' => esc_html__( 'Disable the default styles for skip links. Note: This makes the "Always Visible Skip Link" setting irrelevant.', 'accessibility-checker' ),
 					'section'     => 'skip_link',
 					'condition'   => 'edac_fix_add_skip_link',
 				];

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -45,9 +45,8 @@ class SkipLinkFix implements FixInterface {
 			'edac_filter_fixes_settings_sections',
 			function ( $sections ) {
 				$sections['skip_link'] = [
-					'title'       => esc_html__( 'Skip Link', 'accessibility-checker' ),
-					'description' => esc_html__( 'Adds a skip link to all site pages, allowing users to skip directly to the main content.', 'accessibility-checker' ),
-					'callback'    => [ $this, 'skip_link_section_callback' ],
+					'title'    => esc_html__( 'Skip Link', 'accessibility-checker' ),
+					'callback' => [ $this, 'skip_link_section_callback' ],
 				];
 
 				return $sections;

--- a/src/admin/fixes-page/conditional-required-settings.js
+++ b/src/admin/fixes-page/conditional-required-settings.js
@@ -1,0 +1,26 @@
+// if element with id edac_fix_add_skip_link is checked then force element with id edac_fix_add_skip_link_target_id to be required
+
+export const initRequiredSetup = () => {
+	document.querySelectorAll( '[data-required_when]' ).forEach( ( element ) => {
+		const conditionId = element.getAttribute( 'data-required_when' );
+
+		const conditionElement = document.getElementById( conditionId );
+
+		if ( conditionElement ) {
+			setRequiredState( conditionElement.checked, element.id );
+			conditionElement.addEventListener( 'change', ( event ) => {
+				// find any element that points to this element id and set it to required
+				const targets = document.querySelectorAll( `[data-required_when="${ conditionId }"]` );
+				targets.forEach( ( target ) => {
+					setRequiredState( event.target.checked, target.id );
+				} );
+			} );
+		}
+	} );
+};
+
+const setRequiredState = ( checked, elementId ) => {
+	// if this is checked then force the target id to be required
+	const targetElement = document.getElementById( elementId );
+	targetElement.required = checked;
+};

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -5,6 +5,7 @@ import {
 	initSummaryTabKeyboardAndClickHandlers,
 } from './summary/summary-tab-input-event-handlers';
 import { initFixesInputStateHandler } from './fixes-page/conditional-disable-settings';
+import { initRequiredSetup } from './fixes-page/conditional-required-settings';
 
 // eslint-disable-next-line camelcase
 const edacScriptVars = edac_script_vars;
@@ -15,6 +16,7 @@ const edacScriptVars = edac_script_vars;
 	jQuery( function() {
 		if ( document.getElementById( 'edac-fixes-page' ) ) {
 			initFixesInputStateHandler();
+			initRequiredSetup();
 		}
 
 		// Accessibility Statement disable


### PR DESCRIPTION
Makes some tweaks to the skip links fix options as per feedback from testing.

* Removes the 'always display' and 'disable style output' settings.
* Updates the section messaging
* Makes the Main Target ID input required if the skip links setting is enabled.
* Adjusts some of the copy on settings to swap things like `adds` to `add` and `sets` to `set`

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
