### PR TITLE
Prevent links opening new tabs tweaks

### DIFF
--- a/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
+++ b/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
@@ -22,7 +22,7 @@ class PreventLinksOpeningNewWindowFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_slug(): string {
-		return 'prevent-links-opening-new-windows';
+		return 'prevent_links_opening_new_windows';
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
+++ b/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
@@ -64,14 +64,14 @@ class PreventLinksOpeningNewWindowFix implements FixInterface {
 	 * Run the fix for adding the comment and search form labels.
 	 */
 	public function run(): void {
-		if ( ! get_option( 'edac_fix_prevent_links_opening_in_new_windows', false ) ) {
+		if ( ! get_option( 'edac_fix_' . $this->get_slug(), false ) ) {
 			return;
 		}
 
 		add_filter(
 			'edac_filter_frontend_fixes_data',
 			function ( $data ) {
-				$data['prevent_links_opening_in_new_window'] = [
+				$data[ $this->get_slug() ] = [
 					'enabled' => true,
 				];
 				return $data;

--- a/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
+++ b/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
@@ -44,11 +44,15 @@ class PreventLinksOpeningNewWindowFix implements FixInterface {
 		add_filter(
 			'edac_filter_fixes_settings_fields',
 			function ( $fields ) {
-				$fields['edac_fix_prevent_links_opening_in_new_windows'] = [
-					'label'       => esc_html__( 'Links Opening New Windows', 'accessibility-checker' ),
+				$fields[ 'edac_fix_' . $this->get_slug() ] = [
+					'label'       => esc_html__( 'Block Links Opening New Windows', 'accessibility-checker' ),
 					'type'        => 'checkbox',
 					'labelledby'  => 'prevent_links_opening_in_new_windows',
-					'description' => esc_html__( 'Prevents links from opening in a new window without user intent.', 'accessibility-checker' ),
+					'description' => sprintf(
+						// translators: %1%s: A <code> tag containing target="_blank".
+						esc_html__( 'Prevent links from opening in a new window or tab by removing %1$s.', 'accessibility-checker' ),
+						'<code>target="_blank"</code>'
+					),
 				];
 
 				return $fields;

--- a/src/frontendFixes/Fixes/preventLinksOpeningNewWindowFix.js
+++ b/src/frontendFixes/Fixes/preventLinksOpeningNewWindowFix.js
@@ -1,6 +1,10 @@
 const preventLinksOpeningNewWindowFix = () => {
-	const links = document.querySelectorAll( 'a[target="_blank"]' );
+	const links = document.querySelectorAll( 'a[target="_blank"]:not(.allow-new-tab)' );
 	links.forEach( ( link ) => {
+		// If the link is in a container that allows new tabs, don't remove the target attribute.
+		if ( link.closest( '.allow-new-tab' ) ) {
+			return;
+		}
 		link.removeAttribute( 'target' );
 		link.classList.add( 'edac-removed-target-blank' );
 	} );

--- a/src/frontendFixes/Fixes/preventLinksOpeningNewWindowFix.js
+++ b/src/frontendFixes/Fixes/preventLinksOpeningNewWindowFix.js
@@ -1,8 +1,8 @@
 const preventLinksOpeningNewWindowFix = () => {
-	const links = document.querySelectorAll( 'a[target="_blank"]:not(.allow-new-tab)' );
+	const links = document.querySelectorAll( 'a[target="_blank"]:not(.edac-allow-new-tab)' );
 	links.forEach( ( link ) => {
 		// If the link is in a container that allows new tabs, don't remove the target attribute.
-		if ( link.closest( '.allow-new-tab' ) ) {
+		if ( link.closest( '.edac-allow-new-tab' ) ) {
 			return;
 		}
 		link.removeAttribute( 'target' );

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -49,7 +49,7 @@ if ( edacFrontendFixes?.meta_viewport_scalable?.enabled ) {
 	} );
 }
 
-if ( edacFrontendFixes?.prevent_links_opening_in_new_window?.enabled ) {
+if ( edacFrontendFixes?.prevent_links_opening_new_windows?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "prevent-links-opening-in-new-window" */ './Fixes/preventLinksOpeningNewWindowFix' ).then( ( preventLinksOpeningNewWindowFix ) => {
 		preventLinksOpeningNewWindowFix.default();


### PR DESCRIPTION
Updates the fix that blocks links opening new tabs/windows.

* Updates the description and title.
* Adds a modifier class detection for `.edac-allow-new-tab` that will prevent the target="_blank" being removed if it's on the link or on a parent of the link.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
