### PR TITLE
Include settings for pro fix callouts

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -159,6 +159,8 @@ class FixesPage implements PageInterface {
 			$field_type = $field['type'] ?? 'checkbox';
 			$sanitizer  = $field['sanitize_callback'] ?? [ $this, 'sanitize_checkbox' ];
 
+			$is_upsell = $field['upsell'] ?? false;
+
 			add_settings_field(
 				$field_id,
 				$field['label'],
@@ -172,6 +174,7 @@ class FixesPage implements PageInterface {
 					'condition'     => $field['condition'] ?? '',
 					'required_when' => $field['required_when'] ?? '',
 					'default'       => $field['default'] ?? '',
+					'upsell'        => $is_upsell,
 				]
 			);
 

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -26,7 +26,7 @@ trait Checkbox {
 
 		$option_value = get_option( $args['name'] );
 		?>
-		<label>
+		<label <?php echo ( $upsell ) ? 'class="edac-fix--disabled edac-fix--upsell"' : ''; ?>>
 			<input
 				type="checkbox"
 				value="1"
@@ -35,6 +35,7 @@ trait Checkbox {
 				<?php checked( 1, $option_value ); ?>
 				<?php echo isset( $args['condition'] ) ? 'data-condition="' . esc_attr( $args['condition'] ) . '"' : ''; ?>
 				<?php echo isset( $args['required_when'] ) ? 'data-required_when="' . esc_attr( $args['required_when'] ) . '"' : ''; ?>
+				<?php echo isset( $args['upsell'] ) && $args['upsell'] ? 'disabled' : ''; ?>
 			/>
 			<?php echo wp_kses( $args['description'], [ 'code' => [] ] ); ?>
 		</label>

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -81,10 +81,11 @@ class Enqueue_Admin {
 				'edac',
 				'edac_script_vars',
 				[
-					'postID'     => $post_id,
-					'nonce'      => wp_create_nonce( 'ajax-nonce' ),
-					'edacApiUrl' => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
-					'restNonce'  => wp_create_nonce( 'wp_rest' ),
+					'postID'      => $post_id,
+					'nonce'       => wp_create_nonce( 'ajax-nonce' ),
+					'edacApiUrl'  => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
+					'restNonce'   => wp_create_nonce( 'wp_rest' ),
+					'fixesProUrl' => esc_url_raw( edac_generate_pro_link( [ 'fix', '__fix__' ] ) ),
 				]
 			);
 

--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Fix for adding file size and type to linked files.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Fix for adding file size and type to linked files.
+ *
+ * @since 1.16.0
+ */
+class AddFileSizeAndTypeToLinkedFilesFix implements FixInterface {
+
+	/**
+	 * The slug for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'add_file_size_and_type_to_linked_files';
+	}
+
+	/**
+	 * The type for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'none';
+	}
+
+	/**
+	 * Register anything needed for the fix.
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+				$fields[ 'edac_fix_' . $this->get_slug() ] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Add File Size & Type To Links', 'accessibility-checker' ),
+					'labelledby'  => 'add_file_size_and_type_to_linked_files',
+					'description' => esc_html__( 'Adds the file size and type to linked files that may trigger a download.', 'accessibility-checker' ),
+					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix.
+	 */
+	public function run(): void {
+		// Intentionally left empty.
+	}
+}

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Try label unlabelled form fields.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Try to add labels to unlabelled form fields.
+ *
+ * @since 1.16.0
+ */
+class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'add_label_to_unlabelled_form_fields';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'none';
+	}
+
+	/**
+	 * Registers everything needed for the fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+
+		add_filter(
+			'edac_filter_fixes_settings_sections',
+			function ( $sections ) {
+				$sections[ $this->get_slug() ] = [
+					'title'    => esc_html__( 'Unlabelled Form Fields', 'accessibility-checker' ),
+					'callback' => [ $this, $this->get_slug() . '_section_callback' ],
+				];
+
+				return $sections;
+			}
+		);
+
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+				$fields[ 'edac_fix_' . $this->get_slug() ] = [
+					'label'       => esc_html__( 'Unlabelled Form Fields', 'accessibility-checker' ),
+					'type'        => 'checkbox',
+					'labelledby'  => $this->get_slug(),
+					'description' => esc_html__( 'Attempts to add labels to form fields that are missing them.', 'accessibility-checker' ),
+					'section'     => $this->get_slug(),
+					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix for adding the comment and search form labels.
+	 */
+	public function run(): void {
+
+		// Intentionally left empty.
+	}
+
+	/**
+	 * Callback for the fix settings section.
+	 *
+	 * @return void
+	 */
+	public function add_label_to_unlabelled_form_fields_section_callback() {
+		?>
+		<p>
+			<?php
+				printf(
+				// translators: %1$s: a CSS class name wrapped in a <code> tag.
+					esc_html__( 'Attempts to add labels to form fields that are missing them. Note: You may need to add custom styles targeting the %1$s class if adding labels affects your form layouts.', 'accessibility-checker' ),
+					'<code>.edac-generated-label</code>'
+				);
+			?>
+		</p>
+		<?php
+	}
+}

--- a/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
+++ b/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Fix missing or empty page titles.
+ *
+ * @package accessibility-checker-pro
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Allows the user to add a title to the page <title> tag if empty or missing.
+ *
+ * @since 1.9.0
+ */
+class AddMissingOrEmptyPageTitleFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'missing_or_empty_page_title';
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'none';
+	}
+
+	/**
+	 * Registers everything needed for the fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+
+				$fields['edac_fix_add_missing_or_empty_page_title'] = [
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Add Missing Page Title', 'accessibility-checker' ),
+					'labelledby'  => 'add_missing_or_empty_page_title',
+					// translators: %1$s: a code tag with a title tag.
+					'description' => sprintf( __( 'Adds a %1$s tag to the page if it\'s missing or empty.', 'accessibility-checker' ), '<code>&lt;title&gt;</code>' ),
+					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix for adding a missing or empty page title.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		// Intentionally left empty.
+	}
+}

--- a/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
+++ b/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Fix for blocking PDF uploads.
+ *
+ * @since 1.16.0
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Fix for blocking PDF uploads.
+ *
+ * @since 1.16.0
+ */
+class BlockPDFUploadsFix implements FixInterface {
+
+	/**
+	 * Get the slug for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'block_pdf_uploads';
+	}
+
+	/**
+	 * Get the type for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'none';
+	}
+
+	/**
+	 * Register setting.
+	 */
+	public function register(): void {
+		// Add the settings field for the fix.
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			function ( $fields ) {
+				$fields['edac_fix_block_pdf_uploads'] = [
+					'label'       => esc_html__( 'Block PDF Uploads', 'accessibility-checker' ),
+					'type'        => 'checkbox',
+					'labelledby'  => 'block_pdf_uploads',
+					// translators: %1$s: a code tag with the capability name.
+					'description' => sprintf( __( 'Restricts PDF uploads for users without the %1$s capability (allowed for admins by default).', 'accessibility-checker' ), '<code>edac_upload_pdf</code>' ),
+					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+				];
+
+				return $fields;
+			}
+		);
+	}
+
+	/**
+	 * Run the fix.
+	 */
+	public function run() {
+		// Intentionally empty - this run method should be implemented in an extension class.
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -7,6 +7,10 @@
 
 namespace EqualizeDigital\AccessibilityChecker\Fixes;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddLabelToUnlabelledFormFieldsFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddMissingOrEmptyPageTitleFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\BlockPDFUploadsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
@@ -114,6 +118,10 @@ class FixesManager {
 				MetaViewportScalableFix::class,
 				PreventLinksOpeningNewWindowFix::class,
 				FocusOutlineFix::class,
+				BlockPDFUploadsFix::class,
+				AddFileSizeAndTypeToLinkedFilesFix::class,
+				AddMissingOrEmptyPageTitleFix::class,
+				AddLabelToUnlabelledFormFieldsFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -999,3 +999,31 @@ function edac_is_item_using_matching_extension( string $item, array $extensions 
 	$extension = pathinfo( $item, PATHINFO_EXTENSION );
 	return in_array( '.' . $extension, $extensions, true );
 }
+
+/**
+ * Generate links to pro page with some params.
+ *
+ * @param array $query_args A list of key value pairs to add as query vars to the link.
+ * @return string
+ */
+function edac_generate_pro_link( $query_args = [] ): string {
+	if ( empty( $text ) ) {
+		$text = __( 'Get Pro', 'accessibility-checker' );
+	}
+
+	$query_defaults = [
+		'utm_source'       => 'accessibility-checker',
+		'utm_medium'       => 'software',
+		'utm_campaign'     => 'wordpress-general',
+		'php_version'      => PHP_VERSION,
+		'platform'         => 'wordpress',
+		'platform_version' => $GLOBALS['wp_version'],
+		'software'         => 'free',
+		'software_version' => EDAC_VERSION,
+	];
+
+	$query_args = array_merge( $query_defaults, $query_args );
+
+	// Build the URL.
+	return add_query_arg( $query_args, 'https://www.accessibilitychecker.com/pricing/' );
+}

--- a/src/admin/fixes-page/pro-callout.js
+++ b/src/admin/fixes-page/pro-callout.js
@@ -1,0 +1,21 @@
+import { __ } from '@wordpress/i18n';
+
+export const inlineFixesProUpsell = () => {
+	// find elements with 'edac-fix--upsell' class
+	const upsellElements = document.querySelectorAll( '.edac-fix--upsell' );
+
+	// loop through each element
+	upsellElements.forEach( ( element ) => {
+		// create a link with the upsell url
+		const upsellLink = document.createElement( 'a' );
+		const url = window.edac_script_vars?.fixesProUrl || 'https://equalizedigital.com/accessibility-checker/pricing/';
+		upsellLink.href = url.replace( '__fix__', element.querySelector( 'input' )?.getAttribute( 'name' ) );
+		upsellLink.target = '_blank';
+		upsellLink.rel = 'noopener noreferrer';
+		upsellLink.textContent = __( 'Get Pro' );
+		upsellLink.classList.add( 'edac-fix--upsell-link' );
+
+		// insert the link at the end of nearest tr elements first th
+		element.closest( 'tr' ).querySelector( 'th' ).appendChild( upsellLink );
+	} );
+};

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -6,6 +6,7 @@ import {
 } from './summary/summary-tab-input-event-handlers';
 import { initFixesInputStateHandler } from './fixes-page/conditional-disable-settings';
 import { initRequiredSetup } from './fixes-page/conditional-required-settings';
+import { inlineFixesProUpsell } from './fixes-page/pro-callout';
 
 // eslint-disable-next-line camelcase
 const edacScriptVars = edac_script_vars;
@@ -17,6 +18,7 @@ const edacScriptVars = edac_script_vars;
 		if ( document.getElementById( 'edac-fixes-page' ) ) {
 			initFixesInputStateHandler();
 			initRequiredSetup();
+			inlineFixesProUpsell();
 		}
 
 		// Accessibility Statement disable

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1939,9 +1939,26 @@
 }
 
 #edac-fixes-page {
-	.edac_fix_disabled {
-		opacity: 0.5;
-		display: none !important;
+	.edac-fix {
+		&--disabled {
+			opacity: 0.75;
+		}
+
+		&--upsell-link {
+			background: #f3cd1e;
+			padding: 4px 8px;
+			border-radius: 18px;
+			color: #072446;
+			display: inline-block;
+			font-size: 0.75rem;
+			text-decoration: none;
+			margin-left: 0.25rem;
+			line-height: 1;
+		}
+
+		&--upsell-link:hover {
+			text-decoration: underline;
+		}
 	}
 
 	.edac-notice {

--- a/src/frontendFixes/Fixes/tabindexFix.js
+++ b/src/frontendFixes/Fixes/tabindexFix.js
@@ -15,8 +15,8 @@ const TabindexFix = () => {
 			return;
 		}
 
-		// Remove the tabindex if present
-		if ( element.hasAttribute( 'tabindex' ) ) {
+		// Remove the tabindex if present and is not -1.
+		if ( element.hasAttribute( 'tabindex' ) && element.getAttribute( 'tabindex' ) !== '-1' ) {
 			element.removeAttribute( 'tabindex' );
 		}
 	} );
@@ -29,6 +29,10 @@ const TabindexFix = () => {
 
 	// Loop through each element and add tabindex="0" to make it focusable
 	elementsToFocus.forEach( ( element ) => {
+		// Don't add tabindex 0 to elements that alaredy have -1.
+		if ( element.hasAttribute( 'tabindex' ) && element.getAttribute( 'tabindex' ) === '-1' ) {
+			return;
+		}
 		element.setAttribute( 'tabindex', '0' );
 		element.classList.add( 'edac-focusable' );
 	} );


### PR DESCRIPTION
This PR brings the settings for the pro fixes into the free plugin and flags them as upgrade features for users. The `run` method is empty for pro fixes and the type is set to `none`.

It also adds a helper to generate pro links and some JS to put a pro flag on settings on the fixes page.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
