### PR TITLE
Hotfix/1.15.3

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.15.1
+ * Version:           1.15.3
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.15.1' );
+	define( 'EDAC_VERSION', '1.15.3' );
 }
 
 // Current database version.

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -32,7 +32,7 @@ class Settings {
 		// Check if the new settings class exists. This is added to allow for backwards compatibility
 		// with the old settings class. The old settings class check should be removed after a few releases.
 		$new_settings_class_exists = class_exists( 'EqualizeDigital\AccessibilityCheckerPro\Admin\Settings' );
-		if ( ! class_exists( '\EDACP\Settings' ) || ! $new_settings_class_exists ) {
+		if ( ! class_exists( '\EDACP\Settings' ) && ! $new_settings_class_exists ) {
 
 			$post_types = Helpers::get_option_as_array( 'edac_post_types' );
 

--- a/includes/rules/missing_form_label.php
+++ b/includes/rules/missing_form_label.php
@@ -15,7 +15,7 @@
 function edac_rule_missing_form_label( $content, $post ) { // phpcs:ignore -- $post is reserved for future use or for compliance with a specific interface.
 
 	$dom    = $content['html'];
-	$fields = $dom->find( 'input' );
+	$fields = $dom->find( 'input, textarea, select' );
 	$errors = [];
 
 	foreach ( $fields as $field ) {

--- a/includes/rules/slider_present.php
+++ b/includes/rules/slider_present.php
@@ -39,7 +39,7 @@ function edac_rule_slider_present( $content, $post ) { // phpcs:ignore -- $post 
 
 	$dom      = $content['html'];
 	$errors   = [];
-	$elements = $dom->find( '.slider, .carousel, .owl-carousel, .soliloquy-container, .n2-section-smartslider, .metaslider, .master-slider, [data-layerslider-uid], .rev_slider, .royalSlider, .wonderpluginslider, .meteor-slides, .flexslider, .slick-slider, .swiper-container, .flickity-slider, .spacegallery, .blueimp-gallery, .seq-active, .siema, .keen-slider, [data-jssor-slider], .bxslider, .glide--slider' );
+	$elements = $dom->find( '.slider, .carousel, .owl-carousel, .soliloquy-container, .n2-section-smartslider, .metaslider, .master-slider, [data-layerslider-uid], .rev_slider, .royalSlider, .wonderpluginslider, .meteor-slides, .flexslider, .slick-slider, .uagb-slick-carousel, .swiper-container, .flickity-slider, .spacegallery, .blueimp-gallery, .seq-active, .siema, .keen-slider, [data-jssor-slider], .bxslider, .glide--slider' );
 
 	if ( $elements ) {
 		foreach ( $elements as $element ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-checker",
-  "version": "1.15.1",
+  "version": "1.15.3",
   "description": "Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.",
   "author": "Equalize Digital",
   "license": "GPL-2.0+",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility
 Requires at least: 6.2
 Tested up to: 6.6.1
-Stable tag: 1.15.1
+Stable tag: 1.15.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,6 +170,12 @@ No, Accessibility Checker runs completely on your server and does not require yo
 8. Accessibility Checker Summary tab on a page with no accessibility error or warnings and an included simplified summary.
 
 == Changelog ==
+= 1.15.3
+* Enhancement: Detect missing labels on more elements.
+* Enhancement: Detect slick slider that gets initialized after the page loads.
+
+= 1.15.2 =
+* Fixed: Issue where CPT results would not be reflected in dashboard widgets and reports
 
 = 1.15.1 =
 * Fixed: Issue where a modal could result in JS error preventing display


### PR DESCRIPTION
* 7813448082: catch missing labels on textarea and select, not just input elements
* 7814889444: add class to detect slick slider added with spectra (ultimate addons)

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
