### PR TITLE
Add help link feature for fix descriptions

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -174,6 +174,8 @@ class FixesPage implements PageInterface {
 					'required_when' => $field['required_when'] ?? '',
 					'default'       => $field['default'] ?? '',
 					'upsell'        => $is_upsell,
+					'help_id'       => $field['help_id'] ?? '',
+					'label'         => $field['label'] ?? '',
 				]
 			);
 

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -53,7 +53,7 @@ trait Checkbox {
 				?>
 				<a
 					href="<?php echo esc_url( $link ); ?>"
-					class="edca-dashicon-muted"
+					class="edac-fix-description-help-link"
 					target="_blank"
 					aria-label="Read documentation for <?php echo esc_attr( $args['label'] ); ?>"
 				>

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -23,7 +23,7 @@ trait Checkbox {
 		if ( ! isset( $args['name'], $args['description'] ) ) {
 			return;
 		}
-		$upsell       = isset( $args['upsell'] ) && $args['upsell'] ? true : false;
+		$upsell       = isset( $args['upsell'] ) && $args['upsell'];
 		$option_value = get_option( $args['name'] );
 		?>
 		<label <?php echo ( $upsell ) ? 'class="edac-fix--disabled edac-fix--upsell"' : ''; ?>>
@@ -53,11 +53,11 @@ trait Checkbox {
 				?>
 				<a
 					href="<?php echo esc_url( $link ); ?>"
-					class="edac-details-rule-information"
+					class="edca-dashicon-muted"
 					target="_blank"
 					aria-label="Read documentation for <?php echo esc_attr( $args['label'] ); ?>"
 				>
-					<span class="dashicons dashicons-info"></span>
+					<span class="dashicons dashicons-info edac-dashicon-muted"></span>
 				</a>
 			<?php endif; ?>
 		</label>

--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -38,6 +38,28 @@ trait Checkbox {
 				<?php echo $upsell ? 'disabled' : ''; ?>
 			/>
 			<?php echo wp_kses( $args['description'], [ 'code' => [] ] ); ?>
+			<?php
+			if ( $args['help_id'] && $args['label'] ) :
+				$link = edac_generate_link_type(
+					[
+						'utm-content' => 'fix-description',
+						'utm-term'    => $args['name'],
+					],
+					'help',
+					[
+						'help_id' => $args['help_id'],
+					]
+				)
+				?>
+				<a
+					href="<?php echo esc_url( $link ); ?>"
+					class="edac-details-rule-information"
+					target="_blank"
+					aria-label="Read documentation for <?php echo esc_attr( $args['label'] ); ?>"
+				>
+					<span class="dashicons dashicons-info"></span>
+				</a>
+			<?php endif; ?>
 		</label>
 		<?php
 	}

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -45,7 +45,7 @@ trait Text {
 				?>
 				<a
 					href="<?php echo esc_url( $link ); ?>"
-					class="edca-dashicon-muted"
+					class="edac-fix-description-help-link"
 					target="_blank"
 					aria-label="Read documentation for <?php echo esc_attr( $args['label'] ); ?>"
 				>

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -45,7 +45,7 @@ trait Text {
 				?>
 				<a
 					href="<?php echo esc_url( $link ); ?>"
-					class="edac-details-rule-information"
+					class="edca-dashicon-muted"
 					target="_blank"
 					aria-label="Read documentation for <?php echo esc_attr( $args['label'] ); ?>"
 				>

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -30,6 +30,28 @@ trait Text {
 			style="display: block; margin-bottom: 6px;"
 		>
 			<?php echo wp_kses( $args['description'], [ 'code' => [] ] ); ?>
+			<?php
+			if ( $args['help_id'] && $args['label'] ) :
+				$link = edac_generate_link_type(
+					[
+						'utm-content' => 'fix-description',
+						'utm-term'    => $args['name'],
+					],
+					'help',
+					[
+						'help_id' => $args['help_id'],
+					]
+				)
+				?>
+				<a
+					href="<?php echo esc_url( $link ); ?>"
+					class="edac-details-rule-information"
+					target="_blank"
+					aria-label="Read documentation for <?php echo esc_attr( $args['label'] ); ?>"
+				>
+					<span class="dashicons dashicons-info"></span>
+				</a>
+			<?php endif; ?>
 		</label>
 		<input
 			type="text"

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -85,7 +85,7 @@ class Enqueue_Admin {
 					'nonce'       => wp_create_nonce( 'ajax-nonce' ),
 					'edacApiUrl'  => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
 					'restNonce'   => wp_create_nonce( 'wp_rest' ),
-					'fixesProUrl' => esc_url_raw( edac_generate_pro_link( [ 'fix', '__fix__' ] ) ),
+					'fixesProUrl' => esc_url_raw( edac_generate_link_type( [ 'utm-term', '__fix__' ] ) ),
 				]
 			);
 

--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -47,6 +47,7 @@ class AddFileSizeAndTypeToLinkedFilesFix implements FixInterface {
 					'labelledby'  => 'add_file_size_and_type_to_linked_files',
 					'description' => esc_html__( 'Adds the file size and type to linked files that may trigger a download.', 'accessibility-checker' ),
 					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+					'help_id'     => 8492,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -63,6 +63,7 @@ class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
 					'description' => esc_html__( 'Attempts to add labels to form fields that are missing them.', 'accessibility-checker' ),
 					'section'     => $this->get_slug(),
 					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+					'help_id'     => 8497,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
+++ b/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
@@ -51,6 +51,7 @@ class AddMissingOrEmptyPageTitleFix implements FixInterface {
 					// translators: %1$s: a code tag with a title tag.
 					'description' => sprintf( __( 'Adds a %1$s tag to the page if it\'s missing or empty.', 'accessibility-checker' ), '<code>&lt;title&gt;</code>' ),
 					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+					'help_id'     => 8490,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
+++ b/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
@@ -51,6 +51,7 @@ class BlockPDFUploadsFix implements FixInterface {
 					// translators: %1$s: a code tag with the capability name.
 					'description' => sprintf( __( 'Restricts PDF uploads for users without the %1$s capability (allowed for admins by default).', 'accessibility-checker' ), '<code>edac_upload_pdf</code>' ),
 					'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+					'help_id'     => 8486,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/FocusOutlineFix.php
+++ b/includes/classes/Fixes/Fix/FocusOutlineFix.php
@@ -63,6 +63,7 @@ class FocusOutlineFix implements FixInterface {
 					'labelledby'  => 'fix_focus_outline',
 					'description' => esc_html__( 'Adds an outline to elements when they receive keyboard focus.', 'accessibility-checker' ),
 					'section'     => 'focus_outline',
+					'help_id'     => 8495,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -49,6 +49,7 @@ class HTMLLangAndDirFix implements FixInterface {
 					'labelledby'  => 'add_read_more_title',
 					// translators: %1$s: a attribute name wrapped in a <code> tag. %2$s: dir attribute %3$s: html element.
 					'description' => sprintf( __( 'Adds the site language (%1$s) and text direction (%2$s) attributes to the %3$s element.', 'accessibility-checker' ), '<code>lang</code>', '<code>dir</code>', '<code>&lt;html&gt;</code>' ),
+					'help_id'     => '1234567890',
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -49,7 +49,7 @@ class HTMLLangAndDirFix implements FixInterface {
 					'labelledby'  => 'add_read_more_title',
 					// translators: %1$s: a attribute name wrapped in a <code> tag. %2$s: dir attribute %3$s: html element.
 					'description' => sprintf( __( 'Adds the site language (%1$s) and text direction (%2$s) attributes to the %3$s element.', 'accessibility-checker' ), '<code>lang</code>', '<code>dir</code>', '<code>&lt;html&gt;</code>' ),
-					'help_id'     => '1234567890',
+					'help_id'     => 8487,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/LinkUnderline.php
+++ b/includes/classes/Fixes/Fix/LinkUnderline.php
@@ -48,6 +48,7 @@ class LinkUnderline implements FixInterface {
 					'label'       => esc_html__( 'Force Link Underline', 'accessibility-checker' ),
 					'labelledby'  => 'force_link_underline',
 					'description' => esc_html__( 'Ensures that non-navigation links are underlined.', 'accessibility-checker' ),
+					'help_id'     => 8489,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/MetaViewportScalableFix.php
+++ b/includes/classes/Fixes/Fix/MetaViewportScalableFix.php
@@ -62,6 +62,7 @@ class MetaViewportScalableFix implements FixInterface {
 					'type'        => 'checkbox',
 					'labelledby'  => '',
 					'description' => esc_html__( 'Ensures the viewport tag allows for scaling, enhancing accessibility on mobile devices.', 'accessibility-checker' ),
+					'help_id'     => 8488,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
+++ b/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
@@ -53,6 +53,7 @@ class PreventLinksOpeningNewWindowFix implements FixInterface {
 						esc_html__( 'Prevent links from opening in a new window or tab by removing %1$s.', 'accessibility-checker' ),
 						'<code>target="_blank"</code>'
 					),
+					'help_id'     => 8493,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
+++ b/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
@@ -48,6 +48,7 @@ class RemoveTitleIfPrefferedAccessibleNameFix implements FixInterface {
 					'labelledby'  => 'accessible_name',
 					// translators: %1$s: a attribute name wrapped in a <code> tag.
 					'description' => sprintf( __( 'Removes %1$s attributes from elements that already have a preferred accessible name.', 'accessibility-checker' ), '<code>title</code>' ),
+					'help_id'     => 8494,
 				];
 
 				return $fields;

--- a/includes/classes/Fixes/Fix/TabindexFix.php
+++ b/includes/classes/Fixes/Fix/TabindexFix.php
@@ -49,6 +49,7 @@ class TabindexFix implements FixInterface {
 					'labelledby'  => 'remove_tabindex',
 					// translators: %1$s: a attribute name wrapped in a <code> tag.
 					'description' => sprintf( __( 'Removes the %1$s attribute from focusable elements.', 'accessibility-checker' ), '<code>tabindex</code>' ),
+					'help_id'     => 8496,
 				];
 
 				return $fields;

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1003,27 +1003,39 @@ function edac_is_item_using_matching_extension( string $item, array $extensions 
 /**
  * Generate links to pro page with some params.
  *
- * @param array $query_args A list of key value pairs to add as query vars to the link.
+ * @param array  $query_args A list of key value pairs to add as query vars to the link.
+ * @param string $type The type of link to generate. Default is 'pro'.
+ * @param array  $args Additional arguments to pass on the link.
  * @return string
  */
-function edac_generate_pro_link( $query_args = [] ): string {
-	if ( empty( $text ) ) {
-		$text = __( 'Get Pro', 'accessibility-checker' );
-	}
+function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ): string {
 
-	$query_defaults = [
+	$date_now        = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
+	$activation_date = new DateTime( get_option( 'edac_activation_date', gmdate( 'Y-m-d H:i:s' ) ) );
+	$interval        = $date_now->diff( $activation_date );
+	$days_active     = $interval->days;
+	$query_defaults  = [
 		'utm_source'       => 'accessibility-checker',
 		'utm_medium'       => 'software',
 		'utm_campaign'     => 'wordpress-general',
 		'php_version'      => PHP_VERSION,
 		'platform'         => 'wordpress',
 		'platform_version' => $GLOBALS['wp_version'],
-		'software'         => 'free',
-		'software_version' => EDAC_VERSION,
+		'software'         => defined( 'EDACP_KEY_VALID' ) && EDACP_KEY_VALID ? 'pro' : 'free',
+		'software_version' => defined( 'EDACP_VERSION' ) ? EDACP_VERSION : EDAC_VERSION,
+		'days_active'      => $days_active,
 	];
 
 	$query_args = array_merge( $query_defaults, $query_args );
 
-	// Build the URL.
-	return add_query_arg( $query_args, 'https://equalizedigital.com/accessibility-checker/pricing/' );
+	switch ( $type ) {
+		case 'help':
+			$base_link = trailingslashit( 'https://a11ychecker.com/help' . $args['help_id'] ?? '' );
+			break;
+		case 'pro':
+		default:
+			$base_link = 'https://equalizedigital.com/accessibility-checker/pricing/';
+			break;
+	}
+	return add_query_arg( $query_args, $base_link );
 }

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1971,3 +1971,8 @@
 		}
 	}
 }
+
+.edac-dashicon-muted {
+	color: $color-gray;
+	text-decoration: none;
+}


### PR DESCRIPTION
This PR introduces a way to set help link ids on fixes and a generator to create links with query vars for data.

![Screenshot from 2024-09-23 20-53-53](https://github.com/user-attachments/assets/9eb8ede1-fb41-4b95-99ca-8bff1d5ef29c)

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
