### PR TITLE
Move fix setting to the settings page in a tab

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -45,25 +45,47 @@ class FixesPage implements PageInterface {
 	}
 
 	/**
-	 * Add the page to the admin menu, setup it's tabs and filter in for the content.
+	 * Add the settings sections and fields and setup it's tabs and filter in for the content.
 	 */
 	public function add_page() {
-
-		add_submenu_page(
-			'accessibility_checker',
-			__( 'Accessibility Checker Settings', 'accessibility-checker' ),
-			__( 'Accessibility Fixes', 'accessibility-checker' ),
-			$this->settings_capability,
-			'accessibility_checker_' . self::PAGE_TAB_SLUG,
-			[ $this, 'render_page' ],
-			1
-		);
 
 		$this->register_settings_sections();
 		$this->register_fields_and_settings();
 
 		add_filter( 'edac_filter_admin_scripts_slugs', [ $this, 'add_slug_to_admin_scripts' ] );
 		add_filter( 'edac_filter_remove_admin_notices_screens', [ $this, 'add_slug_to_admin_notices' ] );
+		add_filter( 'edac_filter_settings_tab_items', [ $this, 'add_fixes_tab' ] );
+		add_action( 'edac_settings_tab_content', [ $this, 'add_fixes_tab_content' ], 11, 1 );
+	}
+
+	/**
+	 * Add fixes tab to settings page.
+	 *
+	 * @param  array $settings_tab_items arrray of tab items.
+	 * @return array
+	 */
+	public function add_fixes_tab( $settings_tab_items ) {
+
+		$scan_tab = [
+			'slug'  => 'fixes',
+			'label' => 'Fixes',
+			'order' => 2,
+		];
+		array_push( $settings_tab_items, $scan_tab );
+
+		return $settings_tab_items;
+	}
+
+	/**
+	 * Licence fixes tab content to settings page.
+	 *
+	 * @param  string $tab name of tab.
+	 * @return void
+	 */
+	public function add_fixes_tab_content( $tab ) {
+		if ( 'fixes' === $tab ) {
+			include EDAC_PLUGIN_DIR . '/partials/admin-page/fixes-page.php';
+		}
 	}
 
 	/**

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -7,20 +7,17 @@
 
 ?>
 <div id="edac-fixes-page" class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
-	<h1><?php esc_html_e( 'Accessibility Fixes', 'accessibility-checker' ); ?></h1>
 
-	<div class="tab-content">
-		<div class="edac-settings-general <?php echo EDAC_KEY_VALID ? '' : 'edac-show-pro-callout'; ?>">
-			<form action="options.php" method="post">
-				<?php
-				settings_fields( 'edac_settings_fixes' );
-				do_settings_sections( 'edac_settings_fixes' );
-				submit_button();
-				?>
-			</form>
-			<?php if ( EDAC_KEY_VALID === false ) { ?>
-				<div><?php include EDAC_PLUGIN_DIR . 'partials/pro-callout.php'; ?></div>
-			<?php } ?>
-		</div>
+	<div class="edac-settings-general <?php echo EDAC_KEY_VALID ? '' : 'edac-show-pro-callout'; ?>">
+		<form action="options.php" method="post">
+			<?php
+			settings_fields( 'edac_settings_fixes' );
+			do_settings_sections( 'edac_settings_fixes' );
+			submit_button();
+			?>
+		</form>
+		<?php if ( EDAC_KEY_VALID === false ) { ?>
+			<div><?php include EDAC_PLUGIN_DIR . 'partials/pro-callout.php'; ?></div>
+		<?php } ?>
 	</div>
 </div>

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -51,7 +51,7 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 
 	<?php
 	if ( $settings_tab_items ) {
-		echo '<nav class="nav-tab-wrapper">';
+		echo '<nav class="nav-tab-wrapper" aria-label="Settings Tabs">';
 		foreach ( $settings_tab_items as $settings_tab_item ) {
 			$slug      = $settings_tab_item['slug'] ? $settings_tab_item['slug'] : null;
 			$query_var = $slug ? '&tab=' . $slug : '';


### PR DESCRIPTION
This PR removes the Accessibility Fixes link from the plugin menu and moves it to a tab on the settings page.

- removed the menu link
- added tab via existing filters
- updated `aria-label` on tabs nav element

Fixes: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7810260579