### PR TITLE
Don't flag an issue for empty paragraph if it has aria-hidden

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -34,6 +34,9 @@ unzip accessibility-checker.zip -d ./dist/accessibility-checker
 rm ./dist/accessibility-checker/package.json
 rm ./dist/accessibility-checker/README.md
 
+# remove the unneeded (almost 1MB) tests folder for textstatistics package
+rm ./dist/accessibility-checker/vendor/davechild/textstatistics/tests -r
+
 #remove the original zip
 rm accessibility-checker.zip
 

--- a/src/pageScanner/checks/paragraph-not-empty.js
+++ b/src/pageScanner/checks/paragraph-not-empty.js
@@ -12,6 +12,11 @@ export default {
 			return true;
 		}
 
+		// If element has aria-hidden attribute with a value of true, it passes.
+		if ( node.getAttribute( 'aria-hidden' ) && node.getAttribute( 'aria-hidden' ).toLowerCase() === 'true' ) {
+			return true;
+		}
+
 		// Pass if there are child nodes and any child nodes are not text nodes (not Type of 3).
 		if ( node.childNodes.length && Array.from( node.childNodes ).some( ( child ) => child.nodeType !== 3 ) ) {
 			return true;


### PR DESCRIPTION
Someone opened a support ticket with a reason they wanted empty paragraphs with aria-hidden to not flag and it seems like it's worth it since if they have aria-hidden then screen readers will ignore them anyway and avoid creating noise to a screen reader user.

You can test this with:

```html
<p></p>
<p aria-hidden="true"></p>
<p aria-hidden="false"></p>
<p aria-hidden="TRUE"></p>
```

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
