### PR TITLE
Bump upload-artefact in action to v4

### DIFF
--- a/.github/workflows/code-coverage-and-coveralls.yml
+++ b/.github/workflows/code-coverage-and-coveralls.yml
@@ -40,7 +40,7 @@ jobs:
       run: ./vendor/bin/phpunit --coverage-clover=./coverage/clover.xml --coverage-html=./coverage/html
 
     - name : Attach zipped coverage report as workflow artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-html
         path: ./coverage/coverage-html.zip


### PR DESCRIPTION
One of the steps in the code coverage workflow is no longer working and triggering a stop for the workflow that handles code coverage. This PR bumps that step action to the latest version.

See a failure here: https://github.com/equalizedigital/accessibility-checker/actions/runs/11277744379/job/31364613280

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
