### PR TITLE
Exclude the query monitor container from the JS scan.

### DIFF
--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -44,7 +44,7 @@ const postId = body.getAttribute( 'data-iframe-post-id' );
 const scan = async (
 	options = { configOptions: {}, runOptions: {} }
 ) => {
-	const context = { exclude: [ '#wpadminbar', '.edac-panel-container' ] };
+	const context = { exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main' ] };
 
 	const defaults = {
 		configOptions: {


### PR DESCRIPTION
With some additional rules moved over the the JS scan some items inside the query monitor container were being flagged (new link warnings). 

This PR excludes the container from the scan by using the `context.exclude[]` object passed to the runner.

Excluded by id #query-monitor-main

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
