### PR TITLE
Prevent modal from having aria hidden incorrectly added

### DIFF
--- a/src/frontendHighlighterApp/fixesModal.js
+++ b/src/frontendHighlighterApp/fixesModal.js
@@ -66,11 +66,13 @@ export const openFixesModal = ( openingElement ) => {
 	// get all other imediate children of the body and set their aria-hidden to true
 	const bodyChildren = Array.from( document.body.children );
 	bodyChildren.forEach( ( child ) => {
-		if ( child !== modal || ! child.classList.contains( 'edac-fixes-modal__overlay' ) ) {
-			if ( child.getAttribute( 'aria-hidden' ) !== true ) {
-				child.setAttribute( 'aria-hidden', 'true' );
-				child.setAttribute( 'data-hidden-by-modal', 'true' );
-			}
+		if ( child.id === 'edac-fixes-modal' || child.classList.contains( 'edac-fixes-modal__overlay' ) ) {
+			return;
+		}
+
+		if ( child.getAttribute( 'aria-hidden' ) !== true ) {
+			child.setAttribute( 'aria-hidden', 'true' );
+			child.setAttribute( 'data-hidden-by-modal', 'true' );
 		}
 	} );
 


### PR DESCRIPTION
The code that was running during modal trigger was not excluding the modal from the parts that were handling the aria-hidden attributes of elements. This PR should fix that.

Basecamp card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7923127676

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
