### PR TITLE
Add a Clear Issues button in the editor

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -123,6 +123,7 @@ class Enqueue_Admin {
 							[ 'edac_pageScanner' => 1 ]
 						),
 						'version'    => EDAC_VERSION,
+						'restNonce'  => wp_create_nonce( 'wp_rest' ),
 					]
 				);
 

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -11,8 +11,7 @@ use EDAC\Admin\Helpers;
 use EDAC\Admin\Insert_Rule_Data;
 use EDAC\Admin\Scans_Stats;
 use EDAC\Admin\Settings;
-
-
+use EDAC\Admin\Purge_Post_Data;
 
 /**
  * Class that initializes and handles the REST api
@@ -211,7 +210,14 @@ class REST_Api {
 			return new \WP_REST_Response( [ 'message' => 'The post type is not set to be scanned.' ], 400 );
 		}
 
-		edac_save_post( $post_id, $post_type, 'rescan' );
+		// if flush is passed in via json and is true, then flush the cache.
+		$json = $request->get_json_params();
+		if ( isset( $json['flush'] ) && true === $json['flush'] ) {
+			// purge the issues for this post.
+			Purge_Post_Data::delete_post( $post_id );
+		}
+
+		edac_save_post( $post_id, $post, 'rescan' );
 	}
 
 	/**

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -165,10 +165,10 @@ class REST_Api {
 			function () use ( $ns, $version ) {
 				register_rest_route(
 					$ns . $version,
-					'/trigger-scan/(?P<id>\d+)',
+					'/clear-issues/(?P<id>\d+)',
 					[
 						'methods'             => 'POST',
-						'callback'            => [ $this, 'trigger_scan' ],
+						'callback'            => [ $this, 'clear_issues_for_post' ],
 						'args'                => [
 							'id' => [
 								'validate_callback' => function ( $param ) {
@@ -186,13 +186,13 @@ class REST_Api {
 	}
 
 	/**
-	 * REST handler that triggers a scan for a post.
+	 * REST handler to clear issues results for a given post ID.
 	 *
 	 * @param WP_REST_Request $request  The request passed from the REST call.
 	 *
 	 * @return \WP_REST_Response
 	 */
-	public function trigger_scan( $request ) {
+	public function clear_issues_for_post( $request ) {
 
 		if ( ! isset( $request['id'] ) ) {
 			return new \WP_REST_Response( [ 'message' => 'A required parameter is missing.' ], 400 );
@@ -216,9 +216,8 @@ class REST_Api {
 			// purge the issues for this post.
 			Purge_Post_Data::delete_post( $post_id );
 		}
-
-		edac_save_post( $post_id, $post, 'rescan' );
 	}
+
 
 	/**
 	 * Filter the html of the js validation violation.

--- a/partials/custom-meta-box.php
+++ b/partials/custom-meta-box.php
@@ -45,11 +45,11 @@
 
 		<button
 			role="button"
-			id="edac-rescan-button"
+			id="edac-clear-issues-button"
 			class="components-button is-secondary"
-			aria-label="<?php esc_attr_e( 'Delete all currently found issues and rescan this post', 'accessibility-checker' ); ?>"
+			aria-label="<?php esc_attr_e( 'Delete all currently found issues', 'accessibility-checker' ); ?>"
 			disabled="true"
-		><?php esc_html_e( 'Rescan', 'accessibility-checker' ); ?></button>
+		><?php esc_html_e( 'Clear Issues', 'accessibility-checker' ); ?></button>
 	</div>
 	<div
 		role="tabpanel"

--- a/partials/custom-meta-box.php
+++ b/partials/custom-meta-box.php
@@ -8,39 +8,49 @@
 ?>
 <div id="edac-tabs">
 	<p id="edac-tabs-label" class="screen-reader-text"><?php esc_html_e( 'Accessibility Checker issues panels', 'accessibility-checker' ); ?></p>
-	<ul class="edac-tabs" role="tablist" aria-labelledby="edac-tabs-label">
-		<li class="edac-tab">
-			<button
-				role="tab"
-				aria-selected="true"
-				aria-controls="edac-summary-panel"
-				id="edac-summary-tab"
-				class="active"
-			>
-				<?php esc_html_e( 'Summary', 'accessibility-checker' ); ?>
-			</button>
-		</li>
-		<li class="edac-tab">
-			<button
-				role="tab"
-				aria-selected="false"
-				aria-controls="edac-details-panel"
-				id="edac-details-tab"
-			>
-				<?php esc_html_e( 'Details', 'accessibility-checker' ); ?>
-			</button>
-		</li>
-		<li class="edac-tab">
-			<button
-				role="tab"
-				aria-selected="false"
-				aria-controls="edac-readability-panel"
-				id="edac-readability-tab"
-			>
-				<?php esc_html_e( 'Readability', 'accessibility-checker' ); ?>
-			</button>
-		</li>
-	</ul>
+	<div class="edac-tabs-and-rescan-container">
+		<ul class="edac-tabs" role="tablist" aria-labelledby="edac-tabs-label">
+			<li class="edac-tab">
+				<button
+					role="tab"
+					aria-selected="true"
+					aria-controls="edac-summary-panel"
+					id="edac-summary-tab"
+					class="active"
+				>
+					<?php esc_html_e( 'Summary', 'accessibility-checker' ); ?>
+				</button>
+			</li>
+			<li class="edac-tab">
+				<button
+					role="tab"
+					aria-selected="false"
+					aria-controls="edac-details-panel"
+					id="edac-details-tab"
+				>
+					<?php esc_html_e( 'Details', 'accessibility-checker' ); ?>
+				</button>
+			</li>
+			<li class="edac-tab">
+				<button
+					role="tab"
+					aria-selected="false"
+					aria-controls="edac-readability-panel"
+					id="edac-readability-tab"
+				>
+					<?php esc_html_e( 'Readability', 'accessibility-checker' ); ?>
+				</button>
+			</li>
+		</ul>
+
+		<button
+			role="button"
+			id="edac-rescan-button"
+			class="components-button is-secondary"
+			aria-label="<?php esc_attr_e( 'Delete all currently found issues and rescan this post', 'accessibility-checker' ); ?>"
+			disabled="true"
+		><?php esc_html_e( 'Rescan', 'accessibility-checker' ); ?></button>
+	</div>
 	<div
 		role="tabpanel"
 		aria-labelledby="edac-summary-tab"

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -61,6 +61,10 @@ const edacScriptVars = edac_script_vars;
 	} );
 
 	jQuery( window ).on( 'load', function() {
+		document.addEventListener( 'edac-cleared-issues', function() {
+			refreshTabDetails();
+		} );
+
 		// Allow other js to trigger a tab refresh through an event listener. Refactor.
 		const refreshTabDetails = () => {
 			// reset to first meta box tab

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -64,7 +64,7 @@
 	.edac-tabs-and-rescan-container {
 		display: flex;
 
-		#edac-rescan-button {
+		#edac-clear-issues-button {
 			margin-left: auto;
 			margin-top: 1em;
 			margin-bottom: 1em;

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -61,6 +61,16 @@
   #edac-tabs {
     margin: 15px 0;
 
+	.edac-tabs-and-rescan-container {
+		display: flex;
+
+		#edac-rescan-button {
+			margin-left: auto;
+			margin-top: 1em;
+			margin-bottom: 1em;
+		}
+	}
+
     .edac-tabs {
       margin-bottom: 0;
       position: relative;

--- a/src/editorApp/index.js
+++ b/src/editorApp/index.js
@@ -1,6 +1,7 @@
 /* global edac_editor_app */
 
 import { init as initCheckPage } from './checkPage';
+import { __ } from '@wordpress/i18n';
 
 window.addEventListener( 'DOMContentLoaded', () => {
 	// eslint-disable-next-line camelcase
@@ -21,5 +22,48 @@ window.addEventListener( 'DOMContentLoaded', () => {
 			initCheckPage();
 		}
 	} );
+
+	const rescanButton = document.getElementById( 'edac-rescan-button' );
+	rescanButton.addEventListener( 'click', function() {
+		setRescanButtonState( true, __( 'Rescanning...', 'accessibility-checker' ) + ' <span class="spinner is-active"></span>' );
+
+		fetch( window.edac_editor_app.edacApiUrl + '/trigger-scan/' + window.edac_editor_app.postID, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': window.edac_editor_app.restNonce,
+			},
+			body: JSON.stringify(
+				{
+					id: window.edac_editor_app.postID,
+					flush: true,
+				}
+			),
+		} ).then(
+			( response ) => {
+				if ( response.ok ) {
+					initCheckPage();
+				} else {
+					setRescanButtonState( false, __( 'Scan failed, retry', 'accessibility-checker' ) );
+				}
+			}
+		);
+	} );
+	if ( ! top.JSSCanScavedRescanEventAdded ) {
+		top.JSSCanScavedRescanEventAdded = true;
+		top.addEventListener( 'edac_js_scan_save_complete', function() {
+			setRescanButtonState();
+		} );
+	}
 } );
 
+/**
+ * Set the disabled state of the rescan button and it's contents.
+ * @param {boolean} state   The state to set the buttons disabled value to.
+ * @param {string}  message The message that the button should contain.
+ */
+const setRescanButtonState = ( state, message ) => {
+	const rescanButton = document.getElementById( 'edac-rescan-button' );
+	rescanButton.disabled = state ?? false;
+	rescanButton.innerHTML = message ?? __( 'Rescan', 'accessibility-checker' );
+};

--- a/src/editorApp/index.js
+++ b/src/editorApp/index.js
@@ -52,8 +52,10 @@ window.addEventListener( 'DOMContentLoaded', () => {
 					const clearedEvent = new Event( 'edac-cleared-issues' );
 					document.dispatchEvent( clearedEvent );
 					setClearIssuesButtonState();
+					triggerNotice( __( 'Issues cleared successfully.', 'accessibility-checker' ) );
 				} else {
-					setClearIssuesButtonState( false, __( 'Clearing failed, retry', 'accessibility-checker' ) );
+					setClearIssuesButtonState();
+					triggerNotice( __( 'Failed to clear issues.', 'accessibility-checker' ), 'error' );
 				}
 			}
 		);
@@ -75,4 +77,22 @@ const setClearIssuesButtonState = ( state, message ) => {
 	const rescanButton = document.getElementById( 'edac-clear-issues-button' );
 	rescanButton.disabled = state ?? false;
 	rescanButton.innerHTML = message ?? __( 'Clear Issues', 'accessibility-checker' );
+};
+
+/**
+ * Trigger a notice to the user.
+ *
+ * @param {string} message The message to display.
+ * @param {string} type    The type of notice to display.
+ */
+const triggerNotice = ( message, type = 'success' ) => {
+	wp.data.dispatch( 'core/notices' ).createNotice(
+		type,
+		message,
+		{
+			type: 'snackbar',
+			isDismissible: true,
+			speak: true,
+		}
+	);
 };


### PR DESCRIPTION
EDIT: this PR was repurposed to be just a 'Clear Issues' button instead of a rescan button.

~~This PR adds a rescan button in the edac widget area that will allow a user to trigger a rescan of the post's content.~~

Adds a clear issues button to the editor.

It also resolves an event-building issue resulting in duplicated iframes and ajax/rest calls happening when posts were being opened for editing/resaved.

https://github.com/user-attachments/assets/974a1745-1e0d-4039-bc36-5036448ae83a

Basecamp card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7922855194

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
