### PR TITLE
Iinline frontend highlighter fix button

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -626,15 +626,13 @@ class AccessibilityCheckerHighlight {
 					</div>
 				`;
 				// and the button that will trigger the modal.
-				content += `
-					<div class="edac-fix-settings--action-open">
-						<button role="button" class="edac-fix-settings--button--open edac-highlight-panel-description--button" aria-expanded="false" aria-controls="edac-highlight-panel-description-fix">Fix Issue</button>
-					</div>
-					`;
+				content += ` <br /><button role="button" class="edac-fix-settings--button--open edac-highlight-panel-description--button" aria-expanded="false" aria-controls="edac-highlight-panel-description-fix">Fix Issue</button>`;
+			} else {
+				content += ` <br />`;
 			}
 
 			// Get the link to the documentation
-			content += ` <br /><a class="edac-highlight-panel-description-reference" href="${ matchingObj.link }">Full Documentation</a>`;
+			content += `<a class="edac-highlight-panel-description-reference" href="${ matchingObj.link }">Full Documentation</a>`;
 
 			// Get the code button
 			content += `<button class="edac-highlight-panel-description-code-button" aria-expanded="false" aria-controls="edac-highlight-panel-description-code">Show Code</button>`;

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -428,9 +428,4 @@ body {
 
 		}
 	}
-
-	&--action-open {
-		display: inline-block;
-		width: 100%;
-	}
 }


### PR DESCRIPTION
Shifts the fix button in the inline highlighter to be inline with the other buttons in the panel.

![Screenshot from 2024-10-17 14-17-57](https://github.com/user-attachments/assets/718f9e41-3441-4e4e-bbd3-75dc1fd35bde)

Basecamp card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7922908949

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
