### PR TITLE
Handle permissions and display for fixes

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -345,7 +345,7 @@ class Ajax {
 					$html .= '<div id="edac-details-rule-records-' . $rule['slug'] . '" class="edac-details-rule-records">';
 
 					$fixes_for_item = [];
-					if ( isset( $rule['fixes'] ) ) {
+					if ( isset( $rule['fixes'] ) && current_user_can( apply_filters( 'edac_filter_settings_capability', 'manage_options' ) ) ) {
 						foreach ( $rule['fixes'] as $fix_slug ) {
 							$fixes_for_item[] = FixesManager::get_instance()->get_fix( $fix_slug );
 						}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -230,7 +230,9 @@ class FixesManager {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_fixes' ],
-				'permission_callback' => '__return_true', // need real permission.
+				'permission_callback' => function () {
+					return current_user_can( apply_filters( 'edac_filter_settings_capability', 'manage_options' ) );
+				},
 			]
 		);
 
@@ -240,7 +242,9 @@ class FixesManager {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'update_fix_settings' ],
-				'permission_callback' => '__return_true', // need real permission.
+				'permission_callback' => function () {
+					return current_user_can( apply_filters( 'edac_filter_settings_capability', 'manage_options' ) );
+				},
 			]
 		);
 	}

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -99,6 +99,7 @@ class Enqueue_Frontend {
 				[
 					'postID'         => $post_id,
 					'nonce'          => wp_create_nonce( 'ajax-nonce' ),
+					'userCanFix'     => current_user_can( apply_filters( 'edac_filter_settings_capability', 'manage_options' ) ),
 					'edacUrl'        => esc_url_raw( get_site_url() ),
 					'ajaxurl'        => admin_url( 'admin-ajax.php' ),
 					'loggedIn'       => is_user_logged_in(),

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -608,7 +608,7 @@ class AccessibilityCheckerHighlight {
 			// Get the summary of the issue
 			content += matchingObj.summary;
 
-			if ( this.fixes[ matchingObj.slug ] ) {
+			if ( this.fixes[ matchingObj.slug ] && window.edacFrontendHighlighterApp?.userCanFix ) {
 				// this is the markup to put in the modal.
 				content += `
 					<div style="display:none;">
@@ -660,7 +660,7 @@ class AccessibilityCheckerHighlight {
 			}
 
 			// show fix settings button if available
-			if ( this.fixes[ matchingObj.slug ] ) {
+			if ( this.fixes[ matchingObj.slug ] && window.edacFrontendHighlighterApp?.userCanFix ) {
 				this.fixSettingsButton = document.querySelector( '.edac-fix-settings--button--open' );
 				this.fixSettingsButton.addEventListener( 'click', ( event ) => {
 					this.showFixSettings( event );
@@ -882,5 +882,7 @@ class AccessibilityCheckerHighlight {
 
 window.addEventListener( 'DOMContentLoaded', () => {
 	new AccessibilityCheckerHighlight();
-	fixSettingsModalInit();
+	if ( window.edacFrontendHighlighterApp?.userCanFix ) {
+		fixSettingsModalInit();
+	}
 } );


### PR DESCRIPTION
This PR adds a permission check on the rest endpoints and capability checks (through `edac_filter_settings_capability`) around some points that would generate fix links and data to prevent showing them to users that can't toggle them

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
