### PR TITLE
William/7652430604/attach correct fix to missing title rule

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -234,8 +234,9 @@ class REST_Api {
 				? '// {{ ' . $violation['selector'][0] . ' }}'
 				: '';
 		}
-		if ( 'html-has-lang' === $rule_id ) {
-			// Use just the opening <html> and closing </html> tag for the affected code markup.
+
+		// Use just the opening <html> and closing </html> tag, prevents storing entire page as the affected code.
+		if ( 'html-has-lang' === $rule_id || 'missing_title' === $rule_id ) {
 			$html = preg_replace( '/^.*(<html.*?>).*(<\/html>).*$/s', '$1...$2', $html );
 
 		}

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -236,7 +236,7 @@ class REST_Api {
 		}
 
 		// Use just the opening <html> and closing </html> tag, prevents storing entire page as the affected code.
-		if ( 'html-has-lang' === $rule_id || 'missing_title' === $rule_id ) {
+		if ( 'html-has-lang' === $rule_id || 'document-title' === $rule_id ) {
 			$html = preg_replace( '/^.*(<html.*?>).*(<\/html>).*$/s', '$1...$2', $html );
 
 		}

--- a/includes/rules.php
+++ b/includes/rules.php
@@ -462,7 +462,7 @@ return [
 		'combines'  => [ 'document-title' ],
 		'viewable'  => false,
 		'fixes'     => [
-			ReadMoreAddTitleFix::get_slug(),
+			AddMissingOrEmptyPageTitleFix::get_slug(),
 		],
 	],
 	[


### PR DESCRIPTION
Attaches the correct fix to the missing_title rule so it shows the correct fields when prompted to fix in highlighter and issue detail panel.

It also strips down the stored markup to just the `<html>...</html>`element to prevent storing the entire page plus translates a string that was missed before.

Basecamp Cards:
* https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7879198801
* https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7652430604

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
