### PR TITLE
William/7949329495/allow fix action to appear in all issues page

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -681,6 +681,10 @@ window.addEventListener( 'load', function() {
 			} );
 	}
 
+	if ( this.document.querySelector( 'body.accessibility-checker_page_accessibility_checker_issues' ) ) {
+		initFixButtonEventHandlers();
+	}
+
 	edacTimestampToLocal();
 } );
 

--- a/src/common/saveFixSettingsRest.js
+++ b/src/common/saveFixSettingsRest.js
@@ -46,6 +46,7 @@ export const saveFixSettings = ( fixSettingsContainer ) => {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			'X-WP-Nonce': window.edacSettings?.nonce || window.edac_script_vars?.restNonce,
 		},
 		body: JSON.stringify( settingsToSave ),
 	} ).then(


### PR DESCRIPTION
This PR adds an additional path that will trigger admin side fix buttion init - this is so it can run without other changes on pages that it wouldn't be available on by default.

It also fixes a missing nonce header and sets it to support 2 script passed values (the 2nd is also in support of the additional pages)

Basecamp card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7949329495

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
