### PR TITLE
Handle timing issue for fix button that triggers thickbox

### DIFF
--- a/src/admin/summary/summary-tab-input-event-handlers.js
+++ b/src/admin/summary/summary-tab-input-event-handlers.js
@@ -118,10 +118,15 @@ export const initFixButtonEventHandlers = () => {
 	const changeEventListeners = [];
 	// loop through each button binding a click event
 	fixButtons.forEach( ( button ) => {
-		button.addEventListener( 'click', ( event ) => {
+		button.addEventListener( 'click', async ( event ) => {
 			const restoreFocusTo = event.target;
 
-			const fixSettings = document.getElementById( event.target.getAttribute( 'aria-controls' ) );
+			const fixSettings = await getFixSettingsElement( event.target.getAttribute( 'aria-controls' ) );
+
+			if ( ! fixSettings ) {
+				return;
+			}
+
 			fixSettings.classList.toggle( 'active' );
 
 			document.querySelector( 'body' ).classList.add( 'edac-fix-modal-present' );
@@ -174,5 +179,26 @@ export const initFixButtonEventHandlers = () => {
 			} );
 		} );
 	} );
+};
+
+/**
+ * Get the fixes container to pass into thickbox.
+ *
+ * This has a loop and retry logic as sometimes the element may not be restored
+ * in time to retrieve it.
+ *
+ * @param {string} targetId The element ID to retrieve.
+ * @return {Promise<*>} The element when found.
+ */
+const getFixSettingsElement = async ( targetId ) => {
+	let fixSettings;
+	for ( let i = 0; i < 20; i++ ) {
+		fixSettings = document.getElementById( targetId );
+		if ( fixSettings ) {
+			break;
+		}
+		await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+	}
+	return fixSettings;
 };
 


### PR DESCRIPTION
Adds some retry logic and a return that will prevent errors being thrown if the thickbox target element is not yet available or has not yet been restored when the fix button is clicked.

https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7956375078

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
