### PR TITLE
Use `.currentTarget` rather than `.target` when looking for the aria-…

### DIFF
--- a/src/admin/summary/summary-tab-input-event-handlers.js
+++ b/src/admin/summary/summary-tab-input-event-handlers.js
@@ -119,16 +119,13 @@ export const initFixButtonEventHandlers = () => {
 	// loop through each button binding a click event
 	fixButtons.forEach( ( button ) => {
 		button.addEventListener( 'click', async ( event ) => {
-			const restoreFocusTo = event.target;
-
-			const fixSettings = await getFixSettingsElement( event.target.getAttribute( 'aria-controls' ) );
-
+			const restoreFocusToElement = event.currentTarget;
+			const fixSettings = document.getElementById( restoreFocusToElement.getAttribute( 'aria-controls' ) );
 			if ( ! fixSettings ) {
 				return;
 			}
 
 			fixSettings.classList.toggle( 'active' );
-
 			document.querySelector( 'body' ).classList.add( 'edac-fix-modal-present' );
 
 			// trigger a thickbox that contains the contents of the fixSettings
@@ -175,30 +172,8 @@ export const initFixButtonEventHandlers = () => {
 					} );
 				}, 100 );
 				thickboxFocusTrap.deactivate();
-				restoreFocusTo.focus();
+				restoreFocusToElement.focus();
 			} );
 		} );
 	} );
 };
-
-/**
- * Get the fixes container to pass into thickbox.
- *
- * This has a loop and retry logic as sometimes the element may not be restored
- * in time to retrieve it.
- *
- * @param {string} targetId The element ID to retrieve.
- * @return {Promise<*>} The element when found.
- */
-const getFixSettingsElement = async ( targetId ) => {
-	let fixSettings;
-	for ( let i = 0; i < 20; i++ ) {
-		fixSettings = document.getElementById( targetId );
-		if ( fixSettings ) {
-			break;
-		}
-		await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
-	}
-	return fixSettings;
-};
-


### PR DESCRIPTION
Swap to using `event.currentTarget` rather than `event.target` for finding the element that holds the ID for modal content.

The previous attempt to resolve this assumed a different issue was the cause https://github.com/equalizedigital/accessibility-checker/pull/792. The code from that PR is mostly reverted here.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
