### PR TITLE
Rework tabindex fix to handle all elements with tabindex

### DIFF
--- a/src/frontendFixes/Fixes/tabindexFix.js
+++ b/src/frontendFixes/Fixes/tabindexFix.js
@@ -7,27 +7,32 @@ const TabindexFix = () => {
 		return;
 	}
 
-	// Remove tabindex from elements that are natively focusable
-	const focusable = document.querySelectorAll( 'input, a, select, textarea, button' );
-	focusable.forEach( ( element ) => {
+	// Get all elements with a tabindex
+	const elementsWithTabIndex = document.querySelectorAll( '[tabindex]' );
+	elementsWithTabIndex.forEach( ( element ) => {
 		// Skip anchor tags without an href attribute or those with role="button" as they are not natively focusable
 		if ( element.tagName === 'A' && ( ! element.hasAttribute( 'href' ) || element.getAttribute( 'role' ) === 'button' ) ) {
 			return;
 		}
 
-		// Remove the tabindex if present and is not -1.
-		if ( element.hasAttribute( 'tabindex' ) && element.getAttribute( 'tabindex' ) !== '-1' ) {
-			element.removeAttribute( 'tabindex' );
+		// If the tabindex is -1, skip.
+		if ( element.getAttribute( 'tabindex' ) === '-1' ) {
+			return;
+		}
+
+		// If the tabindex is positive then set it to 0.
+		if ( element.getAttribute( 'tabindex' ) > 0 ) {
+			element.setAttribute( 'tabindex', '0' );
+			element.classList.add( 'edac-focusable-modified' );
 		}
 	} );
 
-	// Add tabindex to elements that appear active but are not natively focusable.
-	// Select all <div> elements with a role of "button" or <a> elements with role="button" without href or tabindex
+	// Select all <div> elements with a role of "button" or <a> elements with role="button", without href or tabindex
 	const elementsToFocus = document.querySelectorAll(
 		'div[role="button"]:not([tabindex]), a[role="button"]:not([tabindex]):not([href])'
 	);
 
-	// Loop through each element and add tabindex="0" to make it focusable
+	// Loop through each element and add tabindex="0" to make it focusable.
 	elementsToFocus.forEach( ( element ) => {
 		// Don't add tabindex 0 to elements that alaredy have -1.
 		if ( element.hasAttribute( 'tabindex' ) && element.getAttribute( 'tabindex' ) === '-1' ) {


### PR DESCRIPTION
This looks at every element, sets positive tabindex to `0`, leaves `-1` and adds `0` to elements with roles that are changed to buttons.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
