### PR TITLE
Tweaks and changes to prepair for next release (1.16.0)

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -357,6 +357,7 @@ class Ajax {
 						<div style="display:none">
 							<div id="<?php echo esc_attr( $controls_id ); ?>" class="edac-details-fix-settings fix-settings--container">
 								<div class="setting-row fix-settings--container" data-fix="<?php echo esc_attr( $controls_id ); ?>">
+									<p class="modal-opening-message"><?php esc_html_e( 'These settings enable global fixes across your entire site. Pages may need to be resaved or a full site scan run to see fixes reflected in reports.', 'accessibility-checker' ); ?></p>
 									<div class="edac-fix-settings">
 										<?php
 										foreach ( $fixes_for_item as $index => $fix ) :

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -357,7 +357,13 @@ class Ajax {
 						<div style="display:none">
 							<div id="<?php echo esc_attr( $controls_id ); ?>" class="edac-details-fix-settings fix-settings--container">
 								<div class="setting-row fix-settings--container" data-fix="<?php echo esc_attr( $controls_id ); ?>">
-									<p class="modal-opening-message"><?php esc_html_e( 'These settings enable global fixes across your entire site. Pages may need to be resaved or a full site scan run to see fixes reflected in reports.', 'accessibility-checker' ); ?></p>
+									<?php
+									printf(
+										'<p class="modal-opening-message">%s <span class="hide-in-editor">%s</span></p>',
+										esc_html__( 'These settings enable global fixes across your entire site.', 'accessibility-checker' ),
+										esc_html__( 'Pages may need to be resaved or a full site scan run to see fixes reflected in reports.', 'accessibility-checker' )
+									)
+									?>
 									<div class="edac-fix-settings">
 										<?php
 										foreach ( $fixes_for_item as $index => $fix ) :

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -362,15 +362,21 @@ class Ajax {
 										foreach ( $fixes_for_item as $index => $fix ) :
 											?>
 											<div class="edac-fix-settings--fields">
-												<div class="title">
-													<h2 class="edac-fix-settings--title"><?php echo esc_html( $fix->get_nicename() ); ?></h2>
-												</div>
+												<fieldset>
+													<div class="title">
+														<legend>
+															<h2 class="edac-fix-settings--title"><?php echo esc_html( $fix->get_nicename() ); ?></h2>
+														</legend>
+													</div>
+													<?php
+													foreach ( $fix->get_fields_array() as $name => $field ) {
+														$field['name']     = $name;
+														$field['location'] = 'details-panel';
+														FixesPage::{$field['type']}( $field );
+													}
+													?>
+												</fieldset>
 												<?php
-												foreach ( $fix->get_fields_array() as $name => $field ) {
-													$field['name']     = $name;
-													$field['location'] = 'details-panel';
-													FixesPage::{$field['type']}( $field );
-												}
 												// Output the save button only in the last group.
 												if ( count( $fixes_for_item ) === $index + 1 ) :
 													?>

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -142,13 +142,23 @@ class Frontend_Highlight {
 		// if we have fixes then create fields for each of the groups.
 		if ( ! empty( $fixes ) ) {
 			foreach ( $fixes as $key => $fix ) {
-				$fix_fields_markup = '';
+				// count the number of fields in the fix.
+				$fields_count = count( $fix );
+				$itteration   = 0;
 				foreach ( $fix as $index => $field ) {
+					++$itteration;
 					$field_type = $field['type'] ?? 'checkbox';
 					ob_start();
 					if ( isset( $field['group_name'] ) ) {
+						// if this is anything other than the first field in the group then close the fieldset.
+						if ( 1 !== $itteration ) {
+							?>
+							</fieldset>
+							<?php
+						}
 						?>
-						<h3 class="title"><?php echo esc_html( $field['group_name'] ); ?></h3>
+						<fieldset>
+						<legend><h3 class="title"><?php echo esc_html( $field['group_name'] ); ?></h3></legend>
 						<?php
 					}
 					FixesPage::{$field_type}(
@@ -160,9 +170,14 @@ class Frontend_Highlight {
 							$field
 						)
 					);
+					if ( $fields_count === $itteration ) {
+						?>
+						</fieldset>
+						<?php
+					}
 					$fix_fields_markup .= ob_get_clean();
 				}
-				$fixes[ $key ]['fields'] = $fix_fields_markup;
+				$fixes[ $key ]['fields'] = $fix_fields_markup . PHP_EOL . '</fieldset>';
 			}
 		}
 

--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -31,7 +31,7 @@ class AddFileSizeAndTypeToLinkedFilesFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add Size & Type To File Links', 'accessibility-checker' );
+		return __( 'Add Context to Linked Files', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -80,7 +80,7 @@ class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
 			'label'       => esc_html__( 'Unlabelled Form Fields', 'accessibility-checker' ),
 			'type'        => 'checkbox',
 			'labelledby'  => $this->get_slug(),
-			'description' => esc_html__( 'Attempts to add labels to form fields that are missing them.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Add labels to unlabelled form fields if field purpose can be determined.', 'accessibility-checker' ),
 			'section'     => $this->get_slug(),
 			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
 			'group_name'  => $this->get_nicename(),

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -85,6 +85,7 @@ class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
 			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
 			'group_name'  => $this->get_nicename(),
 			'fix_slug'    => $this->get_slug(),
+			'help_id'     => 8497,
 		];
 
 		return $fields;

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -31,7 +31,7 @@ class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add Labels to Unlabelled Form Fields', 'accessibility-checker' );
+		return __( 'Label Form Fields', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
+++ b/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
@@ -31,7 +31,7 @@ class AddMissingOrEmptyPageTitleFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add Missing or Empty Page Titles', 'accessibility-checker' );
+		return __( 'Set Page HTML Titles', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
+++ b/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
@@ -31,7 +31,7 @@ class CommentSearchLabelFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add Labels to Comment and Search Forms', 'accessibility-checker' );
+		return __( 'Label Comment/Search Fields', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -30,7 +30,7 @@ class HTMLLangAndDirFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add lang & dir Attributes', 'accessibility-checker' );
+		return __( 'Set Page Language', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -64,7 +64,7 @@ class HTMLLangAndDirFix implements FixInterface {
 	public function get_fields_array( array $fields = [] ): array {
 		$fields['edac_fix_add_lang_and_dir'] = [
 			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Add "lang" & "dir" Attribributes', 'accessibility-checker' ),
+			'label'       => esc_html__( 'Add "lang" & "dir" Attributes', 'accessibility-checker' ),
 			'labelledby'  => 'add_read_more_title',
 			// translators: %1$s: a attribute name wrapped in a <code> tag. %2$s: dir attribute %3$s: html element.
 			'description' => sprintf( __( 'Adds the site language (%1$s) and text direction (%2$s) attributes to the %3$s element.', 'accessibility-checker' ), '<code>lang</code>', '<code>dir</code>', '<code>&lt;html&gt;</code>' ),

--- a/includes/classes/Fixes/Fix/LinkUnderline.php
+++ b/includes/classes/Fixes/Fix/LinkUnderline.php
@@ -30,7 +30,7 @@ class LinkUnderline implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add Underlines to all non-nav Links', 'accessibility-checker' );
+		return __( 'Underline Links', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -31,7 +31,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add "Read" Link with Post Title', 'accessibility-checker' );
+		return __( 'Add Title to Read More Links', 'accessibility-checker' );
 	}
 
 	/**

--- a/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
+++ b/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
@@ -30,7 +30,7 @@ class RemoveTitleIfPrefferedAccessibleNameFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Prefer Accessible Label Attribute', 'accessibility-checker' );
+		return __( 'Remove Unnecessary Title Attributes', 'accessibility-checker' );
 	}
 
 	/**

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -187,11 +187,13 @@
 		position: absolute;
 		top: 5px;
 		right: 5px;
+		color: $color-blue-dark;
 
 		.dashicons, .dashicons::before {
 			vertical-align: middle;
 			display: block;
 			margin: auto;
+			color: $color-blue-dark !important;
 		}
 	}
 }

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -37,8 +37,12 @@
 		}
 
 		input[type="checkbox"] {
+			border: 1px solid #ccc;
+			border-radius: 5px;
+			margin: 0 .5rem 0 0;
+			padding: 0 !important;
 			width: auto;
-			margin-right: 0.5rem;
+
 			&:before {
 				content: none;
 			}
@@ -194,6 +198,12 @@
 			display: block;
 			margin: auto;
 			color: $color-blue-dark !important;
+		}
+
+		&:hover,
+		&:focus {
+			background-color: $color-yellow;
+			color: $color-blue-dark;
 		}
 	}
 }

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -69,6 +69,11 @@
 			display: flex !important;
 		}
 
+		.modal-opening-message {
+			padding: 0;
+			margin-bottom: 0;
+		}
+
 	}
 
 	&--fields {

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -269,3 +269,9 @@ body.edac-fixes-modal--open {
 .hide-fixes-source {
 	display: none;
 }
+
+body.block-editor-page {
+	.hide-in-editor {
+		display: none;
+	}
+}

--- a/src/common/saveFixSettingsRest.js
+++ b/src/common/saveFixSettingsRest.js
@@ -62,7 +62,7 @@ export const saveFixSettings = ( fixSettingsContainer ) => {
 				if ( liveRegion ) {
 					if ( window?.edacFrontendHighlighterApp?.editorLink?.length ) {
 						liveRegion.innerHTML = sprintf(
-							__( 'Settings saved successfully. You must %svisit the editor%s to rescan and remove fixed issues from Accessibility Checker reports.', 'accessibility-checker' ),
+							__( 'Settings saved successfully. You must %svisit the editor%s and save the post to rescan and remove fixed issues from Accessibility Checker reports.', 'accessibility-checker' ),
 							`<a href="${ window.edacFrontendHighlighterApp.editorLink }">`,
 							'</a>'
 						);

--- a/src/common/saveFixSettingsRest.js
+++ b/src/common/saveFixSettingsRest.js
@@ -62,7 +62,7 @@ export const saveFixSettings = ( fixSettingsContainer ) => {
 				if ( liveRegion ) {
 					if ( window?.edacFrontendHighlighterApp?.editorLink?.length ) {
 						liveRegion.innerHTML = sprintf(
-							__( 'Settings saved successfully. %sVisit the editor%s to scan the changes.', 'accessibility-checker' ),
+							__( 'Settings saved successfully. You must %svisit the editor%s to rescan and remove fixed issues from Accessibility Checker reports.', 'accessibility-checker' ),
 							`<a href="${ window.edacFrontendHighlighterApp.editorLink }">`,
 							'</a>'
 						);

--- a/src/frontendFixes/Fixes/tabindexFix.js
+++ b/src/frontendFixes/Fixes/tabindexFix.js
@@ -12,6 +12,7 @@ const TabindexFix = () => {
 	elementsWithTabIndex.forEach( ( element ) => {
 		// Skip anchor tags without an href attribute or those with role="button" as they are not natively focusable
 		if ( element.tagName === 'A' && ( ! element.hasAttribute( 'href' ) || element.getAttribute( 'role' ) === 'button' ) ) {
+			element.setAttribute( 'tabindex', '0' );
 			return;
 		}
 

--- a/src/frontendHighlighterApp/fixesModal.js
+++ b/src/frontendHighlighterApp/fixesModal.js
@@ -150,7 +150,8 @@ export const fillFixesModal = ( content = '', fieldsElement = '' ) => {
 	const modal = document.getElementById( 'edac-fixes-modal' );
 	const modalTitle = modal.querySelector( '#edac-fixes-modal-title' );
 	const modalBody = modal.querySelector( '.edac-fixes-modal__body' );
-	modalTitle.innerText = __( 'Fix settings: ', 'accessibility-checker' ) + groupName;
+
+	modalTitle.innerText = groupName;
 	modalBody.innerHTML = content;
 	modalBody.appendChild( fieldsWrapper );
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -626,7 +626,14 @@ class AccessibilityCheckerHighlight {
 					</div>
 				`;
 				// and the button that will trigger the modal.
-				content += ` <br /><button role="button" class="edac-fix-settings--button--open edac-highlight-panel-description--button" aria-expanded="false" aria-controls="edac-highlight-panel-description-fix">Fix Issue</button>`;
+				content += ` <br />
+ 					<button role="button"
+ 						class="edac-fix-settings--button--open edac-highlight-panel-description--button"
+ 						aria-haspopup="true"
+ 						aria-expanded="false"
+ 						aria-controls="edac-highlight-panel-description-fix"
+ 						aria-label="Open fix settings modal for ${ matchingObj.rule_title } issue with ID ${ matchingObj.id }"
+ 						>Fix Issue</button>`;
 			} else {
 				content += ` <br />`;
 			}

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -813,9 +813,12 @@ class AccessibilityCheckerHighlight {
 		// renive the fixSettingsContainer from the DOM.
 		fixSettingsContainer.remove();
 
-		fillFixesModal( '', fixSettingsContainer );
+		fillFixesModal(
+			`<p class="modal-opening-message">${ __( 'These settings enable global fixes across your entire site. Pages may need to be resaved or a full site scan run to see fixes reflected in reports.', 'accessibility-checker' ) }</p>`,
+			fixSettingsContainer
+		);
 
-		// puse the focus trap.
+		// pause the highlighter panel focus trap.
 		this.panelDescriptionFocusTrap.pause();
 		openFixesModal( event.target );
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -632,7 +632,7 @@ class AccessibilityCheckerHighlight {
  						aria-haspopup="true"
  						aria-expanded="false"
  						aria-controls="edac-highlight-panel-description-fix"
- 						aria-label="Open fix settings modal for ${ matchingObj.rule_title } issue with ID ${ matchingObj.id }"
+ 						aria-label="Fix issue: ${ matchingObj.rule_title }">
  						>Fix Issue</button>`;
 			} else {
 				content += ` <br />`;

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -632,8 +632,7 @@ class AccessibilityCheckerHighlight {
  						aria-haspopup="true"
  						aria-expanded="false"
  						aria-controls="edac-highlight-panel-description-fix"
- 						aria-label="Fix issue: ${ matchingObj.rule_title }">
- 						>Fix Issue</button>`;
+						aria-label="Fix issue: ${ this.fixes[ matchingObj.slug ][ Object.keys( this.fixes[ matchingObj.slug ] )[ 0 ] ].group_name }"> 						Fix Issue</button>`;
 			} else {
 				content += ` <br />`;
 			}

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -479,6 +479,15 @@ body {
 
 			}
 		}
+
+		input[type="checkbox"] {
+			&:before {
+				content: none;
+			}
+			&:checked:before {
+				content: none;
+			}
+		}
 	}
 
 	*:focus {

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -408,7 +408,7 @@ body {
 
 .edac-fixes-modal {
 	display: none;
-
+	width:650px;
 	-webkit-font-smoothing: antialiased !important;
 	-moz-osx-font-smoothing: grayscale !important;
 	background-color: #fff !important;
@@ -425,7 +425,7 @@ body {
 	text-align: left !important;
 	letter-spacing: initial !important;
 
-	@media screen and (max-width: $small-screen-width) {
+	@media screen and (max-width: $medium-screen-width) {
 		width: 100% !important;
 		max-width: calc(100% - 30px) !important;
 		padding: 20px !important;
@@ -475,8 +475,6 @@ body {
 
 			&--button--save {
 				@extend .edac-highlight-panel-description--button;
-
-
 			}
 		}
 

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -488,6 +488,10 @@ body {
 		}
 	}
 
+	.modal-opening-message {
+		margin-bottom: 0.5em !important;
+	}
+
 	*:focus {
 		outline: revert;
 		outline-offset: 2px;


### PR DESCRIPTION
This PR includes various tweaks and fixes to get ready for next release.

* Add some additional styles to frontend fixes modal to prevent more leaking from theme.
* Update the save success message to be clear about what visiting editor does.
* Set a width for modal to reduce layout shift.
* Add better label to fix issue button for frontend modal and add aria-haspopup
* Set even fake buttons and links to `0` tabindex when operating on them
* Add a help id to label fix
* Add fieldset and legend to modals
* Add an opening message to fix modals
* Update the nice names of several fixes

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
