### PR TITLE
updated: fixes setting description to not be plural

### DIFF
--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -66,7 +66,7 @@ class AddFileSizeAndTypeToLinkedFilesFix implements FixInterface {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Add File Size & Type To Links', 'accessibility-checker' ),
 			'labelledby'  => 'add_file_size_and_type_to_linked_files',
-			'description' => esc_html__( 'Adds the file size and type to linked files that may trigger a download.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Add the file size and type to linked files that may trigger a download.', 'accessibility-checker' ),
 			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8492,

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -110,7 +110,7 @@ class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
 			<?php
 				printf(
 				// translators: %1$s: a CSS class name wrapped in a <code> tag.
-					esc_html__( 'Attempts to add labels to form fields that are missing them. Note: You may need to add custom styles targeting the %1$s class if adding labels affects your form layouts.', 'accessibility-checker' ),
+					esc_html__( 'Attempt to add labels to form fields that are missing them. Note: You may need to add custom styles targeting the %1$s class if adding labels affects your form layouts.', 'accessibility-checker' ),
 					'<code>.edac-generated-label</code>'
 				);
 			?>

--- a/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
+++ b/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
@@ -68,7 +68,7 @@ class AddMissingOrEmptyPageTitleFix implements FixInterface {
 			'label'       => esc_html__( 'Add Missing Page Title', 'accessibility-checker' ),
 			'labelledby'  => 'add_missing_or_empty_page_title',
 			// translators: %1$s: a code tag with a title tag.
-			'description' => sprintf( __( 'Adds a %1$s tag to the page if it\'s missing or empty.', 'accessibility-checker' ), '<code>&lt;title&gt;</code>' ),
+			'description' => sprintf( __( 'Add a %1$s tag to the page if it\'s missing or empty.', 'accessibility-checker' ), '<code>&lt;title&gt;</code>' ),
 			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),

--- a/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
+++ b/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
@@ -69,7 +69,7 @@ class BlockPDFUploadsFix implements FixInterface {
 			'type'        => 'checkbox',
 			'labelledby'  => 'block_pdf_uploads',
 			// translators: %1$s: a code tag with the capability name.
-			'description' => sprintf( __( 'Restricts PDF uploads for users without the %1$s capability (allowed for admins by default).', 'accessibility-checker' ), '<code>edac_upload_pdf</code>' ),
+			'description' => sprintf( __( 'Restrict PDF uploads for users without the %1$s capability (allowed for admins by default).', 'accessibility-checker' ), '<code>edac_upload_pdf</code>' ),
 			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8486,

--- a/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
+++ b/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
@@ -81,7 +81,7 @@ class CommentSearchLabelFix implements FixInterface {
 			'label'       => esc_html__( 'Comment Form', 'accessibility-checker' ),
 			'type'        => 'checkbox',
 			'labelledby'  => 'add_comment_label',
-			'description' => esc_html__( 'Adds missing labels to the WordPress comment form.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Add missing labels to the WordPress comment form.', 'accessibility-checker' ),
 			'section'     => 'comment_search_label',
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),
@@ -91,7 +91,7 @@ class CommentSearchLabelFix implements FixInterface {
 			'label'       => esc_html__( 'Search Form', 'accessibility-checker' ),
 			'type'        => 'checkbox',
 			'labelledby'  => 'add_search_label',
-			'description' => esc_html__( 'Adds a missing label to the WordPress search form.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Add a missing label to the WordPress search form.', 'accessibility-checker' ),
 			'section'     => 'comment_search_label',
 			'fix_slug'    => $this->get_slug(),
 		];

--- a/includes/classes/Fixes/Fix/FocusOutlineFix.php
+++ b/includes/classes/Fixes/Fix/FocusOutlineFix.php
@@ -54,7 +54,7 @@ class FocusOutlineFix implements FixInterface {
 			function ( $sections ) {
 				$sections['focus_outline'] = [
 					'title'       => esc_html__( 'Focus Outline', 'accessibility-checker' ),
-					'description' => esc_html__( 'Adds an outline to elements when they receive keyboard focus.', 'accessibility-checker' ),
+					'description' => esc_html__( 'Add an outline to elements when they receive keyboard focus.', 'accessibility-checker' ),
 					'callback'    => [ $this, 'focus_outline_section_callback' ],
 				];
 
@@ -80,7 +80,7 @@ class FocusOutlineFix implements FixInterface {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Focus Outline', 'accessibility-checker' ),
 			'labelledby'  => 'fix_focus_outline',
-			'description' => esc_html__( 'Adds an outline to elements when they receive keyboard focus.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Add an outline to elements when they receive keyboard focus.', 'accessibility-checker' ),
 			'section'     => 'focus_outline',
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8495,

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -67,7 +67,7 @@ class HTMLLangAndDirFix implements FixInterface {
 			'label'       => esc_html__( 'Add "lang" & "dir" Attributes', 'accessibility-checker' ),
 			'labelledby'  => 'add_read_more_title',
 			// translators: %1$s: a attribute name wrapped in a <code> tag. %2$s: dir attribute %3$s: html element.
-			'description' => sprintf( __( 'Adds the site language (%1$s) and text direction (%2$s) attributes to the %3$s element.', 'accessibility-checker' ), '<code>lang</code>', '<code>dir</code>', '<code>&lt;html&gt;</code>' ),
+			'description' => sprintf( __( 'Add the site language (%1$s) and text direction (%2$s) attributes to the %3$s element.', 'accessibility-checker' ), '<code>lang</code>', '<code>dir</code>', '<code>&lt;html&gt;</code>' ),
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),
 			'help_id'     => 8487,

--- a/includes/classes/Fixes/Fix/LinkUnderline.php
+++ b/includes/classes/Fixes/Fix/LinkUnderline.php
@@ -66,7 +66,7 @@ class LinkUnderline implements FixInterface {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Force Link Underline', 'accessibility-checker' ),
 			'labelledby'  => 'force_link_underline',
-			'description' => esc_html__( 'Ensures that non-navigation links are underlined.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Ensure that non-navigation links are underlined.', 'accessibility-checker' ),
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8489,
 		];

--- a/includes/classes/Fixes/Fix/MetaViewportScalableFix.php
+++ b/includes/classes/Fixes/Fix/MetaViewportScalableFix.php
@@ -81,7 +81,7 @@ class MetaViewportScalableFix implements FixInterface {
 			'label'       => esc_html__( 'Scalable Viewport Tag', 'accessibility-checker' ),
 			'type'        => 'checkbox',
 			'labelledby'  => '',
-			'description' => esc_html__( 'Ensures the viewport tag allows for scaling, enhancing accessibility on mobile devices.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Ensure the viewport tag allows for scaling, enhancing accessibility on mobile devices.', 'accessibility-checker' ),
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8488,
 		];

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -81,7 +81,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Add Post Title To "Read More"', 'accessibility-checker' ),
 			'labelledby'  => 'add_read_more_title',
-			'description' => esc_html__( 'Adds the post title to "Read More" links in post lists when your theme outputs those links.', 'accessibility-checker' ),
+			'description' => esc_html__( 'Add the post title to "Read More" links in post lists when your theme outputs those links.', 'accessibility-checker' ),
 			'section'     => 'read_more_links',
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),

--- a/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
+++ b/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
@@ -67,7 +67,7 @@ class RemoveTitleIfPrefferedAccessibleNameFix implements FixInterface {
 			'label'       => esc_html__( 'Remove Title Attributes', 'accessibility-checker' ),
 			'labelledby'  => 'accessible_name',
 			// translators: %1$s: a attribute name wrapped in a <code> tag.
-			'description' => sprintf( __( 'Removes %1$s attributes from elements that already have a preferred accessible name.', 'accessibility-checker' ), '<code>title</code>' ),
+			'description' => sprintf( __( 'Remove %1$s attributes from elements that already have a preferred accessible name.', 'accessibility-checker' ), '<code>title</code>' ),
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8494,
 		];

--- a/includes/classes/Fixes/Fix/TabindexFix.php
+++ b/includes/classes/Fixes/Fix/TabindexFix.php
@@ -67,7 +67,7 @@ class TabindexFix implements FixInterface {
 			'label'       => esc_html__( 'Remove Tab Index', 'accessibility-checker' ),
 			'labelledby'  => 'remove_tabindex',
 			// translators: %1$s: a attribute name wrapped in a <code> tag.
-			'description' => sprintf( __( 'Removes the %1$s attribute from focusable elements.', 'accessibility-checker' ), '<code>tabindex</code>' ),
+			'description' => sprintf( __( 'Remove the %1$s attribute from focusable elements.', 'accessibility-checker' ), '<code>tabindex</code>' ),
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),
 			'help_id'     => 8496,


### PR DESCRIPTION
This PR updated fix setting descriptions to not be plural.

Fixes: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7968004100