### PR TITLE
Add help ID to fields for comment and search form labels fix

### DIFF
--- a/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
+++ b/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
@@ -85,6 +85,7 @@ class CommentSearchLabelFix implements FixInterface {
 			'section'     => 'comment_search_label',
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),
+			'help_id'     => 8497,
 		];
 
 		$fields['edac_fix_search_label'] = [
@@ -94,6 +95,7 @@ class CommentSearchLabelFix implements FixInterface {
 			'description' => esc_html__( 'Adds a missing label to the WordPress search form.', 'accessibility-checker' ),
 			'section'     => 'comment_search_label',
 			'fix_slug'    => $this->get_slug(),
+			'help_id'     => 8497,
 		];
 
 		return $fields;


### PR DESCRIPTION
This PR adds help ids to some fields that were missing them

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
