### PR TITLE
Remove the empty form label rule definition again

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.16.0
+ * Version:           1.16.1
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.16.0' );
+	define( 'EDAC_VERSION', '1.16.1' );
 }
 
 // Current database version.

--- a/includes/rules.php
+++ b/includes/rules.php
@@ -270,23 +270,6 @@ return [
 		),
 	],
 	[
-		'title'     => esc_html__( 'Empty Form Label', 'accessibility-checker' ),
-		'info_url'  => 'https://a11ychecker.com/help4109',
-		'slug'      => 'empty_form_label',
-		'rule_type' => 'error',
-		'summary'   => sprintf(
-			// translators: %s is <code>&lt;label&gt;</code>.
-			esc_html__( 'An Empty Form Label error is triggered when a %s tag is present in your form and associated with an input (form field), but does not contain any text. To fix empty form label errors, you will need to determine how the field and form were created and then add text to the label for the field that is currently blank.', 'accessibility-checker' ),
-			'<code>&lt;label&gt;</code>'
-		),
-		'ruleset'   => 'js',
-		'combines'  => [ 'label' ],
-		'fixes'     => [
-			AddLabelToUnlabelledFormFieldsFix::get_slug(),
-			CommentSearchLabelFix::get_slug(),
-		],
-	],
-	[
 		'title'     => esc_html__( 'Missing Form Label', 'accessibility-checker' ),
 		'info_url'  => 'https://a11ychecker.com/help1949',
 		'slug'      => 'missing_form_label',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-checker",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.",
   "author": "Equalize Digital",
   "license": "GPL-2.0+",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility
 Requires at least: 6.2
 Tested up to: 6.6.7
-Stable tag: 1.16.0
+Stable tag: 1.16.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -171,6 +171,9 @@ No, Accessibility Checker runs completely on your server and does not require yo
 
 == Changelog ==
 
+= 1.16.1 =
+* Fix: Remove redundant empty_form_label rule definition.
+
 = 1.16.0 =
 * New: Introduced a system to handle automated fixes for issues that the scanner would discover.
 * New: Fix to remove or update bad tabindex values on elements.
@@ -192,7 +195,7 @@ No, Accessibility Checker runs completely on your server and does not require yo
 * Fix: Improve or add better aria-labels in several places.
 * Fix: Don't flag empty paragraphs if they have aria-hidden.
 
-= 1.15.3
+= 1.15.3 =
 * Enhancement: Detect missing labels on more elements.
 * Enhancement: Detect slick slider that gets initialized after the page loads.
 


### PR DESCRIPTION
This PR removes a rule definition that was inteded to be removed but got restored during merge resolution here: https://github.com/equalizedigital/accessibility-checker/commit/0b6f3508eac7163f37e4b458730dbe1c5cdd9fca#diff-40652b9b45019a70bc2344f1b523a3220a53ef38d2d326f6821588666a1d2e7a

Basecamp card: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/7980492938