### PR TITLE
Check the label and labelled-by items before the text content for ambiguous_link_text

### DIFF
--- a/src/pageScanner/checks/has-ambiguous-text.js
+++ b/src/pageScanner/checks/has-ambiguous-text.js
@@ -33,11 +33,6 @@ const checkAmbiguousPhrase = ( text ) => {
 export default {
 	id: 'has_ambiguous_text',
 	evaluate: ( node ) => {
-		const textContent = node.textContent;
-		if ( checkAmbiguousPhrase( textContent ) ) {
-			return true;
-		}
-
 		if ( node.hasAttribute( 'aria-label' ) ) {
 			const ariaLabel = node.getAttribute( 'aria-label' );
 			return checkAmbiguousPhrase( ariaLabel );
@@ -47,6 +42,10 @@ export default {
 			const label = node.getAttribute( 'aria-labelledby' );
 			const labelText = document.getElementById( label )?.textContent;
 			return checkAmbiguousPhrase( labelText );
+		}
+
+		if ( node.textContent && node.textContent !== '' ) {
+			return checkAmbiguousPhrase( node.textContent );
 		}
 
 		const images = node.querySelectorAll( 'img' );


### PR DESCRIPTION
This rule was setup to check the link text first as it is the easiest and fasted item to check however it meant that labels were not being checked if the links own text content was ambiguous.

This PR changes the order to look in the label, the labelled-by and then the text of the node. It is correct to use labels to disambiguate link text so the former order was incorrect.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
