### PR TITLE
Restore the correct nicename for the label form fields fix

### DIFF
--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -31,7 +31,7 @@ class AddLabelToUnlabelledFormFieldsFix implements FixInterface {
 	 * @return string
 	 */
 	public static function get_nicename(): string {
-		return __( 'Add Size & Type To File Links', 'accessibility-checker' );
+		return __( 'Add Labels to Unlabelled Form Fields', 'accessibility-checker' );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes an issue where a nicename for one fix was incorrectly set to a different fixes name.

We can point this to the main branch to do a hotfix on Monday but it is probably best to do a normal release and get other small things out alongside it.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
