### PR TITLE
Add fixes settings to site health

### DIFF
--- a/admin/site-health/class-free.php
+++ b/admin/site-health/class-free.php
@@ -8,6 +8,8 @@
 
 namespace EDAC\Admin\SiteHealth;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
+
 /**
  * Loads free information into Site Health
  *
@@ -28,6 +30,18 @@ class Free {
 	 * @return array
 	 */
 	public function get() {
+		// Get only the non-pro fixes.
+		$fixes = array_filter(
+			FixesManager::get_instance()->get_fixes_settings(),
+			function ( $fix ) {
+				return ! $fix['is_pro'];
+			}
+		);
+		// remove the is_pro flag, this isn't needed in the output.
+		foreach ( $fixes as $key => $fix ) {
+			unset( $fixes[ $key ]['is_pro'] );
+		}
+
 		return [
 			'label'  => __( 'Accessibility Checker &mdash; Free', 'accessibility-checker' ),
 			'fields' => [
@@ -86,6 +100,10 @@ class Free {
 				'db_table_count'          => [
 					'label' => 'DB Table Count',
 					'value' => absint( edac_database_table_count( 'accessibility_checker' ) ),
+				],
+				'fixes'                   => [
+					'label' => 'Fixes',
+					'value' => esc_html( wp_json_encode( $fixes ) ),
 				],
 			],
 		];

--- a/admin/site-health/class-pro.php
+++ b/admin/site-health/class-pro.php
@@ -8,6 +8,8 @@
 
 namespace EDAC\Admin\SiteHealth;
 
+use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
+
 /**
  * Loads pro information into Site Health
  *
@@ -28,6 +30,19 @@ class Pro {
 	 * @return array
 	 */
 	public function get() {
+
+		// Get only the pro fixes.
+		$fixes = array_filter(
+			FixesManager::get_instance()->get_fixes_settings(),
+			function ( $fix ) {
+				return $fix['is_pro'];
+			}
+		);
+		// remove the is_pro flag, this isn't needed in the output.
+		foreach ( $fixes as $key => $fix ) {
+			unset( $fixes[ $key ]['is_pro'] );
+		}
+
 		return [
 			'label'  => __( 'Accessibility Checker &mdash; Pro', 'accessibility-checker' ),
 			'fields' => [
@@ -70,6 +85,10 @@ class Pro {
 				'ignores_db_table_count' => [
 					'label' => 'Ignores DB Table Count',
 					'value' => absint( edac_database_table_count( 'accessibility_checker_global_ignores' ) ),
+				],
+				'fixes'                  => [
+					'label' => 'Fixes',
+					'value' => esc_html( wp_json_encode( $fixes ) ),
 				],
 			],
 		];

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -159,6 +159,30 @@ class FixesManager {
 	}
 
 	/**
+	 * Get the fixes settings.
+	 *
+	 * Returns an array of all the fix settings and their values along with a pro or not flag.
+	 *
+	 * @return array
+	 */
+	public function get_fixes_settings() {
+		$fixes_array = [];
+		foreach ( $this->fixes as $fix ) {
+
+			$fields = [];
+			foreach ( $fix->get_fields_array() as $field_slug => $field ) {
+				$fields[ $field_slug ] = get_option( $field_slug, $field['default'] ?? 0 );
+			}
+
+			$fixes_array[ $fix->get_slug() ] = [
+				'fields' => $fields,
+				'is_pro' => isset( $fix->is_pro ) ? $fix->is_pro : false,
+			];
+		}
+		return $fixes_array;
+	}
+
+	/**
 	 * Register the fixes.
 	 */
 	public function register_fixes() {

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -174,7 +174,7 @@ class FixesManager {
 				$fields[ $field_slug ] = get_option( $field_slug, $field['default'] ?? 0 );
 			}
 
-			$fixes_array[ $fix->get_slug() ] = [
+			$fixes_array[ $fix::get_slug() ] = [
 				'fields' => $fields,
 				'is_pro' => isset( $fix->is_pro ) ? $fix->is_pro : false,
 			];

--- a/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
+++ b/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Test class for FixesManager.
+ *
+ * @package accessibility-checker
+ */
+
+use PHPUnit\Framework\TestCase;
+use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Unit tests for the FixesManager class.
+ */
+class FixesManagerTest extends TestCase {
+
+	/**
+	 * Setup the test environment by resetting the instance before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Reset the instance before each test.
+		$reflection = new ReflectionClass( FixesManager::class );
+		$instance   = $reflection->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+	}
+
+	/**
+	 * Test that the instance retuns an empty array when no fixes are registered.
+	 *
+	 * @return void
+	 */
+	public function test_get_fixes_settings_returns_empty_array_when_no_fixes() {
+		$fixes_manager = FixesManager::get_instance();
+		$this->assertEmpty( $fixes_manager->get_fixes_settings() );
+	}
+
+	/**
+	 * Test that the instance returns the correct structure when fixes are registered.
+	 *
+	 * @return void
+	 */
+	public function test_get_fixes_settings_returns_correct_structure() {
+		$fix_mock = $this->createMock( FixInterface::class );
+		$fix_mock->method( 'get_fields_array' )->willReturn(
+			[
+				'field1' => [ 'default' => 'value1' ],
+				'field2' => [ 'default' => 'value2' ],
+			]
+		);
+		$fix_mock->method( 'get_slug' )->willReturn( 'mock_fix' );
+		$fix_mock->is_pro = true;
+
+		$fixes_manager  = FixesManager::get_instance();
+		$reflection     = new ReflectionClass( $fixes_manager );
+		$fixes_property = $reflection->getProperty( 'fixes' );
+		$fixes_property->setAccessible( true );
+		$fixes_property->setValue( $fixes_manager, [ 'mock_fix' => $fix_mock ] );
+
+		$expected = [
+			'mock_fix' => [
+				'fields' => [
+					'field1' => 'value1',
+					'field2' => 'value2',
+				],
+				'is_pro' => true,
+			],
+		];
+
+		$this->assertEquals( $expected, $fixes_manager->get_fixes_settings() );
+	}
+
+	/**
+	 * Test that the instance returns the default values when options aren't set.
+	 *
+	 * @return void
+	 */
+	public function test_get_fixes_settings_uses_default_values() {
+		$fix_mock = $this->createMock( FixInterface::class );
+		$fix_mock->method( 'get_fields_array' )->willReturn(
+			[
+				'field1' => [ 'default' => 'default_value1' ],
+				'field2' => [ 'default' => 'default_value2' ],
+			]
+		);
+		$fix_mock->method( 'get_slug' )->willReturn( 'mock_fix' );
+
+		$fixes_manager = FixesManager::get_instance();
+		$reflection    = new ReflectionClass( $fixes_manager );
+		$fixes_propert = $reflection->getProperty( 'fixes' );
+		$fixes_propert->setAccessible( true );
+		$fixes_propert->setValue( $fixes_manager, [ 'mock_fix' => $fix_mock ] );
+
+		$expected = [
+			'mock_fix' => [
+				'fields' => [
+					'field1' => 'default_value1',
+					'field2' => 'default_value2',
+				],
+				'is_pro' => false,
+			],
+		];
+
+		$this->assertEquals( $expected, $fixes_manager->get_fixes_settings() );
+	}
+}

--- a/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
+++ b/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
@@ -5,6 +5,7 @@
  * @package accessibility-checker
  */
 
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
@@ -29,6 +30,15 @@ class FixesManagerTest extends TestCase {
 	}
 
 	/**
+	 * Tear down the test environment by closing Mockery.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Mockery::close();
+	}
+
+	/**
 	 * Test that the instance retuns an empty array when no fixes are registered.
 	 *
 	 * @return void
@@ -44,14 +54,14 @@ class FixesManagerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_get_fixes_settings_returns_correct_structure() {
-		$fix_mock = $this->createMock( FixInterface::class );
-		$fix_mock->method( 'get_fields_array' )->willReturn(
+		$fix_mock = Mockery::mock( 'alias:EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix' );
+		$fix_mock->shouldReceive( 'get_slug' )->andReturn( 'mock_fix' );
+		$fix_mock->shouldReceive( 'get_fields_array' )->andReturn(
 			[
 				'field1' => [ 'default' => 'value1' ],
 				'field2' => [ 'default' => 'value2' ],
 			]
 		);
-		$fix_mock->method( 'get_slug' )->willReturn( 'mock_fix' );
 		$fix_mock->is_pro = true;
 
 		$fixes_manager  = FixesManager::get_instance();
@@ -79,14 +89,14 @@ class FixesManagerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_get_fixes_settings_uses_default_values() {
-		$fix_mock = $this->createMock( FixInterface::class );
-		$fix_mock->method( 'get_fields_array' )->willReturn(
+		$fix_mock = Mockery::mock( 'alias:EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix' );
+		$fix_mock->shouldReceive( 'get_slug' )->andReturn( 'mock_fix' );
+		$fix_mock->shouldReceive( 'get_fields_array' )->andReturn(
 			[
 				'field1' => [ 'default' => 'default_value1' ],
 				'field2' => [ 'default' => 'default_value2' ],
 			]
 		);
-		$fix_mock->method( 'get_slug' )->willReturn( 'mock_fix' );
 
 		$fixes_manager  = FixesManager::get_instance();
 		$reflection     = new ReflectionClass( $fixes_manager );

--- a/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
+++ b/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
@@ -88,11 +88,11 @@ class FixesManagerTest extends TestCase {
 		);
 		$fix_mock->method( 'get_slug' )->willReturn( 'mock_fix' );
 
-		$fixes_manager = FixesManager::get_instance();
-		$reflection    = new ReflectionClass( $fixes_manager );
-		$fixes_propert = $reflection->getProperty( 'fixes' );
-		$fixes_propert->setAccessible( true );
-		$fixes_propert->setValue( $fixes_manager, [ 'mock_fix' => $fix_mock ] );
+		$fixes_manager  = FixesManager::get_instance();
+		$reflection     = new ReflectionClass( $fixes_manager );
+		$fixes_property = $reflection->getProperty( 'fixes' );
+		$fixes_property->setAccessible( true );
+		$fixes_property->setValue( $fixes_manager, [ 'mock_fix' => $fix_mock ] );
 
 		$expected = [
 			'mock_fix' => [

--- a/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
+++ b/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
@@ -5,7 +5,6 @@
  * @package accessibility-checker
  */
 
-use Mockery;
 use PHPUnit\Framework\TestCase;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
@@ -13,7 +12,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 /**
  * Unit tests for the FixesManager class.
  */
-class FixesManagerTest extends TestCase {
+class FixesManagerTest extends WP_UnitTestCase {
 
 	/**
 	 * Setup the test environment by resetting the instance before each test.

--- a/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
+++ b/tests/phpunit/includes/classes/Fixes/FixesManagerTest.php
@@ -54,7 +54,7 @@ class FixesManagerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_get_fixes_settings_returns_correct_structure() {
-		$fix_mock = Mockery::mock( 'alias:EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix' );
+		$fix_mock = Mockery::mock( 'EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix' );
 		$fix_mock->shouldReceive( 'get_slug' )->andReturn( 'mock_fix' );
 		$fix_mock->shouldReceive( 'get_fields_array' )->andReturn(
 			[
@@ -89,7 +89,7 @@ class FixesManagerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_get_fixes_settings_uses_default_values() {
-		$fix_mock = Mockery::mock( 'alias:EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix' );
+		$fix_mock = Mockery::mock( 'EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFilesFix' );
 		$fix_mock->shouldReceive( 'get_slug' )->andReturn( 'mock_fix' );
 		$fix_mock->shouldReceive( 'get_fields_array' )->andReturn(
 			[


### PR DESCRIPTION
Adds fixes and their values as a json_encoded string to the site health page for both the free and the pro sections.

![Screenshot from 2024-11-18 14-03-59](https://github.com/user-attachments/assets/f33debcc-a852-4e94-88fa-c8e9f3a93f86)
![Screenshot from 2024-11-18 14-03-50](https://github.com/user-attachments/assets/bd0efb80-e2be-4ab7-b974-fa4b0d33fd95)



## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
