### PR TITLE
Handle editorLink passed via edac_script_vars

### DIFF
--- a/src/admin/summary/summary-tab-input-event-handlers.js
+++ b/src/admin/summary/summary-tab-input-event-handlers.js
@@ -135,6 +135,10 @@ export const initFixButtonEventHandlers = () => {
 			if ( ! fixSettings ) {
 				return;
 			}
+			// if this button has a data-editor attribute, then we need to set the value of the fix setting to the value of the data-editor attribute
+			if ( button.hasAttribute( 'data-editor' ) ) {
+				window.edac_script_vars.editorLink = button.getAttribute( 'data-editor' );
+			}
 
 			fixSettings.classList.toggle( 'active' );
 			document.querySelector( 'body' ).classList.add( 'edac-fix-modal-present' );

--- a/src/common/saveFixSettingsRest.js
+++ b/src/common/saveFixSettingsRest.js
@@ -60,10 +60,11 @@ export const saveFixSettings = ( fixSettingsContainer ) => {
 				fixSettingsContainer.classList.add( 'edac-fix-settings--saved--success' );
 				// find the aria-live region and update the text
 				if ( liveRegion ) {
-					if ( window?.edacFrontendHighlighterApp?.editorLink?.length ) {
+					const editLink = window?.edacFrontendHighlighterApp?.editorLink || window?.edac_script_vars?.editorLink;
+					if ( editLink ) {
 						liveRegion.innerHTML = sprintf(
 							__( 'Settings saved successfully. You must %svisit the editor%s and save the post to rescan and remove fixed issues from Accessibility Checker reports.', 'accessibility-checker' ),
-							`<a href="${ window.edacFrontendHighlighterApp.editorLink }">`,
+							`<a href="${ editLink }">`,
 							'</a>'
 						);
 					} else {


### PR DESCRIPTION
In some situations, we would want to programmatically set an editor link. This PR sets up the required handling in the script. 

Part of a resolution to allow better fix settings save messaging on the open issues page.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
