### PR TITLE
Show a notice when fixes settings are saved on options page

### DIFF
--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -7,7 +7,14 @@
 
 ?>
 <div id="edac-fixes-page" class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
-
+	<?php if ( get_transient( 'edac_fixes_settings_saved' ) ) : ?>
+		<div class="notice notice-warning">
+			<p><?php esc_html_e( 'Settings saved. You need to rescan your site for the updates to be confirmed and reflected in site stats. If you have a caching plugin on your site make sure to flush is so that the updated fixes are reflected.', 'accessibility-checker' ); ?></p>
+		</div>
+		<?php
+		delete_transient( 'edac_fixes_settings_saved' );
+	endif;
+	?>
 	<div class="edac-settings-general <?php echo EDAC_KEY_VALID ? '' : 'edac-show-pro-callout'; ?>">
 		<form action="options.php" method="post">
 			<?php

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -8,7 +8,7 @@
 ?>
 <div id="edac-fixes-page" class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
 	<?php if ( get_transient( 'edac_fixes_settings_saved' ) ) : ?>
-		<div class="notice notice-warning">
+		<div class="notice notice-warning is-dismissible">
 			<p><?php esc_html_e( 'Settings saved. You need to rescan your site for the updates to be confirmed and reflected in site stats. If you have a caching plugin on your site make sure to flush is so that the updated fixes are reflected.', 'accessibility-checker' ); ?></p>
 		</div>
 		<?php

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -9,7 +9,7 @@
 <div id="edac-fixes-page" class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
 	<?php if ( get_transient( 'edac_fixes_settings_saved' ) ) : ?>
 		<div class="notice notice-warning is-dismissible">
-			<p><?php esc_html_e( 'Settings saved. You need to rescan your site for the updates to be confirmed and reflected in site stats. If you have a caching plugin on your site make sure to flush is so that the updated fixes are reflected.', 'accessibility-checker' ); ?></p>
+			<p><?php esc_html_e( 'Settings Saved. To confirm and reflect these updates in your site's statistics, please rescan your site. If you are using a caching plugin, make sure to clear the cache to ensure the updated fixes are applied correctly.', 'accessibility-checker' ); ?></p>
 		</div>
 		<?php
 		delete_transient( 'edac_fixes_settings_saved' );

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -9,7 +9,7 @@
 <div id="edac-fixes-page" class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
 	<?php if ( get_transient( 'edac_fixes_settings_saved' ) ) : ?>
 		<div class="notice notice-warning is-dismissible">
-			<p><?php esc_html_e( 'Settings Saved. To confirm and reflect these updates in your site's statistics, please rescan your site. If you are using a caching plugin, make sure to clear the cache to ensure the updated fixes are applied correctly.', 'accessibility-checker' ); ?></p>
+			<p><?php esc_html_e( "Settings Saved. To confirm and reflect these updates in your site's statistics, please rescan your site. If you are using a caching plugin, make sure to clear the cache to ensure the updated fixes are applied correctly.", 'accessibility-checker' ); ?></p>
 		</div>
 		<?php
 		delete_transient( 'edac_fixes_settings_saved' );


### PR DESCRIPTION
When fixes settings are saved, a transient is set to be used as a flag for notifications. It is used in the fixes_page.php partial to output a notice about rescanning and flushing the cache.

It's done this way rather than via admin_notifications because we are unhooking all other notifications when on the settings pages.

![Screenshot from 2024-11-18 21-49-25](https://github.com/user-attachments/assets/cf6f62ea-bbb0-4007-a014-e770b0afe3cc)

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
