### PR TITLE
Fix: Improve table header detection logic to correctly validate row headers

### DIFF
--- a/includes/rules/missing_table_header.php
+++ b/includes/rules/missing_table_header.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase -- underscore is for valid function name.
 /**
- * Accessibility Checker pluign file.
+ * Accessibility Checker plugin file.
  *
  * @package Accessibility_Checker
  */
@@ -19,32 +19,43 @@ function edac_rule_missing_table_header( $content, $post ) { // phpcs:ignore -- 
 	$tables = $dom->find( 'table' );
 
 	if ( ! $tables ) {
-		return;
+		return $errors; // Return empty errors array if no tables are found.
 	}
-	foreach ( $tables as $table ) {
 
-		if ( ! edac_th_match_td( $table ) ) {
+	foreach ( $tables as $table ) {
+		// Check if the table has proper headers.
+		if ( ! edac_has_proper_headers( $table ) ) {
 			$errors[] = $table;
 		}
 	}
+
 	return $errors;
 }
 
 /**
- * Check for TH TD matching
+ * Check if the table has proper headers
  *
- * @param obj $table Object to check.
- * @return int
+ * @param object $table Object to check.
+ * @return bool
  */
-function edac_th_match_td( $table ) {
-	$table_rows   = $table->find( 'tr' );
-	$header_count = 0;
-	$max_rows     = 0;
+function edac_has_proper_headers( $table ) {
+	$table_rows = $table->find( 'tr' );
+	$has_headers = false;
+
 	foreach ( $table_rows as $table_row ) {
-		if ( 0 === $header_count ) {
-			$header_count = count( $table_row->find( 'th' ) );
+		// Check for row or column headers in the current row.
+		$headers = $table_row->find( 'th' );
+		foreach ( $headers as $header ) {
+			// Check if the header has a valid scope or contains text.
+			$scope = $header->getAttribute( 'scope' );
+			$text  = trim( $header->plaintext );
+
+			if ( ! empty( $text ) && ( in_array( $scope, [ 'row', 'col', 'rowgroup', 'colgroup' ], true ) || empty( $scope ) ) ) {
+				$has_headers = true;
+				break 2; // Exit both loops as headers are valid.
+			}
 		}
-		$max_rows = max( $max_rows, count( $table_row->find( 'td' ) ) );
 	}
-	return $max_rows <= $header_count;
+
+	return $has_headers;
 }

--- a/includes/rules/missing_table_header.php
+++ b/includes/rules/missing_table_header.php
@@ -39,7 +39,7 @@ function edac_rule_missing_table_header( $content, $post ) { // phpcs:ignore -- 
  * @return bool
  */
 function edac_has_proper_headers( $table ) {
-	$table_rows = $table->find( 'tr' );
+	$table_rows  = $table->find( 'tr' );
 	$has_headers = false;
 
 	foreach ( $table_rows as $table_row ) {


### PR DESCRIPTION
This pull request includes updates to the `includes/rules/missing_table_header.php` file to improve the accessibility checks for table headers. The most significant changes involve renaming a function for clarity, modifying the logic to check for proper table headers, and ensuring that the function returns an appropriate value when no tables are found.

Key changes:

-  Renamed the function `edac_th_match_td` to `edac_has_proper_headers` for better clarity.
-  Enhanced the logic within the `edac_has_proper_headers` function to check for valid table headers by verifying the presence of header text and valid scope attributes.
-  Modified the `edac_rule_missing_table_header` function to return an empty errors array if no tables are found, ensuring consistency in the return type.
-  Corrected a typo in the file header comment from "pluign" to "plugin".

Fixes: https://3.basecamp.com/3579237/buckets/29333825/card_tables/cards/8057688694