### PR TITLE
Remove a duplicated siteid reference in query

### DIFF
--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -165,7 +165,7 @@ class Summary_Generator {
 		global $wpdb;
 
 		$warnings_parameters = [ get_current_blog_id(), $this->post_id, 'warning', 0 ];
-		$warnings_where      = 'WHERE siteid = siteid = %d and postid = %d and ruletype = %s and ignre = %d';
+		$warnings_where      = 'WHERE siteid = %d and postid = %d and ruletype = %s and ignre = %d';
 		if ( EDAC_ANWW_ACTIVE ) {
 			array_push( $warnings_parameters, 'link_blank' );
 			$warnings_where .= ' and rule != %s';


### PR DESCRIPTION
When this is here, it always results in a falsey value which loosely casts to 0, making this only able to retrieve warning counts of siteid 0.

It was added in https://github.com/equalizedigital/accessibility-checker/commit/6732c3d8d297e4e2868f9c579b08a3c6ad4d0134#diff-350d3eed90dcfd8d1466cc7e406d1b17b604e284b62d478a7eb271cdd11287e7R765 so it's been here 3-4 years.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
