### PR TITLE
added: ignore permission logic to ignore button

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -495,7 +495,9 @@ class Ajax {
 							$html      .= '<a href="' . $url . '" class="edac-details-rule-records-record-actions-highlight-front" target="_blank" aria-label="' . esc_attr( $aria_label ) . '" ><span class="dashicons dashicons-welcome-view-site"></span>' . __( 'View on page', 'accessibility-checker' ) . '</a>';
 						}
 
-						$html .= '<button class="edac-details-rule-records-record-actions-ignore' . $ignore_class . '" aria-expanded="false" aria-controls="edac-details-rule-records-record-ignore-' . $row['id'] . '">' . EDAC_SVG_IGNORE_ICON . '<span class="edac-details-rule-records-record-actions-ignore-label">' . $ignore_label . '</span></button>';
+						if ( true === $ignore_permission ) {
+							$html .= '<button class="edac-details-rule-records-record-actions-ignore' . $ignore_class . '" aria-expanded="false" aria-controls="edac-details-rule-records-record-ignore-' . $row['id'] . '">' . EDAC_SVG_IGNORE_ICON . '<span class="edac-details-rule-records-record-actions-ignore-label">' . $ignore_label . '</span></button>';
+						}
 
 						if ( ! empty( $fixes_for_item ) ) {
 							$html .= sprintf(


### PR DESCRIPTION
This pull request includes an update to the `admin/class-ajax.php` file to add a new conditional check for displaying the ignore button based on user permissions.

Changes to conditional display logic:

* [`admin/class-ajax.php`](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eR498-R500): Added a conditional check to display the ignore button only if the `$ignore_permission` variable is set to `true`.