### PR TITLE
Fix: URLs with 100% score will always be 0

### DIFF
--- a/admin/class-welcome-page.php
+++ b/admin/class-welcome-page.php
@@ -253,7 +253,7 @@ class Welcome_Page {
 						<div class="edac-welcome-grid-c11 edac-welcome-grid-item edac-background-light">
 							<div class="edac-inner-row">
 								<div class="edac-stat-number">
-									<?php echo esc_html( $summary['posts_without_issues_formatted'] ); ?>
+									<?php echo esc_html( $summary['posts_without_issues'] ?? 0 ); ?>
 								</div>
 							</div>
 							<div class="edac-inner-row">


### PR DESCRIPTION
Swap the array key that is checked for the passing urls to `posts_without_issues` since `posts_without_issues_formatted` doesn't exist in the summary array.

The key was changed to one that will always be empty in this commit: https://github.com/equalizedigital/accessibility-checker/commit/1c47aa73d0659dc514b768974a27af44eac07c2d

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
