### PR TITLE
Enhancement: Retry frontend highlighter init later

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -907,3 +907,7 @@ const initHighlighter = () => {
 window.addEventListener( 'DOMContentLoaded', () => {
 	initHighlighter();
 } );
+// Add a listener later than DOMCOntentLoaded to check if the init has run.
+window.addEventListener( 'load', () => {
+	initHighlighter();
+} );

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -894,14 +894,14 @@ class AccessibilityCheckerHighlight {
 // Some systems (Cloudflare Rocket Loader) defers scripts for performance but that can
 // cause some DOMContentLoaded events to be missed. This is flag tracks if it run so we
 // can retry at a latter event listener.
-let initHasRun = false;
+let highlighterInitialized = false;
 const initHighlighter = () => {
-	if ( ! initHasRun ) {
+	if ( ! highlighterInitialized ) {
 		new AccessibilityCheckerHighlight();
 		if ( window.edacFrontendHighlighterApp?.userCanFix ) {
 			fixSettingsModalInit();
 		}
-		initHasRun = true;
+		highlighterInitialized = true;
 	}
 };
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -891,9 +891,19 @@ class AccessibilityCheckerHighlight {
 	}
 }
 
-window.addEventListener( 'DOMContentLoaded', () => {
-	new AccessibilityCheckerHighlight();
-	if ( window.edacFrontendHighlighterApp?.userCanFix ) {
-		fixSettingsModalInit();
+// Some systems (Cloudflare Rocket Loader) defers scripts for performance but that can
+// cause some DOMContentLoaded events to be missed. This is flag tracks if it run so we
+// can retry at a latter event listener.
+let initHasRun = false;
+const initHighlighter = () => {
+	if ( ! initHasRun ) {
+		new AccessibilityCheckerHighlight();
+		if ( window.edacFrontendHighlighterApp?.userCanFix ) {
+			fixSettingsModalInit();
+		}
+		initHasRun = true;
 	}
+};
+window.addEventListener( 'DOMContentLoaded', () => {
+	initHighlighter();
 } );

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -904,10 +904,7 @@ const initHighlighter = () => {
 		initHasRun = true;
 	}
 };
-window.addEventListener( 'DOMContentLoaded', () => {
-	initHighlighter();
-} );
-// Add a listener later than DOMCOntentLoaded to check if the init has run.
-window.addEventListener( 'load', () => {
-	initHighlighter();
+
+[ 'DOMContentLoaded', 'load' ].forEach( ( event ) => {
+	window.addEventListener( event, initHighlighter );
 } );


### PR DESCRIPTION
This PR adds a simple retry later to init the Frontend Highlighter. This should solve the issue where Cloudflare Rocket Loader defer prevents the highlighter from initialising.

It will try init first on `DOMContentLoaded` and then later at `load`. It adds a variable as a flag to track if the init code has already run to prevent it duplicating on `load` if it already ran when initially intended.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
