### PR TITLE
Add a flag to skip cache when getting scan stats

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -76,6 +76,10 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM-DD.
           custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
+      # Some images won't have svn available. Install it if that's the case.
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
       - name: Install WP
         shell: bash
         run: tests/bin/install-wp-tests.sh wordpress_tests root '' 127.0.0.1:3306 ${{ matrix.wp_version }}

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -109,9 +109,10 @@ class Scans_Stats {
 	/**
 	 * Gets summary information about all scans
 	 *
-	 * @return array .
+	 * @param  boolean $skip_cache whether to skip the cache.
+	 * @return array
 	 */
-	public function summary() {
+	public function summary( $skip_cache = false ) {
 
 		global $wpdb;
 
@@ -119,7 +120,7 @@ class Scans_Stats {
 
 		$cache = get_transient( $transient_name );
 
-		if ( $this->cache_time && $cache ) {
+		if ( ! $skip_cache && ( $this->cache_time && $cache ) ) {
 
 			if ( $cache['expires_at'] >= time() && $cache['cached_at'] + $this->cache_time >= time()
 			) {

--- a/tests/phpunit/helper-functions/OrdinalTest.php
+++ b/tests/phpunit/helper-functions/OrdinalTest.php
@@ -132,7 +132,7 @@ class OrdinalTest extends WP_UnitTestCase {
 			// Tests for the `ar` locale.
 			'integer 1, ar'         => [
 				'numeric_value'             => 1,
-				'ordinal_value'             => '١.',
+				'ordinal_value'             => '١',
 				'locale'                    => 'ar',
 				'ordinal_value_no_php-intl' => '1st',
 			],
@@ -140,7 +140,7 @@ class OrdinalTest extends WP_UnitTestCase {
 			// Tests for the `el_GR` locale.
 			'integer 1, el_GR'      => [
 				'numeric_value'             => 1,
-				'ordinal_value'             => '1.',
+				'ordinal_value'             => '1',
 				'locale'                    => 'el_GR',
 				'ordinal_value_no_php-intl' => '1st',
 			],


### PR DESCRIPTION
This pull request includes an update to the `summary` method in the `admin/class-scans-stats.php` file to add a new parameter for skipping the cache.

This is needed for the multisite support where stats are retrieved through the plugin.

There are unrelated workflow and test changes in this PR that are not related to the cache skip change. The `latest` version of some docker images has changed and some adjustments were needed to CI workflows.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
