### PR TITLE
removed: unused admin notices functionality from FixesPage and Admin Notices classes

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -53,7 +53,6 @@ class FixesPage implements PageInterface {
 		$this->register_fields_and_settings();
 
 		add_filter( 'edac_filter_admin_scripts_slugs', [ $this, 'add_slug_to_admin_scripts' ] );
-		add_filter( 'edac_filter_remove_admin_notices_screens', [ $this, 'add_slug_to_admin_notices' ] );
 		add_filter( 'edac_filter_settings_tab_items', [ $this, 'add_fixes_tab' ] );
 		add_action( 'edac_settings_tab_content', [ $this, 'add_fixes_tab_content' ], 11, 1 );
 	}
@@ -96,17 +95,6 @@ class FixesPage implements PageInterface {
 	 */
 	public function add_slug_to_admin_scripts( $slugs ) {
 		$slugs[] = 'accessibility_checker_' . self::PAGE_TAB_SLUG;
-		return $slugs;
-	}
-
-	/**
-	 * Add the fixes slug to the admin notices.
-	 *
-	 * @param array $slugs The slugs that are already added.
-	 * @return array
-	 */
-	public function add_slug_to_admin_notices( $slugs ) {
-		$slugs[] = 'accessibility-checker_page_accessibility_checker_' . self::PAGE_TAB_SLUG;
 		return $slugs;
 	}
 

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -26,8 +26,6 @@ class Admin_Notices {
 	 * @return void
 	 */
 	public function init_hooks() {
-
-		add_action( 'in_admin_header', [ $this, 'edac_remove_admin_notices' ], 1000 );
 		add_action( 'init', [ $this, 'hook_notices' ] );
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
 	}
@@ -52,39 +50,6 @@ class Admin_Notices {
 		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
 		add_action( 'admin_notices', [ $this, 'edac_password_protected_notice' ] );
 		add_action( 'wp_ajax_edac_password_protected_notice_ajax', [ $this, 'edac_password_protected_notice_ajax' ] );
-	}
-
-	/**
-	 * Remove Admin Notices
-	 *
-	 * @return void
-	 */
-	public function edac_remove_admin_notices() {
-
-		$current_screen = get_current_screen();
-		$screens        = apply_filters(
-			'edac_filter_remove_admin_notices_screens',
-			[
-				'toplevel_page_accessibility_checker',
-				'accessibility-checker_page_accessibility_checker_issues',
-				'accessibility-checker_page_accessibility_checker_ignored',
-				'accessibility-checker_page_accessibility_checker_settings',
-			]
-		);
-
-		/**
-		 * Filter the screens where admin notices should be removed.
-		 *
-		 * @since 1.14.0
-		 *
-		 * @param array $screens The screens where admin notices should be removed.
-		 */
-		$screens = apply_filters( 'edac_filter_remove_admin_notices_screens', $screens );
-
-		if ( in_array( $current_screen->id, $screens, true ) ) {
-			remove_all_actions( 'admin_notices' );
-			remove_all_actions( 'all_admin_notices' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
This pull request removes the functionality related to the removal of admin notices in the `admin` module. The most important changes include the removal of the `add_slug_to_admin_notices` method and the `edac_remove_admin_notices` method, along with their associated hooks.

Removal of admin notices functionality:

* [`admin/AdminPage/FixesPage.php`](diffhunk://#diff-c9f2ca5909e6e4c48b97530f86fd6dadcb2475aaf67ba9d1750546dcf0604417L56): Removed the `add_slug_to_admin_notices` method and the associated filter `edac_filter_remove_admin_notices_screens` from the `add_page` method. [[1]](diffhunk://#diff-c9f2ca5909e6e4c48b97530f86fd6dadcb2475aaf67ba9d1750546dcf0604417L56) [[2]](diffhunk://#diff-c9f2ca5909e6e4c48b97530f86fd6dadcb2475aaf67ba9d1750546dcf0604417L102-L112)
* [`admin/class-admin-notices.php`](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL29-L30): Removed the `edac_remove_admin_notices` method and its associated action `in_admin_header` from the `init_hooks` method. [[1]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL29-L30) [[2]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL57-L89)