### PR TITLE
Make the endpoint for clearing issues less strict

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -231,14 +231,16 @@ class REST_Api {
 			}
 		}
 
-		// if flush is passed in via json and is true, then flush the cache.
-		if ( isset( $json['flush'] ) && true === $json['flush'] ) {
+		// if flush is set then clear the issues for that ID.
+		if ( isset( $json['flush'] ) ) {
 			// purge the issues for this post.
 			Purge_Post_Data::delete_post( $post_id );
 		}
+
 		return new \WP_REST_Response(
 			[
 				'success' => true,
+				'flushed' => isset( $json['flush'] ),
 				'id'      => $post_id,
 			]
 		);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -213,27 +213,22 @@ class REST_Api {
 	public function clear_issues_for_post( $request ) {
 
 		if ( ! isset( $request['id'] ) ) {
-			return new \WP_REST_Response( [ 'message' => 'A required parameter is missing.' ], 400 );
-		}
-
-		$post_id = (int) $request['id'];
-		$post    = get_post( $post_id );
-		if ( ! is_object( $post ) ) {
-			return new \WP_REST_Response( [ 'message' => 'The post is not valid.' ], 400 );
-		}
-
-		$post_type  = get_post_type( $post );
-		$post_types = Helpers::get_option_as_array( 'edac_post_types' );
-		if ( empty( $post_types ) || ! in_array( $post_type, $post_types, true ) ) {
-			return new \WP_REST_Response( [ 'message' => 'The post type is not set to be scanned.' ], 400 );
+			return new \WP_REST_Response( [ 'message' => 'ID paramiter is required' ], 400 );
 		}
 
 		// if flush is passed in via json and is true, then flush the cache.
 		$json = $request->get_json_params();
-		if ( isset( $json['flush'] ) && true === $json['flush'] ) {
+		if ( isset( $json['flush'] ) ) {
 			// purge the issues for this post.
 			Purge_Post_Data::delete_post( $post_id );
 		}
+		return new \WP_REST_Response(
+			[
+				'success' => true,
+				'flushed' => isset( $json['flush'] ) ? true : false,
+				'id'      => $post_id,
+			]
+		);
 	}
 
 


### PR DESCRIPTION
This now allows posts that no longer exist to be flushed out of the table of issues when passed a specific 'skip_post_exists_check' parameter.

Why: A support request came in about issues existing for a post that was deleted. It is difficult to clear these issues out without database access and the clear-issues endpoint had a check to validate that the post exists in it and that the post type was valid. 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
