### PR TITLE
Install SVN in deploy container if not already there

### DIFF
--- a/.github/workflows/deploy-on-release-to-dot-org.yml
+++ b/.github/workflows/deploy-on-release-to-dot-org.yml
@@ -22,6 +22,17 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      # Some images won't have svn available. Install it if that's the case.
+      - name: Install SVN
+        run: |
+          if ! command -v svn &> /dev/null; then
+            echo "Installing SVN..."
+            sudo apt-get update || { echo "Failed to update package lists"; exit 1; }
+            sudo apt-get install -y subversion || { echo "Failed to install SVN"; exit 1; }
+          else
+            echo "SVN is already installed"
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Fixes SVN not being available in `ubuntu-latest` and installs it in the deploy container