### PR TITLE
Refactor the text_size_too_small check

### DIFF
--- a/src/pageScanner/checks/text-size-too-small.js
+++ b/src/pageScanner/checks/text-size-too-small.js
@@ -17,14 +17,16 @@ export default {
 			return false;
 		}
 
-		// Check only if child nodes of the element that are text nodes. Nodes with no
-		// text children are treated as if they are a text node themselves.
+		// Check if the node has any direct text nodes as children. For a node with no
+		// children, or with TEXT_NODE children, evaluate the nodes font size. This
+		// handles both leaf nodes and container elements with mixed content.
 		const hasTextChild = Array.from( node.childNodes ).some( ( child ) => child.nodeType === Node.TEXT_NODE );
 		if ( ! node.childNodes.length || hasTextChild ) {
 			return fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD;
 		}
 
-		// Did not find any text that was too small.
+		// No text nodes were found in direct children, and this is not a leaf node,
+		// so we can safely ignore font size checks.
 		return false;
 	},
 };

--- a/src/pageScanner/checks/text-size-too-small.js
+++ b/src/pageScanner/checks/text-size-too-small.js
@@ -17,20 +17,14 @@ export default {
 			return false;
 		}
 
-		// If the node has no child nodes, then consider it as a text node itself and check it.
-		if ( ! node.childNodes.length ) {
+		// Check only if child nodes of the element that are text nodes. Nodes with no
+		// text children are treated as if they are a text node themselves.
+		const hasTextChild = Array.from( node.childNodes ).some( ( child ) => child.nodeType === Node.TEXT_NODE );
+		if ( ! node.childNodes.length || hasTextChild ) {
 			return fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD;
 		}
 
-		// Check onlychild nodes of the element that are text nodes.
-		let isTextTooSmall = false;
-		node.childNodes.forEach( ( child ) => {
-			if ( child.nodeType === Node.TEXT_NODE ) {
-				if ( fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD ) {
-					isTextTooSmall = true;
-				}
-			}
-		} );
-		return isTextTooSmall;
+		// Did not find any text that was too small.
+		return false;
 	},
 };

--- a/src/pageScanner/checks/text-size-too-small.js
+++ b/src/pageScanner/checks/text-size-too-small.js
@@ -12,7 +12,25 @@ const SMALL_FONT_SIZE_THRESHOLD = 10;
 export default {
 	id: 'text_size_too_small',
 	evaluate: ( node ) => {
-		// fails if the font size is less than or equal to 10px.
-		return fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD;
+		// If the node has no text content then it can't have text that's too small.
+		if ( ! node.textContent.trim().length ) {
+			return false;
+		}
+
+		// If the node has no child nodes, then consider it as a text node itself and check it.
+		if ( ! node.childNodes.length ) {
+			return fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD;
+		}
+
+		// Check onlychild nodes of the element that are text nodes.
+		let isTextTooSmall = false;
+		node.childNodes.forEach( ( child ) => {
+			if ( child.nodeType === Node.TEXT_NODE ) {
+				if ( fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD ) {
+					isTextTooSmall = true;
+				}
+			}
+		} );
+		return isTextTooSmall;
 	},
 };


### PR DESCRIPTION
This PR updates how the check for text-too-small works. It now checks the text size of:

1. Items with text content AND no child nodes
2. The child nodes of an item (if they exist) AND only if they are TEXT_NODE type.

This prevents checking elements that are not the direct text holder and avoiding false positives such as when a ul has a size of 0 set for layout purposes (to collapse the padding completely in the element) and inner elements have their own size.

I tested this change against the rulecheck site and confirmed that the number of issues in our font size test post did not change.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved text size detection algorithm to more accurately identify small text across different node types and structures.
	- Enhanced text size evaluation to account for nodes with no text content and to better handle child nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->