### PR TITLE
Reinstate the notifications blocking setup we previously had

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -53,6 +53,7 @@ class FixesPage implements PageInterface {
 		$this->register_fields_and_settings();
 
 		add_filter( 'edac_filter_admin_scripts_slugs', [ $this, 'add_slug_to_admin_scripts' ] );
+		add_filter( 'edac_filter_remove_admin_notices_screens', [ $this, 'add_slug_to_admin_notices' ] );
 		add_filter( 'edac_filter_settings_tab_items', [ $this, 'add_fixes_tab' ] );
 		add_action( 'edac_settings_tab_content', [ $this, 'add_fixes_tab_content' ], 11, 1 );
 	}
@@ -95,6 +96,17 @@ class FixesPage implements PageInterface {
 	 */
 	public function add_slug_to_admin_scripts( $slugs ) {
 		$slugs[] = 'accessibility_checker_' . self::PAGE_TAB_SLUG;
+		return $slugs;
+	}
+
+	/**
+	 * Add the fixes slug to the admin notices.
+	 *
+	 * @param array $slugs The slugs that are already added.
+	 * @return array
+	 */
+	public function add_slug_to_admin_notices( $slugs ) {
+		$slugs[] = 'accessibility-checker_page_accessibility_checker_' . self::PAGE_TAB_SLUG;
 		return $slugs;
 	}
 

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -26,6 +26,8 @@ class Admin_Notices {
 	 * @return void
 	 */
 	public function init_hooks() {
+
+		add_action( 'in_admin_header', [ $this, 'edac_remove_admin_notices' ], 1000 );
 		add_action( 'init', [ $this, 'hook_notices' ] );
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
 	}
@@ -50,6 +52,39 @@ class Admin_Notices {
 		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
 		add_action( 'admin_notices', [ $this, 'edac_password_protected_notice' ] );
 		add_action( 'wp_ajax_edac_password_protected_notice_ajax', [ $this, 'edac_password_protected_notice_ajax' ] );
+	}
+
+	/**
+	 * Remove Admin Notices
+	 *
+	 * @return void
+	 */
+	public function edac_remove_admin_notices() {
+
+		$current_screen = get_current_screen();
+		$screens        = apply_filters(
+			'edac_filter_remove_admin_notices_screens',
+			[
+				'toplevel_page_accessibility_checker',
+				'accessibility-checker_page_accessibility_checker_issues',
+				'accessibility-checker_page_accessibility_checker_ignored',
+				'accessibility-checker_page_accessibility_checker_settings',
+			]
+		);
+
+		/**
+		 * Filter the screens where admin notices should be removed.
+		 *
+		 * @since 1.14.0
+		 *
+		 * @param array $screens The screens where admin notices should be removed.
+		 */
+		$screens = apply_filters( 'edac_filter_remove_admin_notices_screens', $screens );
+
+		if ( in_array( $current_screen->id, $screens, true ) ) {
+			remove_all_actions( 'admin_notices' );
+			remove_all_actions( 'all_admin_notices' );
+		}
 	}
 
 	/**

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -62,15 +62,12 @@ class Admin_Notices {
 	public function edac_remove_admin_notices() {
 
 		$current_screen = get_current_screen();
-		$screens        = apply_filters(
-			'edac_filter_remove_admin_notices_screens',
-			[
-				'toplevel_page_accessibility_checker',
-				'accessibility-checker_page_accessibility_checker_issues',
-				'accessibility-checker_page_accessibility_checker_ignored',
-				'accessibility-checker_page_accessibility_checker_settings',
-			]
-		);
+		$screens        = [
+			'toplevel_page_accessibility_checker',
+			'accessibility-checker_page_accessibility_checker_issues',
+			'accessibility-checker_page_accessibility_checker_ignored',
+			'accessibility-checker_page_accessibility_checker_settings',
+		];
 
 		/**
 		 * Filter the screens where admin notices should be removed.

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -28,7 +28,7 @@ class Admin_Notices {
 	public function init_hooks() {
 
 		add_action( 'in_admin_header', [ $this, 'edac_remove_admin_notices' ], 1000 );
-		add_action( 'init', [ $this, 'hook_notices' ] );
+		add_action( 'in_admin_header', [ $this, 'hook_notices' ], 1001 );
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
 	}
 

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -25,14 +25,14 @@ use EDAC\Admin\Welcome_Page;
 						$version       = EDAC_VERSION;
 					}
 
-					echo esc_html( $welcome_title );
+					printf(
+						'%1$s <span class="edac-welcome-header-version">%2$s %3$s</span>',
+						esc_html( $welcome_title ),
+						esc_html__( 'version', 'accessibility-checker' ),
+						esc_html( $version )
+					);
 					?>
 				</h1>
-				<p>
-					<?php
-					echo( esc_html__( 'version ', 'accessibility-checker' ) . esc_html( $version ) );
-					?>
-				</p>
 			</div>
 
 		<div class="edac-welcome-header-right">

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -685,6 +685,21 @@ window.addEventListener( 'load', function() {
 		initFixButtonEventHandlers();
 	}
 
+	// On our welcome page the notices break layout, so we move them to a new container in
+	// the grid we have in the header.
+	const notices = document.querySelectorAll( '.edac-welcome-header-left .notice' );
+	if ( notices.length ) {
+		// Create a new div after .edac-welcome-header-right element
+		const noticesContainer = document.createElement( 'div' );
+		noticesContainer.classList.add( 'edac-welcome-header-notices' );
+		document.querySelector( '.edac-welcome-header-right' ).insertAdjacentElement( 'afterend', noticesContainer );
+		if ( document.querySelector( '.edac-welcome-header-notices' ) ) {
+			notices.forEach( function( notice ) {
+				noticesContainer.appendChild( notice );
+			} );
+		}
+	}
+
 	edacTimestampToLocal();
 } );
 

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -693,6 +693,7 @@ window.addEventListener( 'load', function() {
 		const noticesContainer = document.createElement( 'div' );
 		noticesContainer.classList.add( 'edac-welcome-header-notices' );
 		document.querySelector( '.edac-welcome-header-right' ).insertAdjacentElement( 'afterend', noticesContainer );
+		// If the new container was created then put the notices into it.
 		if ( document.querySelector( '.edac-welcome-header-notices' ) ) {
 			notices.forEach( function( notice ) {
 				noticesContainer.appendChild( notice );

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -917,9 +917,13 @@
 	}
 
     &-left {
-      grid-column: 1 / -1;
       grid-row: 1;
     }
+
+	&-left,
+	&-notices {
+		grid-column: 1 / -1;
+	}
 
     &-right {
       grid-column: 2 / 3;
@@ -1602,8 +1606,17 @@
       flex-direction: column-reverse;
       text-align: center;
 
+      .edac-welcome-header-left {
+		order: 2;
+	  }
+
       .edac-welcome-header-right {
         text-align: center;
+		  order: 3;
+      }
+
+      .edac-welcome-header-notices {
+        order: 1
       }
     }
 

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -923,6 +923,10 @@
         display: block;
       }
     }
+
+	&-notices {
+		grid-column: 1 / -1;
+	}
   }
 
   &-title {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -905,13 +905,19 @@
     padding: 1rem 2rem;
     border-bottom: 1px solid variables.$color-gray-light;
 
-    @include helpers.breakpoint(md) {
+    @include helpers.breakpoint(sm) {
       display: grid;
-      grid-template-columns: auto 200px;
+      grid-template-columns: minmax(200px, auto) 1fr;
     }
 
+	&-version {
+		display: block;
+		font-size: 12px;
+		margin-top: 6px;
+	}
+
     &-left {
-      grid-column: 1 / 2;
+      grid-column: 1 / -1;
       grid-row: 1;
     }
 
@@ -920,17 +926,14 @@
       grid-row: 1;
 
       a {
-        display: block;
+        display: inline-block;
       }
     }
-
-	&-notices {
-		grid-column: 1 / -1;
-	}
   }
 
   &-title {
     font-size: 24px;
+    display: inline-block;
   }
 
   &-subtitle {


### PR DESCRIPTION
This PR reinstates the notice removal/blocking we had on our admin pages that was removed in #835.

It also swaps notices to an alternative pattern ensuring our notices are added after we run our removal. Our other plugins need to adopt that same pattern as well.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced admin notice management for specific pages.
	- Improved control over admin notice display timing and visibility.
	- New layout for notices on the welcome page to prevent disruption.

- **Improvements**
	- Added ability to selectively remove admin notices on certain screens.
	- Refined admin notice processing workflow.
	- Enhanced layout and responsiveness of the welcome component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->