### PR TITLE
Prevent password protected notice being triggered by woocommerse checkout page scan

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1047,7 +1047,7 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
  *
  * @return bool
  */
-function edac_is_woocommerse_enabled() {
+function edac_is_woocommerce_enabled() {
 	return function_exists( 'WC' ) && class_exists( 'WooCommerce' );
 }
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1043,7 +1043,7 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 /**
  * Check if WooCommerce is enabled.
  *
- * This just checks for existance of the main WooCommerce function and class.
+ * This just checks for existence of the main WooCommerce function and class.
  *
  * @return bool
  */

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1039,3 +1039,28 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 	}
 	return add_query_arg( $query_args, $base_link );
 }
+
+/**
+ * Check if WooCommerce is enabled.
+ *
+ * This just checks for existance of the main WooCommerce function and class.
+ *
+ * @return bool
+ */
+function edac_is_woocommerse_enabled() {
+	return function_exists( 'WC' ) && class_exists( 'WooCommerce' );
+}
+
+/**
+ * Check if a given post id is the WooCommerce checkout page.
+ *
+ * @param int $post_id The post ID to check.
+ * @return bool
+ */
+function edac_check_if_post_id_is_woocommerse_checkout_page( $post_id ) {
+	if ( ! edacp_is_woocommerse_enabled() ) {
+		return false;
+	}
+
+	return wc_get_page_id( 'checkout' ) === $post_id;
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1057,8 +1057,8 @@ function edac_is_woocommerse_enabled() {
  * @param int $post_id The post ID to check.
  * @return bool
  */
-function edac_check_if_post_id_is_woocommerse_checkout_page( $post_id ) {
-	if ( ! edacp_is_woocommerse_enabled() ) {
+function edac_check_if_post_id_is_woocommerce_checkout_page( $post_id ) {
+	if ( ! edac_is_woocommerce_enabled() ) {
 		return false;
 	}
 

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -146,11 +146,11 @@ function edac_validate( $post_ID, $post, $action ) {
 	do_action( 'edac_after_get_content', $post_ID, $content, $action );
 
 	if ( ! $content['html'] ) {
-		// The woocommerse checkout page will always be a redirect when it has no items. The redirect
+		// The woocommerce checkout page will always be a redirect when it has no items. The redirect
 		// will cause the content to be empty.
 		// TEMPORARY FIX: Just return without setting this as a password protected page. In future we
 		// will need to fix this properly by adding a product to the cart before checking.
-		if ( edac_check_if_post_id_is_woocommerse_checkout_page( $post_ID ) ) {
+		if ( edac_check_if_post_id_is_woocommerce_checkout_page( $post_ID ) ) {
 			return;
 		}
 

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -146,6 +146,14 @@ function edac_validate( $post_ID, $post, $action ) {
 	do_action( 'edac_after_get_content', $post_ID, $content, $action );
 
 	if ( ! $content['html'] ) {
+		// The woocommerse checkout page will always be a redirect when it has no items. The redirect
+		// will cause the content to be empty.
+		// TEMPORARY FIX: Just return without setting this as a password protected page. In future we
+		// will need to fix this properly by adding a product to the cart before checking.
+		if ( edac_check_if_post_id_is_woocommerse_checkout_page( $post_ID ) ) {
+			return;
+		}
+
 		update_option( 'edac_password_protected', true );
 		return;
 	} else {


### PR DESCRIPTION
This PR detects when a scan fail occurs on the woocommerse checkout page (due to a redirect when cart is empty) and returns early before the `edac_password_protected` option is set.

The page still will not scan after this change - but it will not show an inaccurate notice when it occurs.

We will need to cycle back in future to resolve actually being able to scan the checkout page in different situations.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added helper functions to check WooCommerce plugin status and identify the checkout page.
	- Enhanced validation process for WooCommerce checkout pages.

- **Bug Fixes**
	- Resolved an issue with content validation on WooCommerce checkout pages.
	- Improved handling of empty content scenarios during page validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->