### PR TITLE
Rework urls counts and values of post scanned and other welcome page stats

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -61,16 +61,16 @@ class Admin_Notices {
 	/**
 	 * Notify users of the improvements to stats calculations.
 	 *
-	 * In version 1.20.0 we changed how posts_scanned was counted along with how other values like averages
+	 * In version 1.21.0 we changed how posts_scanned was counted along with how other values like averages
 	 * were calculated.
 	 *
-	 * @since 1.20.0
+	 * @since 1.21.0
 	 *
 	 * @return void
 	 */
 	public function welcome_page_post_count_change_notice() {
-		// Only show this notice if the version number is below 1.21.0.
-		if ( version_compare( EDAC_VERSION, '1.21.0', '>=' ) ) {
+		// Only show this notice if the version number is below 1.22.0.
+		if ( version_compare( EDAC_VERSION, '1.22.0', '>=' ) ) {
 			return;
 		}
 

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -86,7 +86,17 @@ class Admin_Notices {
 
 		?>
 		<div class="notice notice-info is-dismissible edac-stats-improvement-notice">
-			<p><?php esc_html_e( 'We have improved the statistics calculations in version 1.12.0. As a result, some numbers in the data below may have changed. Read more in our release announcement post.', 'accessibility-checker' ); ?></p>
+			<p>
+				<?php
+					$release_post_link = edac_generate_link_type( [], 'custom', [ 'base_link' => 'https://equalizedigital.com/corrected-calculations-in-accessibility-checker-pro-and-audit-history/' ] );
+					printf(
+						// translators: %1$s is the opening anchor tag, %2$s is the closing anchor tag.
+						esc_html__( 'We have improved the statistics calculations in version 1.21.0. As a result, some numbers in the data below may have changed. Read more in our %1$srelease announcement post%2$s.', 'accessibility-checker' ),
+						'<a href="' . esc_url( $release_post_link ) . '" target="_blank">',
+						'</a>'
+					);
+				?>
+			</p>
 		</div>
 		<?php
 	}

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -34,7 +34,7 @@ class Admin_Notices {
 		add_action( 'wp_ajax_edac_gaad_notice_ajax', [ $this, 'edac_gaad_notice_ajax' ] );
 		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
 		add_action( 'wp_ajax_edac_password_protected_notice_ajax', [ $this, 'edac_password_protected_notice_ajax' ] );
-    add_action( 'wp_ajax_edac_welcome_page_post_count_change_notice_dismiss_ajax', [ $this, 'welcome_page_post_count_change_notice_ajax' ] );
+		add_action( 'wp_ajax_edac_welcome_page_post_count_change_notice_dismiss_ajax', [ $this, 'welcome_page_post_count_change_notice_ajax' ] );
 		// Save fixes transient on save.
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
 	}

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -281,15 +281,15 @@ class Scans_Stats {
 		}
 
 		$data['avg_issue_density_percentage'] =
-		$wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
-			$wpdb->prepare(
-				'SELECT avg(meta_value) from ' . $wpdb->postmeta . '
-				JOIN ' . $wpdb->prefix . 'accessibility_checker ON postid=post_id
-				WHERE meta_key = %s
-				and ' . $wpdb->prefix . 'accessibility_checker.siteid=%d and ignre=%d and ignre_global=%d LIMIT %d',
-				[ '_edac_issue_density', $siteid, 0, 0, $this->record_limit ]
-			)
-		);
+			$wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
+				$wpdb->prepare(
+					'SELECT avg(meta_value) from ' . $wpdb->postmeta . '
+					JOIN ' . $wpdb->prefix . 'accessibility_checker ON postid=post_id
+					WHERE meta_key = %s
+					and ' . $wpdb->prefix . 'accessibility_checker.siteid=%d and ignre=%d and ignre_global=%d LIMIT %d',
+					[ '_edac_issue_density', $siteid, 0, 0, $this->record_limit ]
+				)
+			);
 
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -264,6 +264,10 @@ class Scans_Stats {
          // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 			$data['posts_without_issues'] = $wpdb->get_var( $sql );
 			$data['avg_issues_per_post']  = round( ( $data['warnings'] + $data['errors'] ) / $data['posts_scanned'], 2 );
+
+			if ( $data['avg_issues_per_post'] < 1 ) {
+				$data['avg_issues_per_post'] = '< 1';
+			}
 		}
 
 		$data['avg_issue_density_percentage'] =

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -306,7 +306,7 @@ class Scans_Stats {
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';
 		} else {
-			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 2 );
+			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 4 );
 		}
 
 		$data['fullscan_running']      = false;

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -277,9 +277,11 @@ class Scans_Stats {
 			)
 		);
 
-		$data['avg_issue_density_percentage'] = ( null === $data['avg_issue_density_percentage'] )
-		? 'N/A'
-		: round( $data['avg_issue_density_percentage'], 2 );
+		if ( null === $data['avg_issue_density_percentage'] ) {
+			$data['avg_issue_density_percentage'] = 'N/A';
+		} else {
+			$data['avg_issue_density_percentage'] = $data['avg_issue_density_percentage'] < 1 ? '< 1' : round( $data['avg_issue_density_percentage'], 2 );
+		}
 
 		$data['fullscan_running']      = false;
 		$data['fullscan_state']        = '';

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -156,6 +156,18 @@ class Scans_Stats {
 
 		$issues_query = new Issues_Query( [], $this->record_limit, Issues_Query::FLAG_INCLUDE_ALL_POST_TYPES );
 
+		// Count total unique meta values from postmeta table where the meta_key is _edac_issue_density.
+		// This will give us the total number of posts that have been scanned.
+		$data['posts_scanned'] = (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
+			$wpdb->prepare(
+				'SELECT COUNT(DISTINCT %i) FROM %i WHERE meta_key = %s',
+				'post_id',
+				$wpdb->postmeta,
+				'_edac_issue_density'
+			)
+		);
+
+
 		$data['is_truncated']               = $issues_query->has_truncated_results();
 		$data['distinct_posts_with_issues'] = (int) $issues_query->distinct_posts_count();
 		$data['rules_failed']               = 0;

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -265,11 +265,9 @@ class Scans_Stats {
 			// give me sql that will find all post ids in the accessibility_checker table
 			// where ALL issues with that ID are eiter ignored or globally ignored.
 			$posts_with_just_ignored_issues = '
-				SELECT postid FROM ' . $wpdb->prefix . 'accessibility_checker
-				WHERE postid IN (SELECT postid FROM ' . $wpdb->prefix . 'accessibility_checker
-				WHERE ignre=0 OR ignre_global=0)
-				GROUP BY postid
-				HAVING COUNT(*) = SUM(ignre=0 OR ignre_global=0)';
+				SELECT COUNT( postid ) FROM ' . $wpdb->prefix . 'accessibility_checker
+				WHERE postid IN (SELECT DISTINCT postid FROM ' . $wpdb->prefix . 'accessibility_checker
+				WHERE ignre=0 OR ignre_global=0)';
 
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 			$data['posts_without_issues'] = $wpdb->get_var( $posts_without_issues ) + $wpdb->get_var( $posts_with_just_ignored_issues );

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -168,9 +168,9 @@ class Scans_Stats {
 		);
 
 
-		$data['is_truncated']               = $issues_query->has_truncated_results();
-		$data['distinct_posts_with_issues'] = (int) $issues_query->distinct_posts_count();
-		$data['rules_failed']               = 0;
+		$data['is_truncated']      = $issues_query->has_truncated_results();
+		$data['posts_with_issues'] = (int) $issues_query->distinct_posts_count();
+		$data['rules_failed']      = 0;
 
 		// Get a count of rules that are not in the issues table.
 		$rule_slugs = array_map(

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -304,11 +304,6 @@ class Scans_Stats {
 				)
 			);
 
-		// if the number is over 1 then we need to make it a fraction below 1.
-		if ( $data['avg_issue_density_percentage'] > 1 ) {
-			$data['avg_issue_density_percentage'] = 1 - ( 1 / $data['avg_issue_density_percentage'] );
-		}
-
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';
 		} else {

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -156,9 +156,9 @@ class Scans_Stats {
 
 		$issues_query = new Issues_Query( [], $this->record_limit, Issues_Query::FLAG_INCLUDE_ALL_POST_TYPES );
 
-		$data['is_truncated']  = $issues_query->has_truncated_results();
-		$data['posts_scanned'] = (int) $issues_query->distinct_posts_count();
-		$data['rules_failed']  = 0;
+		$data['is_truncated']               = $issues_query->has_truncated_results();
+		$data['distinct_posts_with_issues'] = (int) $issues_query->distinct_posts_count();
+		$data['rules_failed']               = 0;
 
 		// Get a count of rules that are not in the issues table.
 		$rule_slugs = array_map(

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -306,7 +306,7 @@ class Scans_Stats {
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';
 		} else {
-			$data['avg_issue_density_percentage'] = $data['avg_issue_density_percentage'] < 1 ? '< 1%' : round( $data['avg_issue_density_percentage'], 2 );
+			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 2 );
 		}
 
 		$data['fullscan_running']      = false;

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -252,26 +252,22 @@ class Scans_Stats {
 		) {
 			$ac_table_name = $wpdb->prefix . 'accessibility_checker';
 
-			// Get all posts in scannable post types with scannable post statuses and that have no issues.
-			$posts_without_issues = $wpdb->prepare(
-				"SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts}
-				LEFT JOIN %i ON {$wpdb->posts}.ID = " .
+			$posts_without_issues = "
+				SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts}
+				LEFT JOIN " . $wpdb->prefix . "accessibility_checker ON {$wpdb->posts}.ID = " .
 				$wpdb->prefix . 'accessibility_checker.postid WHERE ' .
 				$wpdb->prefix . 'accessibility_checker.postid IS NULL
-				AND post_type IN(%s)
-				AND post_status IN(%s)',
-				[
-					$ac_table_name,
+				AND post_type IN(' .
 					Helpers::array_to_sql_safe_list(
 						Settings::get_scannable_post_types()
-					),
+					) . ')
+				AND post_status IN(' .
 					Helpers::array_to_sql_safe_list(
 						Settings::get_scannable_post_statuses()
-					),
-				]
-			);
+					) . ')';
 
-			// Get all posts that have ONLY ignored issues.
+			// give me sql that will find all post ids in the accessibility_checker table
+			// where ALL issues with that ID are eiter ignored or globally ignored.
 			$posts_with_just_ignored_issues = $wpdb->prepare(
 				'SELECT COUNT( DISTINCT postid )
 				FROM %i

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -271,9 +271,9 @@ class Scans_Stats {
 			$wpdb->prepare(
 				'SELECT avg(meta_value) from ' . $wpdb->postmeta . '
 				JOIN ' . $wpdb->prefix . 'accessibility_checker ON postid=post_id
-				WHERE meta_key = %s and meta_value > %d
+				WHERE meta_key = %s
 				and ' . $wpdb->prefix . 'accessibility_checker.siteid=%d and ignre=%d and ignre_global=%d LIMIT %d',
-				[ '_edac_issue_density', 0, $siteid, 0, 0, $this->record_limit ]
+				[ '_edac_issue_density', $siteid, 0, 0, $this->record_limit ]
 			)
 		);
 

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -280,7 +280,7 @@ class Scans_Stats {
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';
 		} else {
-			$data['avg_issue_density_percentage'] = $data['avg_issue_density_percentage'] < 1 ? '< 1' : round( $data['avg_issue_density_percentage'], 2 );
+			$data['avg_issue_density_percentage'] = $data['avg_issue_density_percentage'] < 1 ? '< 1%' : round( $data['avg_issue_density_percentage'], 2 );
 		}
 
 		$data['fullscan_running']      = false;

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -264,10 +264,15 @@ class Scans_Stats {
 
 			// give me sql that will find all post ids in the accessibility_checker table
 			// where ALL issues with that ID are eiter ignored or globally ignored.
-			$posts_with_just_ignored_issues = '
-				SELECT COUNT( postid ) FROM ' . $wpdb->prefix . 'accessibility_checker
-				WHERE postid IN (SELECT DISTINCT postid FROM ' . $wpdb->prefix . 'accessibility_checker
-				WHERE ignre=0 OR ignre_global=0)';
+
+			$posts_with_just_ignored_issues = 'SELECT COUNT( DISTINCT postid )
+				FROM ' . $wpdb->prefix . 'accessibility_checker
+				WHERE siteid = ' . $siteid . '
+				AND postid NOT IN (
+				  	SELECT postid
+				  	FROM ' . $wpdb->prefix . 'accessibility_checker
+				  	WHERE ignre=0 AND ignre_global=0
+				)';
 
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 			$data['posts_without_issues'] = $wpdb->get_var( $posts_without_issues ) + $wpdb->get_var( $posts_with_just_ignored_issues );

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -307,7 +307,7 @@ class Scans_Stats {
 		if ( null === $data['avg_issue_density_percentage'] ) {
 			$data['avg_issue_density_percentage'] = 'N/A';
 		} else {
-			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 4 );
+			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 2 );
 		}
 
 		$data['fullscan_running']      = false;
@@ -372,8 +372,10 @@ class Scans_Stats {
 		if ( $data['fullscan_completed_at'] > 0 ) {
 			$formatting['fullscan_completed_at_formatted'] = Helpers::format_date( $data['fullscan_completed_at'], true );
 		}
-		$formatting['passed_percentage_formatted']            = Helpers::format_percentage( $data['passed_percentage'] );
-		$formatting['avg_issue_density_percentage_formatted'] = Helpers::format_percentage( $data['avg_issue_density_percentage'] );
+		$formatting['passed_percentage_formatted'] = Helpers::format_percentage( $data['passed_percentage'] );
+
+		// The density should already a percentage value, just add the sign. If not an integer, just return the value which will be 'N/A'.
+		$formatting['avg_issue_density_percentage_formatted'] = is_int( $data['avg_issue_density_percentage'] ) ? $data['avg_issue_density_percentage'] . '%' : $data['avg_issue_density_percentage'];
 
 		$formatting['cached_at_formatted'] = Helpers::format_date( $data['cached_at'], true );
 

--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -275,7 +275,7 @@ class Scans_Stats {
 			$data['posts_without_issues'] = $wpdb->get_var( $posts_without_issues ) + $wpdb->get_var( $posts_with_just_ignored_issues );
 			$data['avg_issues_per_post']  = round( ( $data['warnings'] + $data['errors'] ) / $data['posts_scanned'], 2 );
 
-			if ( $data['avg_issues_per_post'] < 1 ) {
+			if ( $data['avg_issues_per_post'] < 1 && 0 !== $data['avg_issues_per_post'] ) {
 				$data['avg_issues_per_post'] = '< 1';
 			}
 		}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1032,6 +1032,11 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 		case 'help':
 			$base_link = trailingslashit( 'https://a11ychecker.com/help' . $args['help_id'] ?? '' );
 			break;
+		case 'custom': // phpcs:ignore -- intentially only breaking inside the condition because if it's not set we want to hit default.
+			if ( $args['base_link'] ) {
+				$base_link = $args['base_link'];
+				break;
+			}
 		case 'pro':
 		default:
 			$base_link = 'https://equalizedigital.com/accessibility-checker/pricing/';

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -582,6 +582,28 @@ const edacScriptVars = edac_script_vars;
 			} );
 		}
 
+		// Handle dismiss stats improvement notice.
+		if ( jQuery( '.edac-stats-improvement-notice' ).length ) {
+			jQuery( '.edac-stats-improvement-notice .notice-dismiss' ).on( 'click', function() {
+				edacStatsImprovementNoticeAjax();
+			} );
+		}
+
+		function edacStatsImprovementNoticeAjax() {
+			jQuery.ajax( {
+				url: ajaxurl,
+				method: 'GET',
+				data: {
+					action: 'edac_welcome_page_post_count_change_notice_dismiss_ajax',
+					nonce: edacScriptVars.nonce,
+				},
+			} ).done( function( response ) {
+				if ( true === response.success ) {
+					const responseJSON = jQuery.parseJSON( response.data );
+				}
+			} );
+		}
+
 		if ( jQuery( '#edac-summary-panel' ).length ) {
 			refreshSummaryAndReadability();
 			edacDetailsAjax();


### PR DESCRIPTION
The main change in this PR is swapping the `posts_scanned` value used in several places and calculations to actually contain a number that is the total number of posts scanned. The number previously contained a value that was 'posts_with_issues`.

* posts_scanned value now is generated from post metadata (if a post has a density value then it has been scanned) - the value now is more in line with it's name.
* posts_with_issues is a new metric produced and holds the value that `posts_scanned` used to contain - this value is being kept under the new key as it may be useful in future.
* avg_issue_density_percentage now includes posts in the total that have `0` issues - so that the average reflects site average and not just the average density of posts that have issues.
* if avg_issues_per_page is < 1 then it will show `< 1` string rather than a number with a decimal.

Improvements to scan statistics:

* [`admin/class-scans-stats.php`](diffhunk://#diff-a60c9bd16cb44ab306c6325d9e5db0e79041354c491b655d3b616125dd1cdff1R159-R172): Added a direct database query to count the total unique meta values from the `postmeta` table where the `meta_key` is `_edac_issue_density`, providing the total number of posts that have been scanned. This replaces the previous method of counting distinct posts through `Issues_Query`.
* [`admin/class-scans-stats.php`](diffhunk://#diff-a60c9bd16cb44ab306c6325d9e5db0e79041354c491b655d3b616125dd1cdff1L262-R284): Updated the calculation of `avg_issue_density_percentage` to handle values less than 1, displaying them as `< 1` instead of rounding to zero. This change ensures more accurate representation of low issue densities.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dismissible notice for improvements in statistics calculations on the admin welcome page.
	- Added AJAX functionality to handle dismissal of the welcome page notice.
	- Implemented a mechanism for counting distinct posts with issues for enhanced accuracy.
	- Enhanced event handling for the dismissal notice in the admin interface.
	- Added support for custom base links in URL generation.

- **Bug Fixes**
	- Improved accuracy of post scanning statistics calculation.
	- Enhanced calculation of average issue density percentage.
	- Refined data retrieval and formatting for scan statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->