### PR TITLE
Fix button style and ajax handlers for notices

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -302,9 +302,9 @@ class Admin_Notices {
 				<?php esc_html_e( "Hello! Thank you for using Accessibility Checker as part of your accessibility toolkit. Since you've been using it for a while, would you please write a 5-star review of Accessibility Checker in the WordPress plugin directory? This will help increase our visibility so more people can learn about the importance of web accessibility. Thanks so much!", 'accessibility-checker' ); ?>
 			</p>
 			<p>
-				<button class="edac-review-notice-review"><?php esc_html_e( 'Write A Review', 'accessibility-checker' ); ?></button>
-				<button class="edac-review-notice-remind"><?php esc_html_e( 'Remind Me In Two Weeks', 'accessibility-checker' ); ?></button>
-				<button class="edac-review-notice-dismiss"><?php esc_html_e( 'Never Ask Again', 'accessibility-checker' ); ?></button>
+				<button class="edac-review-notice-review button button-small button-primary"><?php esc_html_e( 'Write A Review', 'accessibility-checker' ); ?></button>
+				<button class="edac-review-notice-remind button button-small"><?php esc_html_e( 'Remind Me In Two Weeks', 'accessibility-checker' ); ?></button>
+				<button class="edac-review-notice-dismiss button button-small"><?php esc_html_e( 'Never Ask Again', 'accessibility-checker' ); ?></button>
 			</p>
 		</div>
 		<?php

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -29,6 +29,12 @@ class Admin_Notices {
 
 		add_action( 'in_admin_header', [ $this, 'edac_remove_admin_notices' ], 1000 );
 		add_action( 'in_admin_header', [ $this, 'hook_notices' ], 1001 );
+		// Ajax handlers for notices.
+		add_action( 'wp_ajax_edac_black_friday_notice_ajax', [ $this, 'edac_black_friday_notice_ajax' ] );
+		add_action( 'wp_ajax_edac_gaad_notice_ajax', [ $this, 'edac_gaad_notice_ajax' ] );
+		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
+		add_action( 'wp_ajax_edac_password_protected_notice_ajax', [ $this, 'edac_password_protected_notice_ajax' ] );
+		// Save fixes transient on save.
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
 	}
 
@@ -45,13 +51,9 @@ class Admin_Notices {
 		}
 
 		add_action( 'admin_notices', [ $this, 'edac_black_friday_notice' ] );
-		add_action( 'wp_ajax_edac_black_friday_notice_ajax', [ $this, 'edac_black_friday_notice_ajax' ] );
 		add_action( 'admin_notices', [ $this, 'edac_gaad_notice' ] );
-		add_action( 'wp_ajax_edac_gaad_notice_ajax', [ $this, 'edac_gaad_notice_ajax' ] );
 		add_action( 'admin_notices', [ $this, 'edac_review_notice' ] );
-		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
 		add_action( 'admin_notices', [ $this, 'edac_password_protected_notice' ] );
-		add_action( 'wp_ajax_edac_password_protected_notice_ajax', [ $this, 'edac_password_protected_notice_ajax' ] );
 	}
 
 	/**

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1110,6 +1110,9 @@
   }
 
   &-review {
+
+    font-weight: 600;
+
     &:after {
       content: " \f155\f155\f155\f155\f155";
       font-family: dashicons;

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1110,28 +1110,15 @@
   }
 
   &-review {
-    color: variables.$color-white;
-    font-weight: bold;
-    background-color: variables.$color-blue;
-    border: none;
-    border-radius: 5px;
-    padding: 3px 6px;
-
     &:after {
       content: " \f155\f155\f155\f155\f155";
       font-family: dashicons;
       position: relative;
       bottom: -1px;
       color: variables.$color-yellow;
-    }
-
-    &:hover {
-      background-color: #135e96;
+      font-size: 10px;
     }
   }
-
-  &-remind,
-  &-dismiss {}
 }
 
 .edac_gaad_notice,


### PR DESCRIPTION
This PR updates the styles on the buttons in the review plugin notice.

It also moves the ajax calls to a higher scope as a recent change that put them inside `in_admin_header` called them too late.

Before:
![Screenshot from 2025-02-03 18-34-27](https://github.com/user-attachments/assets/eccb053d-21d6-4305-81cb-658b866649f4)

After: 
![Screenshot from 2025-02-03 18-38-04](https://github.com/user-attachments/assets/443aa4b7-4a08-4e22-bc42-6bb0ec290662)

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled interactive dismissal of admin notifications using dynamic AJAX functionality.
- **Style**
	- Refined the appearance of review notices with updated typography and simplified visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->