### PR TITLE
updated: edac_validate to ensure dynamic blocks and oEmbeds are processed before validation

### DIFF
--- a/includes/validate.php
+++ b/includes/validate.php
@@ -130,6 +130,9 @@ function edac_validate( $post_ID, $post, $action ) {
 	 * @param string $action  The action being performed.
 	 */
 	do_action( 'edac_before_validate', $post_ID, $action );
+	
+	// Ensure dynamic blocks and oEmbeds are processed before validation.
+	$post->post_content = do_blocks( $post->post_content );
 
 	// apply filters to content.
 	$content = edac_get_content( $post );


### PR DESCRIPTION
This pull request includes a change to the `includes/validate.php` file to ensure dynamic blocks and oEmbeds are processed before validation.

* [`includes/validate.php`](diffhunk://#diff-760607d970915bf7ff29bded009e0d536ca564b33f09669b59db55860264f49bR134-R136): Added a call to `do_blocks` on `$post->post_content` in the `edac_validate` function to process dynamic blocks and oEmbeds before validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced content processing to render dynamic and embedded elements before final validation, ensuring that posts with rich media are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->