### PR TITLE
fixed: summary stat label pluralization

### DIFF
--- a/admin/class-welcome-page.php
+++ b/admin/class-welcome-page.php
@@ -86,7 +86,7 @@ class Welcome_Page {
 												_n(
 													'Unique Error',
 													'Unique Errors',
-													$summary['distinct_errors_without_contrast_formatted'],
+													$summary['distinct_errors_without_contrast'],
 													'accessibility-checker'
 												),
 												$summary['distinct_errors_without_contrast_formatted']
@@ -111,7 +111,7 @@ class Welcome_Page {
 												_n(
 													'Unique Color Contrast Error',
 													'Unique Color Contrast Errors',
-													$summary['distinct_contrast_errors_formatted'],
+													$summary['distinct_contrast_errors'],
 													'accessibility-checker'
 												),
 												$summary['distinct_contrast_errors_formatted']
@@ -136,7 +136,7 @@ class Welcome_Page {
 												_n(
 													'Unique Warning',
 													'Unique Warnings',
-													$summary['distinct_warnings_formatted'],
+													$summary['distinct_warnings'],
 													'accessibility-checker'
 												),
 												$summary['distinct_warnings_formatted']
@@ -161,7 +161,7 @@ class Welcome_Page {
 												_n(
 													'Ignored Item',
 													'Ignored Items',
-													$summary['distinct_ignored_formatted'],
+													$summary['distinct_ignored'],
 													'accessibility-checker'
 												),
 												$summary['distinct_ignored_formatted']


### PR DESCRIPTION
This pull request includes changes to the `admin/class-welcome-page.php` file, specifically in the `render_summary` method. The changes involve modifying the summary data keys to use unformatted versions for various summary stat labels.

Changes in `admin/class-welcome-page.php`:

* Updated the key for unique errors to use unformatted data (`$summary['distinct_errors_without_contrast']`).
* Updated the key for unique color contrast errors to use unformatted data (`$summary['distinct_contrast_errors']`).
* Updated the key for unique warnings to use unformatted data (`$summary['distinct_warnings']`).
* Updated the key for ignored items to use unformatted data (`$summary['distinct_ignored']`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of counts on the Welcome page by ensuring that errors, warnings, and ignored items now display the correct numerical values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->