### PR TITLE
updated: EDAC_Dom and missing_transcript to modify element output to ensure each unique element is stored

### DIFF
--- a/includes/classes/class-edac-dom.php
+++ b/includes/classes/class-edac-dom.php
@@ -91,7 +91,7 @@ class EDAC_Dom extends simple_html_dom {
 		}
 
 		foreach ( $elements as $element ) {
-			$element->innertext = '[' . $element->tag_start . '_ac_element]';
+			$element->outertext .= ' element:' . $element->tag_start;
 		}
 	}
 

--- a/includes/rules/missing_transcript.php
+++ b/includes/rules/missing_transcript.php
@@ -28,8 +28,7 @@ function edac_rule_missing_transcript( $content, $post ) { // phpcs:ignore -- $c
 	$dom->convert_tag_to_marker( [ 'img', 'iframe', 'audio', 'video', '.is-type-video' ] );
 	foreach ( $elements as $element ) {
 		if ( ! $dom->text_around_element_contains( $element, __( 'transcript', 'accessibility-checker' ), 25 ) ) {
-			$element->innertext = '';
-			$errors[]           = $element;
+			$errors[] = $element;
 		}
 	}
 	$linked_media = $dom->find_linked_media( true );


### PR DESCRIPTION
This pull request includes changes to the `class-edac-dom.php` and `missing_transcript.php` files to modify how elements are processed and marked up. The most important changes are:

Changes to element processing:

* [`includes/classes/class-edac-dom.php`](diffhunk://#diff-c2c3314a2f8cb405cbf69e4661e3ac3bae925040814dd9c7f938d7f3e46dca29L94-R94): Modified the `convert_tag_to_marker` function to append the tag start to the `outertext` of elements instead of replacing the `innertext`.

Changes to error handling:

* [`includes/rules/missing_transcript.php`](diffhunk://#diff-d807c192ab87cd50e7d51d39ab112f782439dfc9766838bba6925423cb8cf7c8L31): Removed the line that cleared the `innertext` of elements when a transcript is missing, ensuring the elements are preserved in the `$errors` array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated element content generation to append additional details for improved display output.
  - Modified transcript handling to retain existing text when transcript criteria are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->