### PR TITLE
Update the dist script to include version strings in the archive

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -20,37 +20,36 @@ while getopts ":-:" opt; do
   esac
 done
 
-# Ensure ./dist directory exists.
-#rm -frd ./dist
+# Ensure ./dist directory exists, if not create it
 mkdir -p ./dist
 
-# Run the wp script that produces the zip
+# Run the wp-scripts command that produces the zip
 npx wp-scripts plugin-zip
 
-# Always clear the dist/accessiblity-checker folder before unzipping
+# Always clear the dist/accessibility-checker folder before unzipping
 rm -rfd ./dist/accessibility-checker
 
-# unzip the zip into its own folder so we can zip that
+# Unzip the zip into its own folder so we can repackage with some changes
 unzip accessibility-checker.zip -d ./dist/accessibility-checker
 
-# plugin-zip includes package.json which is not needed for the plugin, so remove.
+# The plugin-zip commands includes package.json, which is not needed for the plugin, so remove it and the repo README
 rm ./dist/accessibility-checker/package.json
 rm ./dist/accessibility-checker/README.md
 
-# remove the unneeded (almost 1MB) tests folder for textstatistics package
+# Remove the unneeded (almost 1MB) tests folder for textstatistics package
 rm ./dist/accessibility-checker/vendor/davechild/textstatistics/tests -r
 
-#remove the original zip
+# Remove the original zip
 rm accessibility-checker.zip
 
-# get the digits at the end of the line starting with ' * Version:' from the main plugin file
+# Get the string at the end of the line starting with ' * Version:' from the main plugin file
 VERSION=$(grep " * Version:" ./dist/accessibility-checker/accessibility-checker.php | grep -o '[0-9.]*\(-[a-zA-Z0-9.]*\)*')
 
 # Move into the dist folder and zip the plugin's folder
 cd ./dist
 zip -r accessibility-checker-$VERSION.zip accessibility-checker
 
-#cleanup and drop back into the original dir
+# Drop back into the original dir
 cd ..
 
 # Skip this step if the 'keep-build-folder' flag is true

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -20,12 +20,15 @@ while getopts ":-:" opt; do
   esac
 done
 
-#Remove the contents of the dist folder
-rm -frd ./dist
-mkdir ./dist
+# Ensure ./dist directory exists.
+#rm -frd ./dist
+mkdir -p ./dist
 
-#Run the wp script that produces the zip
+# Run the wp script that produces the zip
 npx wp-scripts plugin-zip
+
+# Always clear the dist/accessiblity-checker folder before unzipping
+rm -rfd ./dist/accessibility-checker
 
 # unzip the zip into its own folder so we can zip that
 unzip accessibility-checker.zip -d ./dist/accessibility-checker
@@ -40,13 +43,17 @@ rm ./dist/accessibility-checker/vendor/davechild/textstatistics/tests -r
 #remove the original zip
 rm accessibility-checker.zip
 
-#move into the dist folder and zip the plugin's folder
+# get the digits at the end of the line starting with ' * Version:' from the main plugin file
+VERSION=$(grep " * Version:" ./dist/accessibility-checker/accessibility-checker.php | grep -o '[0-9.]*\(-[a-zA-Z0-9.]*\)*')
+
+# Move into the dist folder and zip the plugin's folder
 cd ./dist
-zip -r accessibility-checker.zip ./accessibility-checker
+zip -r accessibility-checker-$VERSION.zip accessibility-checker
 
 #cleanup and drop back into the original dir
+cd ..
+
 # Skip this step if the 'keep-build-folder' flag is true
 if [ "$KEEP_BUILD_FOLDER" = false ] ; then
-  rm -r ./accessibility-checker
+  rm -r ./dist/accessibility-checker
 fi
-cd ..


### PR DESCRIPTION
This change updates the dist script to put the version string in the archive name and no longer delete the directory before zipping. With this we can keep old versioned archives in the directory and keep better track of what archive version is what.

![Screenshot from 2025-02-05 18-50-38](https://github.com/user-attachments/assets/90cdf101-b61c-4d9d-b8d5-f8a62a4ec78d)

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the build process with improved directory handling and cleanup.
	- Introduced dynamic package naming that reflects the current version.
	- Refined deployment steps for greater reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->