### PR TITLE
Loosen up the gtm url check in iframe_missing_title check more

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Cache the Node.js modules to speed up the workflow.
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1089,7 +1089,8 @@ function edac_check_gtm_frame( $dom_element ) {
 
 	// GTM iframes should be skipped by the detection above, but just in case some plugin modifies the markup
 	// expectations let's double check the src attribute.
-	$gtm = preg_match( '/(^http(s)?:\/\/www.)?googletagmanager.com(\/)?/', $dom_element->getAttribute( 'src' ) );
+	$gtm = preg_match( '/^(https?:\/\/)?(www\.)?googletagmanager\.com(\/.*)?$/', $iframe->getAttribute( 'src' ) );
+
 	if ( $gtm ) {
 		return true;
 	}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1069,3 +1069,30 @@ function edac_check_if_post_id_is_woocommerce_checkout_page( $post_id ) {
 
 	return wc_get_page_id( 'checkout' ) === $post_id;
 }
+
+/**
+ * Checks the values from the iframe tag to see if it is hidden.
+ *
+ * @param simple_html_dom $dom_element The iframe element.
+ * @return bool - true if passing, false if failing.
+ */
+function edac_check_gtm_frame( $dom_element ) {
+	if ( ! $dom_element instanceof simple_html_dom ) {
+		// if we don't have an actual simple_html_dom element then assume pass.
+		return true;
+	}
+
+	$display_none_and_visibility_hidden = preg_match( '/(?=.*display\s*:\s*none);?(?=.*visibility\s*:\s*hidden)/is', $dom_element->getAttribute( 'style' ) );
+	if ( $display_none_and_visibility_hidden ) {
+		return true;
+	}
+
+	// GTM iframes should be skipped by the detection above, but just in case some plugin modifies the markup
+	// expectations let's double check the src attribute.
+	$gtm = preg_match( '/(^http(s)?:\/\/www.)?googletagmanager.com(\/)?/', $dom_element->getAttribute( 'src' ) );
+	if ( $gtm ) {
+		return true;
+	}
+
+	return false;
+}

--- a/includes/rules/iframe_missing_title.php
+++ b/includes/rules/iframe_missing_title.php
@@ -28,7 +28,7 @@ function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore -- 
 
 			// GTM iframes should be skipped by the detection above, but just in case some plugin modifies the markup
 			// expectations let's double check the src attribute.
-			$gtm = preg_match( '/^https:\/\/www.googletagmanager.com\//', $iframe->getAttribute( 'src' ) );
+			$gtm = preg_match( '/(^http(s)?:\/\/www.)?googletagmanager.com(\/)?/', $iframe->getAttribute( 'src' ) );
 			if ( $gtm ) {
 				continue;
 			}

--- a/includes/rules/iframe_missing_title.php
+++ b/includes/rules/iframe_missing_title.php
@@ -21,15 +21,8 @@ function edac_rule_iframe_missing_title( $content, $post ) { // phpcs:ignore -- 
 	foreach ( $iframe_tags as $iframe ) {
 		if ( isset( $iframe ) && empty( $iframe->getAttribute( 'title' ) ) && empty( $iframe->getAttribute( 'aria-label' ) ) ) {
 
-			$display_none_and_visibility_hidden = preg_match( '/(?=.*display\s*:\s*none);?(?=.*visibility\s*:\s*hidden)/is', $iframe->getAttribute( 'style' ) );
-			if ( $display_none_and_visibility_hidden ) {
-				continue;
-			}
-
-			// GTM iframes should be skipped by the detection above, but just in case some plugin modifies the markup
-			// expectations let's double check the src attribute.
-			$gtm = preg_match( '/(^http(s)?:\/\/www.)?googletagmanager.com(\/)?/', $iframe->getAttribute( 'src' ) );
-			if ( $gtm ) {
+			// If this is a gtm frame we should skip it.
+			if ( edac_check_gtm_frame( $iframe ) ) {
 				continue;
 			}
 

--- a/tests/phpunit/helper-functions/CheckGTMFrameTest.php
+++ b/tests/phpunit/helper-functions/CheckGTMFrameTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Test that the function properly checks and detects GTM iframes.
+ *
+ * @package Accessibility_Checker
+ */
+
+use simple_html_dom;
+
+/**
+ * Class CheckGTMFrameTest
+ */
+class CheckGTMFrameTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that the function returns true for a hidden iframe.
+	 */
+	public function testHiddenIframe() {
+		$iframe = new simple_html_dom();
+		$iframe->load( '<iframe style="display: none; visibility: hidden;"></iframe>' );
+		$this->assertTrue( edac_check_gtm_frame( $iframe->find( 'iframe', 0 ) ) );
+		// Most of the time the style is minified, dropping spaces and the final semi-colon.
+		$iframe->load( '<iframe style="display:none;visibility:hidden"></iframe>' );
+		$this->assertTrue( edac_check_gtm_frame( $iframe->find( 'iframe', 0 ) ) );
+	}
+
+	/**
+	 * Test that the function returns true for a GTM iframe.
+	 */
+	public function testGtmIframe() {
+		$iframe = new simple_html_dom();
+		$iframe->load( '<iframe src="https://www.googletagmanager.com"></iframe>' );
+		$this->assertTrue( edac_check_gtm_frame( $iframe->find( 'iframe', 0 ) ) );
+	}
+
+	/**
+	 * Test that the function returns false for a visible iframe.
+	 */
+	public function testVisibleIframe() {
+		$iframe = new simple_html_dom();
+		$iframe->load( '<iframe style="display: block;"></iframe>' );
+		$this->assertFalse( edac_check_gtm_frame( $iframe->find( 'iframe', 0 ) ) );
+	}
+
+	/**
+	 * Test that the function returns false for a non-GTM iframe with no styles.
+	 */
+	public function testNonGtmIframeNoStyles() {
+		$iframe = new simple_html_dom();
+		$iframe->load( '<iframe src="https://example.com"></iframe>' );
+		$this->assertFalse( edac_check_gtm_frame( $iframe->find( 'iframe', 0 ) ) );
+	}
+}


### PR DESCRIPTION
Another user has mentioned that they are still seeing issues flagged for a gtm snippet. I am not sure how that could happen however I have loosened up the src part of the check in the iframe_missing_title rule even more so that it would match someother potential url patterns for gtm.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to check iframe visibility, specifically for Google Tag Manager iframes.
  
- **Bug Fixes**
  - Enhanced tag integration handling to recognize a wider variety of URL formats for improved consistency when processing external tags.

- **Tests**
  - Added a new test class to validate the functionality of the iframe visibility check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->