### PR TITLE
Bump the actions/cache to v4 to avoid fails due to v2 deprecated

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Cache the Node.js modules to speed up the workflow.
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Bumps the action cache version to a non-deprecated version number (to latest). The workflow was failing before this change.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the internal caching mechanism used during our build process to the latest version, enhancing performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->