### PR TITLE
Parse block content through the_content instead of do_block directly and use a new WP_Post object

### DIFF
--- a/includes/validate.php
+++ b/includes/validate.php
@@ -130,9 +130,9 @@ function edac_validate( $post_ID, $post, $action ) {
 	 * @param string $action  The action being performed.
 	 */
 	do_action( 'edac_before_validate', $post_ID, $action );
-	
+
 	// Ensure dynamic blocks and oEmbeds are processed before validation.
-	$post->post_content = do_blocks( $post->post_content );
+	$post->post_content = apply_filters( 'the_content', $post->post_content );
 
 	// apply filters to content.
 	$content = edac_get_content( $post );

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -242,7 +242,7 @@ function edac_validate( $post_ID, $post, $action ) {
 	}
 
 	// remove corrected records.
-	edac_remove_corrected_posts( $post_ID, $post->post_type, $pre = 2, 'php' );
+	edac_remove_corrected_posts( $post_ID, $block_parsed_post->post_type, $pre = 2, 'php' );
 
 	// set post meta checked.
 	update_post_meta( $post_ID, '_edac_post_checked', true );

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -131,12 +131,15 @@ function edac_validate( $post_ID, $post, $action ) {
 	 */
 	do_action( 'edac_before_validate', $post_ID, $action );
 
+	// Make a new post object to avoid changing the original (which could come from global $post).
+	$block_parsed_post = new \WP_Post( (object) $post );
+
 	// Ensure dynamic blocks and oEmbeds are processed before validation.
 	// Use the_content filter to ensure do_block allows wpautop to be handled correctly for custom blocks. See https://github.com/equalizedigital/accessibility-checker/pull/862.
-	$post->post_content = apply_filters( 'the_content', $post->post_content );
+	$block_parsed_post->post_content = apply_filters( 'the_content', $post->post_content );
 
 	// apply filters to content.
-	$content = edac_get_content( $post );
+	$content = edac_get_content( $block_parsed_post );
 
 	/**
 	 * Allows to hook in after the content has been retrieved for a post.
@@ -194,7 +197,7 @@ function edac_validate( $post_ID, $post, $action ) {
 				if ( EDAC_DEBUG === true ) {
 					$rule_process_time = microtime( true );
 				}
-				$errors = call_user_func( 'edac_rule_' . $rule['slug'], $content, $post );
+				$errors = call_user_func( 'edac_rule_' . $rule['slug'], $content, $block_parsed_post );
 
 				if ( $errors && is_array( $errors ) ) {
 					/**

--- a/includes/validate.php
+++ b/includes/validate.php
@@ -132,6 +132,7 @@ function edac_validate( $post_ID, $post, $action ) {
 	do_action( 'edac_before_validate', $post_ID, $action );
 
 	// Ensure dynamic blocks and oEmbeds are processed before validation.
+	// Use the_content filter to ensure do_block allows wpautop to be handled correctly for custom blocks. See https://github.com/equalizedigital/accessibility-checker/pull/862.
 	$post->post_content = apply_filters( 'the_content', $post->post_content );
 
 	// apply filters to content.

--- a/tests/phpunit/includes/EdacValidateTest.php
+++ b/tests/phpunit/includes/EdacValidateTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Test class for edac_validate function.
+ *
+ * @package accessibility-checker
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for edac_validate function.
+ */
+class EdacValidateTest extends TestCase {
+
+	/**
+	 * Test that the_content filter is properly applied during validation.
+	 */
+	public function test_validation_applies_the_content_filter() {
+		// Setup a test post with content that requires the_content processing.
+		$post_id = $this->factory->post->create(
+			[
+				'post_content' => '<!-- wp:paragraph --><p>Test content</p><!-- /wp:paragraph -->',
+			]
+		);
+		$post    = get_post( $post_id );
+
+		// Mock the_content filter to verify it's called.
+		add_filter(
+			'the_content',
+			function ( $content ) {
+				$this->content_filter_called = true;
+				return $content;
+			}
+		);
+
+		// Run validation.
+		edac_validate( $post_id, $post, 'test' );
+
+		// Assert that the_content filter was called.
+		$this->assertTrue( $this->content_filter_called );
+	}
+}

--- a/tests/phpunit/includes/EdacValidateTest.php
+++ b/tests/phpunit/includes/EdacValidateTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test class for edac_validate function.
  */
-class EdacValidateTest extends TestCase {
+class EdacValidateTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that the_content filter is properly applied during validation.


### PR DESCRIPTION
Avoid running do_block directly on the $post->post_content (this can sometimes be the global $post object).

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved the validation process to preserve the integrity of the original post data while enhancing content handling for custom blocks.

- **Tests**
  - Introduced a new test class to validate the functionality of the updated validation process, ensuring proper application of content filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->