### PR TITLE
Add some extra code to shift focus in the skip link fix

### DIFF
--- a/src/frontendFixes/Fixes/skipLinkFix.js
+++ b/src/frontendFixes/Fixes/skipLinkFix.js
@@ -28,6 +28,23 @@ const tryDetectSkipLink = () => {
 	return false;
 };
 
+function handleSkipLinkFocusShift( foundMainTarget, skipLink ) {
+	const skipLinkTargetEl = document.querySelector( foundMainTarget );
+	if ( ! skipLinkTargetEl ) {
+		return;
+	}
+
+	// Make sure the target is focusable so we can move focus to it. Needed for some browsers.
+	skipLinkTargetEl.setAttribute( 'tabindex', '0' );
+	// Bind to the click (also cover keyboard enter) event to move focus to the target.
+	skipLink.querySelector( '.edac-skip-link--content' ).addEventListener( 'click', () => {
+		// Make the history reflect the move.
+		history.pushState( {}, '', foundMainTarget );
+		// Focus on the target element.
+		skipLinkTargetEl.focus();
+	} );
+}
+
 const SkipLinkFixInit = () => {
 	const skipLinkTemplate = document.getElementById( 'skip-link-template' );
 	if ( ! skipLinkTemplate ) {
@@ -56,6 +73,9 @@ const SkipLinkFixInit = () => {
 	// set the href to the first target if found or remove it if not.
 	if ( foundMainTarget ) {
 		skipLink.querySelector( '.edac-skip-link--content' ).href = foundMainTarget;
+		// To override any bad programatic smooth scroll or focus override manually
+		// move the focus and update history.
+		handleSkipLinkFocusShift( foundMainTarget, skipLink );
 	} else {
 		skipLink.querySelector( '.edac-skip-link--content' ).remove();
 	}


### PR DESCRIPTION
This is to override bad smooth scroll implementations found on some sites which block the focus shifting so here a manual focus shift is added to combat that

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
