### PR TITLE
Make the metaViewport check also match a `0` value as well as `no`

### DIFF
--- a/src/frontendFixes/Fixes/metaViewportScalableFix.js
+++ b/src/frontendFixes/Fixes/metaViewportScalableFix.js
@@ -10,8 +10,8 @@ const MetaViewportScalableFix = () => {
 	// Get the meta viewport tag.
 	const metaViewport = document.querySelector( 'meta[name="viewport"]' );
 	if ( metaViewport ) {
-		// check if it has scalable set to no.
-		if ( ! metaViewport.content.includes( 'user-scalable=no' ) ) {
+		// check if it has scalable set to no or 0.
+		if ( ! metaViewport.content.match( /user\-scalable\s*=\s*(no|0)/ ) ) {
 			return;
 		}
 		// remove the meta viewport tag as it blocks scaling.

--- a/src/frontendFixes/Fixes/metaViewportScalableFix.js
+++ b/src/frontendFixes/Fixes/metaViewportScalableFix.js
@@ -11,7 +11,7 @@ const MetaViewportScalableFix = () => {
 	const metaViewport = document.querySelector( 'meta[name="viewport"]' );
 	if ( metaViewport ) {
 		// check if it has scalable set to no or 0.
-		if ( ! metaViewport.content.match( /user\-scalable\s*=\s*(no|0)/ ) ) {
+		if ( ! metaViewport.content.match( /user\-scalable\s*=\s*(no|0)/i ) ) {
 			return;
 		}
 		// remove the meta viewport tag as it blocks scaling.


### PR DESCRIPTION
Also make the check more robust and handle possible spaces between the definition and the value.


One half of solve for #871 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved viewport scaling detection for more consistent behavior across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->