### PR TITLE
🧠 Add accessibility test case markup prompt

### DIFF
--- a/.github/prompts/test-markup.prompt.md
+++ b/.github/prompts/test-markup.prompt.md
@@ -13,7 +13,7 @@ Please follow these guidelines:
 
 3. **Wrap the test markup inside a Gutenberg HTML block**:
    - Enclose each example in `<!-- wp:html -->` and `<!-- /wp:html -->` so it’s valid in Code Editor mode.
-   - Do **not** modify the test markup—output it exactly as provided.
+   - Do **not** modify the test markup—output it exactly as provided, except add the required `data-test-name` attribute for failing cases as specified in step 4.
 
 4. **Add a unique `data-test-name` attribute**:
    - For any element in the failing test case that will be flagged in a scan, add a `data-test-name="..."` attribute, using the test name or a simplified identifier.

--- a/.github/prompts/test-markup.prompt.md
+++ b/.github/prompts/test-markup.prompt.md
@@ -11,8 +11,8 @@ Please follow these guidelines:
    - Add an `<h2>` heading titled "Failing Tests" above the failing block markup.
    - Each test case should have its name included as an `<h3>` heading above it.
 
-3. **Wrap the test markup inside an `HTML` block**:
-   - Each test’s example markup should be wrapped using the Gutenberg HTML block format.
+3. **Wrap the test markup inside a Gutenberg HTML block**:
+   - Enclose each example in `<!-- wp:html -->` and `<!-- /wp:html -->` so it’s valid in Code Editor mode.
    - Do **not** modify the test markup—output it exactly as provided.
 
 4. **Add a unique `data-test-name` attribute**:

--- a/.github/prompts/test-markup.prompt.md
+++ b/.github/prompts/test-markup.prompt.md
@@ -1,0 +1,26 @@
+I have a set of accessibility test cases. Can you generate WordPress block editor markup that I can paste into the editor which matches all these test cases?
+
+Please follow these guidelines:
+
+1. **Separate the test cases into two sections**:
+   - One for tests expected to **pass**
+   - One for tests expected to **fail**
+
+2. **Use proper HTML hierarchy**:
+   - Add an `<h2>` heading titled "Passing Tests" above the passing block markup.
+   - Add an `<h2>` heading titled "Failing Tests" above the failing block markup.
+   - Each test case should have its name included as an `<h3>` heading above it.
+
+3. **Wrap the test markup inside an `HTML` block**:
+   - Each test’s example markup should be wrapped using the Gutenberg HTML block format.
+   - Do **not** modify the test markup—output it exactly as provided.
+
+4. **Add a unique `data-test-name` attribute**:
+   - For any element in the failing test case that will be flagged in a scan, add a `data-test-name="..."` attribute, using the test name or a simplified identifier.
+   - This helps ensure the issue is clearly identifiable.
+
+5. **Output only valid WordPress block markup**:
+   - Structure it so I can copy and paste it directly into the block editor in "Code Editor" mode.
+
+Optional:
+- If possible, at the end of the output, summarize how many failing cases there are.


### PR DESCRIPTION
This pull request introduces a new prompt file for generating WordPress block editor markup tailored to accessibility test cases. The prompt provides detailed guidelines for structuring the markup and ensuring it adheres to accessibility and WordPress standards.

### Added prompt for accessibility test markup generation:

* [`.github/prompts/test-markup.prompt.md`](diffhunk://#diff-45a52ab9f75ae0caba7b250948bbe30104a747457bcdd1b4bcf87f52afee74b3R1-R26): Added a detailed prompt instructing how to generate WordPress block editor markup for accessibility test cases. The guidelines include separating tests into "Passing" and "Failing" sections, using proper HTML hierarchy, wrapping markup in Gutenberg HTML blocks, adding a `data-test-name` attribute for failing cases, and ensuring valid WordPress block markup. An optional summary of failing cases is also suggested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new prompt file with instructions for generating accessible WordPress block editor markup based on test cases, including guidelines for organizing passing and failing tests and ensuring valid output for the block editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->