### PR TITLE
Swap to using graphql for getting meetup events data to display

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -517,7 +517,7 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 	}
 
 	// Min of 1 and max of 25.
-	$count = absint( min( 1, max( 25, $count ) ) );
+	$count = absint( max( 1, min( 25, $count ) ) );
 
 	$key    = '_upcoming_meetups__' . sanitize_title( $meetup ) . '__' . (int) $count;
 	$output = get_transient( $key );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -512,25 +512,77 @@ function edac_is_valid_nonce( $secret, $nonce ) {
  */
 function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 
-	$key    = 'upcoming_meetups__' . sanitize_title( $meetup ) . '__' . (int) $count;
+	if ( empty( $meetup ) || ! is_string( $meetup ) ) {
+		return;
+	}
+
+	// Min of 1 and max of 25.
+	$count = absint( min( 1, max( 25, $count ) ) );
+
+	$key    = '_upcoming_meetups__' . sanitize_title( $meetup ) . '__' . (int) $count;
 	$output = get_transient( $key );
 
 	if ( false === $output ) {
+		$request_uri = 'https://api.meetup.com/gql-ext';
+		$query       = '
+		query Group {
+			groupByUrlname(urlname: "' . (string) $meetup . '") {
+				events(first: ' . (int) $count . ') {
+					totalCount
+					edges {
+						node {
+							dateTime
+							eventUrl
+							id
+							title
+						}
+					}
+				}
+			}
+		}';
 
-		$query_args = [
-			'sign'       => 'true',
-			'photo-host' => 'public',
-			'page'       => (int) $count,
-		];
-
-		$request_uri = 'https://api.meetup.com/' . sanitize_title( $meetup ) . '/events';
-		$request     = wp_remote_get( add_query_arg( $query_args, $request_uri ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get -- wp_remote_get needed to be compatible with all environments.
+		// Make POST request with the GraphQL query.
+		$request = wp_remote_post(
+			$request_uri,
+			[
+				'headers' => [
+					'Content-Type' => 'application/json',
+				],
+				'body'    => wp_json_encode(
+					[
+						'query' => $query,
+					]
+				),
+			]
+		);
 
 		if ( is_wp_error( $request ) || 200 !== (int) wp_remote_retrieve_response_code( $request ) ) {
 			return;
 		}
 
-		$output = json_decode( wp_remote_retrieve_body( $request ) );
+		$response_body = json_decode( wp_remote_retrieve_body( $request ) );
+
+		// Return early if we don't have the expected data.
+		if ( empty( $response_body ) || ! isset( $response_body->data->groupByUrlname->events->edges ) ) {
+			return;
+		}
+
+		// Transform the GraphQL response to match the format expected from old rest response.
+		$output = [];
+		foreach ( $response_body->data->groupByUrlname->events->edges as $edge ) {
+			$event = $edge->node;
+
+			// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL response uses camelCase.
+			$event_data       = new stdClass();
+			$event_data->name = $event->title;
+			$event_data->time = strtotime( $event->dateTime ) * 1000; // Convert to milliseconds to match old format.
+			$event_data->link = $event->eventUrl;
+			$event_data->id   = $event->id;
+			// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase.
+
+			$output[] = $event_data;
+		}
+
 		if ( empty( $output ) ) {
 			return;
 		}
@@ -540,7 +592,6 @@ function edac_get_upcoming_meetups_json( $meetup, $count = 5 ) {
 
 	return $output;
 }
-
 
 /**
  * Upcoming meetups in html


### PR DESCRIPTION
Swaps the code that was making a call to the old rest api for meetups to use the new graphql query for events. It includes a transform to keep the shape of the stored response data the same as it was for the request request to avoid needing to refactor anywhere else outside of the one function.

[PRO-67]

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes

Fixes: #937 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability and accuracy of upcoming Meetup event listings by enhancing how events are retrieved and validated.
- **Performance**
	- Optimized event data fetching and caching for faster and more consistent loading of upcoming Meetup events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->