### PR TITLE
In lint-js workflow scan changed files in PR and all files when not a PR

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -41,17 +41,23 @@ jobs:
       - name: 'Install NPM packages'
         run: npm install --ignore-scripts
 
-      - name: Get changed files
+      - name: Get only files changed in this PR
         id: changed-files
         uses: actions/github-script@v6
         with:
           script: |
+            if (!context.payload.pull_request) {
+              core.warning("No pull request context available. Skipping changed files retrieval.");
+              core.setOutput('files', '');
+              return '';
+            }
+
             const changedFiles = await github.paginate(
               github.rest.pulls.listFiles,
               {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request?.number,
+                pull_number: context.payload.pull_request.number,
               }
             );
             const jsFiles = changedFiles
@@ -62,6 +68,8 @@ jobs:
             core.setOutput('files', jsFiles);
             return jsFiles;
 
-      - name: Run eslint on changed files
-        if: ${{ steps.changed-files.outputs.files != '' }}
-        run: npx wp-scripts lint-js ${{ steps.changed-files.outputs.files }}
+      # If this is a PR then lint only js changed in the PR, if not a PR then lint them all.
+      - name: Run eslint
+        run: npx wp-scripts lint-js ${{ steps.changed-files.outputs.files || '' }}
+
+


### PR DESCRIPTION
The lint-js workflow was recently changed to get it working again on changed files, and it does work on PRs. But the changes did not work correctly for merges that were not PRs. This updates the workflow file to run against changed js files when in a PR and against all JS files when not a PR.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
