### PR TITLE
Update exclusion list in scan context to exclude #qm-icon-container

### DIFF
--- a/src/pageScanner/config/exclusions.js
+++ b/src/pageScanner/config/exclusions.js
@@ -1,0 +1,8 @@
+
+// Define the list of exclusions for accessibility scans.
+export const exclusionsArray = [
+	'#wpadminbar',
+	'.edac-panel-container',
+	'#query-monitor-main',
+	'#qm-icon-container',
+];

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -4,7 +4,8 @@
 import 'axe-core';
 import { rulesArray, checksArray, standardRuleIdsArray, customRuleIdsArray } from './config/rules';
 import { exclusionsArray } from './config/exclusions';
-import imgAnimated, { preScanAnimatedImages } from './config/animatedImages';
+import imgAnimated from './rules/img-animated';
+import { preScanAnimatedImages } from './checks/img-animated-check';
 
 const SCAN_TIMEOUT_IN_SECONDS = 30;
 

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -3,6 +3,7 @@
 
 import 'axe-core';
 import { rulesArray, checksArray, standardRuleIdsArray, customRuleIdsArray } from './config/rules';
+import { exclusionsArray } from './config/exclusions';
 import imgAnimated, { preScanAnimatedImages } from './config/animatedImages';
 
 const SCAN_TIMEOUT_IN_SECONDS = 30;
@@ -16,7 +17,7 @@ const postId = body.getAttribute( 'data-iframe-post-id' );
 const scan = async (
 	options = { configOptions: {}, runOptions: {} }
 ) => {
-	const context = { exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ] };
+	const context = { exclude: exclusionsArray };
 
 	const defaults = {
 		configOptions: {

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -16,7 +16,7 @@ const postId = body.getAttribute( 'data-iframe-post-id' );
 const scan = async (
 	options = { configOptions: {}, runOptions: {} }
 ) => {
-	const context = { exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main' ] };
+	const context = { exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ] };
 
 	const defaults = {
 		configOptions: {

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -7,6 +7,7 @@
  * #qm-icon-container selector.
  */
 import axe from 'axe-core';
+import { exclusionsArray } from '../../../../src/pageScanner/config/exclusions';
 
 describe( 'Scanner Context Exclusions', ( ) => {
 	beforeEach( ( ) => {
@@ -38,7 +39,7 @@ describe( 'Scanner Context Exclusions', ( ) => {
 
 		// Define context with exclude list matching src/pageScanner/index.js
 		const context = {
-			exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ],
+			exclude: exclusionsArray,
 		};
 
 		// Run axe with button-name rule to detect empty buttons

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -1,62 +1,63 @@
+
 /**
  * Test for scanner context exclusions
- * 
+ *
  * This test verifies that elements with the selectors in the exclude array
  * are properly excluded from accessibility scans, including the newly added
  * #qm-icon-container selector.
  */
 import axe from 'axe-core';
 
-describe('Scanner Context Exclusions', () => {
-  beforeEach(() => {
-    // Reset the DOM before each test
-    document.body.innerHTML = '';
-  });
+describe( 'Scanner Context Exclusions', ( ) => {
+	beforeEach( ( ) => {
+		// Reset the DOM before each test
+		document.body.innerHTML = '';
+	} );
 
-  test('should exclude #qm-icon-container from scan', async () => {
-    // Create test HTML with empty buttons (accessibility violation)
-    // Some in regular content, others in containers that should be excluded
-    document.body.innerHTML = `
-      &lt;!-- Control button that should be scanned --&gt;
-      <button id="control-button"></button>
-      
-      &lt;!-- Containers that should be excluded from scan --&gt;
-      <div id="qm-icon-container">
-        <button id="qm-icon-button"></button>
-      </div>
-      <div id="wpadminbar">
-        <button id="wpadminbar-button"></button>
-      </div>
-      <div id="query-monitor-main">
-        <button id="query-monitor-button"></button>
-      </div>
-      <div class="edac-panel-container">
-        <button id="edac-panel-button"></button>
-      </div>
-    `;
+	test( 'should exclude #qm-icon-container from scan', async ( ) => {
+		// Create test HTML with empty buttons (accessibility violation)
+		// Some in regular content, others in containers that should be excluded
+		document.body.innerHTML = `
+			<!-- Control button that should be scanned -->
+			<button id="control-button"></button>
 
-    // Define context with exclude list matching src/pageScanner/index.js
-    const context = { 
-      exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ] 
-    };
+			<!-- Containers that should be excluded from scan -->
+			<div id="qm-icon-container">
+				<button id="qm-icon-button"></button>
+			</div>
+			<div id="wpadminbar">
+				<button id="wpadminbar-button"></button>
+			</div>
+			<div id="query-monitor-main">
+				<button id="query-monitor-button"></button>
+			</div>
+			<div class="edac-panel-container">
+				<button id="edac-panel-button"></button>
+			</div>
+		`;
 
-    // Run axe with button-name rule to detect empty buttons
-    const results = await axe.run(context, {
-      runOnly: ['button-name']
-    });
+		// Define context with exclude list matching src/pageScanner/index.js
+		const context = {
+			exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ]
+		};
 
-    // Get all HTML from the violation nodes
-    const violationHTML = results.violations
-      .flatMap(violation => violation.nodes)
-      .map(node => node.html);
+		// Run axe with button-name rule to detect empty buttons
+		const results = await axe.run( context, {
+			runOnly: [ 'button-name' ]
+		} );
 
-    // Control button should appear in violations
-    expect(violationHTML.some(html => html.includes('id="control-button"'))).toBe(true);
-    
-    // Buttons in excluded containers should not appear in violations
-    expect(violationHTML.some(html => html.includes('id="qm-icon-button"'))).toBe(false);
-    expect(violationHTML.some(html => html.includes('id="wpadminbar-button"'))).toBe(false);
-    expect(violationHTML.some(html => html.includes('id="query-monitor-button"'))).toBe(false);
-    expect(violationHTML.some(html => html.includes('id="edac-panel-button"'))).toBe(false);
-  });
-});
+		// Get all HTML from the violation nodes
+		const violationHTML = results.violations
+			.flatMap( ( violation ) => violation.nodes )
+			.map( ( node ) => node.html );
+
+		// Control button should appear in violations
+		expect( violationHTML.some( ( html ) => html.includes( 'id="control-button"' ) ) ).toBe( true );
+
+		// Buttons in excluded containers should not appear in violations
+		expect( violationHTML.some( ( html ) => html.includes( 'id="qm-icon-button"' ) ) ).toBe( false );
+		expect( violationHTML.some( ( html ) => html.includes( 'id="wpadminbar-button"' ) ) ).toBe( false );
+		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-button"' ) ) ).toBe( false );
+		expect( violationHTML.some( ( html ) => html.includes( 'id="edac-panel-button"' ) ) ).toBe( false );
+	} );
+} );

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -7,7 +7,7 @@
  * #qm-icon-container selector.
  */
 import axe from 'axe-core';
-import { exclusionsArray } from '../../../../src/pageScanner/config/exclusions';
+import { exclusionsArray } from '../../../src/pageScanner/config/exclusions';
 
 describe( 'Scanner Context Exclusions', ( ) => {
 	beforeEach( ( ) => {

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -1,0 +1,62 @@
+/**
+ * Test for scanner context exclusions
+ * 
+ * This test verifies that elements with the selectors in the exclude array
+ * are properly excluded from accessibility scans, including the newly added
+ * #qm-icon-container selector.
+ */
+import axe from 'axe-core';
+
+describe('Scanner Context Exclusions', () => {
+  beforeEach(() => {
+    // Reset the DOM before each test
+    document.body.innerHTML = '';
+  });
+
+  test('should exclude #qm-icon-container from scan', async () => {
+    // Create test HTML with empty buttons (accessibility violation)
+    // Some in regular content, others in containers that should be excluded
+    document.body.innerHTML = `
+      &lt;!-- Control button that should be scanned --&gt;
+      <button id="control-button"></button>
+      
+      &lt;!-- Containers that should be excluded from scan --&gt;
+      <div id="qm-icon-container">
+        <button id="qm-icon-button"></button>
+      </div>
+      <div id="wpadminbar">
+        <button id="wpadminbar-button"></button>
+      </div>
+      <div id="query-monitor-main">
+        <button id="query-monitor-button"></button>
+      </div>
+      <div class="edac-panel-container">
+        <button id="edac-panel-button"></button>
+      </div>
+    `;
+
+    // Define context with exclude list matching src/pageScanner/index.js
+    const context = { 
+      exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ] 
+    };
+
+    // Run axe with button-name rule to detect empty buttons
+    const results = await axe.run(context, {
+      runOnly: ['button-name']
+    });
+
+    // Get all HTML from the violation nodes
+    const violationHTML = results.violations
+      .flatMap(violation => violation.nodes)
+      .map(node => node.html);
+
+    // Control button should appear in violations
+    expect(violationHTML.some(html => html.includes('id="control-button"'))).toBe(true);
+    
+    // Buttons in excluded containers should not appear in violations
+    expect(violationHTML.some(html => html.includes('id="qm-icon-button"'))).toBe(false);
+    expect(violationHTML.some(html => html.includes('id="wpadminbar-button"'))).toBe(false);
+    expect(violationHTML.some(html => html.includes('id="query-monitor-button"'))).toBe(false);
+    expect(violationHTML.some(html => html.includes('id="edac-panel-button"'))).toBe(false);
+  });
+});

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -38,12 +38,12 @@ describe( 'Scanner Context Exclusions', ( ) => {
 
 		// Define context with exclude list matching src/pageScanner/index.js
 		const context = {
-			exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ]
+			exclude: [ '#wpadminbar', '.edac-panel-container', '#query-monitor-main', '#qm-icon-container' ],
 		};
 
 		// Run axe with button-name rule to detect empty buttons
 		const results = await axe.run( context, {
-			runOnly: [ 'button-name' ]
+			runOnly: [ 'button-name' ],
 		} );
 
 		// Get all HTML from the violation nodes

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -15,7 +15,7 @@ describe( 'Scanner Context Exclusions', ( ) => {
 		document.body.innerHTML = '';
 	} );
 
-	test( 'should exclude #qm-icon-container from scan', async ( ) => {
+	test( 'should exclude configured containers from scan', async ( ) => {
 		// Create test HTML with empty buttons (accessibility violation)
 		// Some in regular content, others in containers that should be excluded
 		document.body.innerHTML = `


### PR DESCRIPTION
This pull request makes a small update to the `src/pageScanner/index.js` file to expand the list of elements excluded from the scanning context.

* [`src/pageScanner/index.js`](diffhunk://#diff-dfb86049e76745f75b4b756a00137c09d0ea1b1bb7bd8d3db94e8c5f38728c10L19-R19): Added `#qm-icon-container` to the `exclude` array in the `context` object to prevent this element from being included in the scan.

<!-- Always provide a short description -->

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated accessibility scanning to exclude additional interface elements from checks, refining the scope of accessibility reports.  
- **Tests**
  - Added tests to verify that specific interface elements are properly excluded from accessibility scans, ensuring accurate detection of accessibility issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->