### PR TITLE
updated: heading validation to account for aria-hidden content

### DIFF
--- a/src/pageScanner/checks/heading-is-empty.js
+++ b/src/pageScanner/checks/heading-is-empty.js
@@ -1,8 +1,25 @@
 export default {
 	id: 'heading_is_empty',
 	evaluate( node ) {
+		// Get all aria-hidden elements
+		const hiddenElements = node.querySelectorAll( '[aria-hidden="true"]' );
+
+		// Clone node to work with
+		const clone = node.cloneNode( true );
+
+		// Remove aria-hidden elements from clone
+		hiddenElements.forEach( ( el ) => {
+			const elementToRemove = Array.from( clone.querySelectorAll( '*' ) ).find( ( cloneEl ) =>
+				// Find the corresponding element in the clone by comparing content and structure
+				cloneEl.isEqualNode( el )
+			);
+			if ( elementToRemove ) {
+				elementToRemove.remove();
+			}
+		} );
+
 		// Check for visible text content (excluding just whitespace, hyphens, underscores)
-		const headingText = node.textContent.trim();
+		const headingText = clone.textContent.trim();
 		const hasValidText = headingText && ! /^[-_\s]*$/.test( headingText );
 
 		// Check for aria-label

--- a/tests/jest/rules/emptyHeading.test.js
+++ b/tests/jest/rules/emptyHeading.test.js
@@ -76,6 +76,11 @@ describe( 'Empty Heading Validation', () => {
 			html: '<span id="label-text">Hidden Title</span><h1 aria-labelledby="label-text"></h1>',
 			shouldPass: true,
 		},
+		{
+			name: 'should pass when heading has both visible and aria-hidden content',
+			html: '<h4>Visible Content<span aria-hidden="true">Hidden Part</span></h4>',
+			shouldPass: true,
+		},
 		// Edge cases
 		{
 			name: 'should pass when heading contains only punctuation',
@@ -157,6 +162,21 @@ describe( 'Empty Heading Validation', () => {
 		{
 			name: 'should fail for heading with aria-labelledby referencing empty element',
 			html: '<span id="empty-label"></span><h1 aria-labelledby="empty-label"></h1>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail when heading content is all aria-hidden',
+			html: '<h1><span aria-hidden="true">Hidden Content</span></h1>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail when heading has multiple aria-hidden elements',
+			html: '<h2><span aria-hidden="true">First</span><div aria-hidden="true">Second</div></h2>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail when heading has nested aria-hidden content',
+			html: '<h3><div aria-hidden="true"><span>Nested Hidden Content</span></div></h3>',
 			shouldPass: false,
 		},
 		// Edge cases

--- a/tests/jest/rules/emptyHeading.test.js
+++ b/tests/jest/rules/emptyHeading.test.js
@@ -81,6 +81,11 @@ describe( 'Empty Heading Validation', () => {
 			html: '<h4>Visible Content<span aria-hidden="true">Hidden Part</span></h4>',
 			shouldPass: true,
 		},
+		{
+			name: 'should pass with interleaved visible and aria-hidden content',
+			html: '<h1>Start <span aria-hidden="true">Hidden</span> Middle <span aria-hidden="true">Hidden Again</span> End</h1>',
+			shouldPass: true,
+		},
 		// Edge cases
 		{
 			name: 'should pass when heading contains only punctuation',


### PR DESCRIPTION
This pull request enhances the empty heading validation logic by ensuring that `aria-hidden` elements are excluded from the text content evaluation. It also expands the test coverage to include cases involving `aria-hidden` elements. The most important changes are as follows:

### Improvements to empty heading validation logic:

* Updated `src/pageScanner/checks/heading-is-empty.js` to clone the heading node, remove all `aria-hidden` elements from the clone, and evaluate the visible text content from the modified clone. This ensures that hidden elements do not affect the validation.

### Expanded test coverage:

* Added a test case to verify that a heading with both visible and `aria-hidden` content passes validation.
* Added multiple test cases to ensure that headings fail validation when their content is entirely `aria-hidden`, includes multiple `aria-hidden` elements, or contains nested `aria-hidden` content.

Fixes #954 

![Screenshot 2025-05-02 at 11 36 13 AM](https://github.com/user-attachments/assets/afbdd907-7805-4aa5-92b3-c20b53ca48d4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved heading validation to ignore content inside elements marked as aria-hidden, ensuring only visible text is considered.
- **Tests**
	- Added new test cases to verify correct handling of headings containing aria-hidden content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->