### PR TITLE
Fixed empty button check to exclude aria-hidden

### DIFF
--- a/src/pageScanner/checks/button-is-empty.js
+++ b/src/pageScanner/checks/button-is-empty.js
@@ -6,9 +6,9 @@ export default {
 			const hiddenTexts = [];
 
 			// Get aria-hidden content
-			element.querySelectorAll( '[aria-hidden="true"]' ).forEach( ( el ) =>
-				hiddenTexts.push( el.textContent )
-			);
+			element.querySelectorAll( '[aria-hidden="true"]' ).forEach( ( el ) => {
+				hiddenTexts.push( el.cloneNode( true ).textContent );
+			} );
 
 			// Get visually hidden content
 			Array.from( element.getElementsByTagName( '*' ) ).forEach( ( el ) => {

--- a/src/pageScanner/checks/button-is-empty.js
+++ b/src/pageScanner/checks/button-is-empty.js
@@ -1,9 +1,34 @@
 export default {
 	id: 'button_is_empty',
 	evaluate( node ) {
-		// Check for visible text content
-		const textContent = node.textContent.trim();
-		// if we have text content
+		// Get all aria-hidden and visually hidden elements
+		const getVisibleTextContent = ( element ) => {
+			const hiddenTexts = [];
+
+			// Get aria-hidden content
+			element.querySelectorAll( '[aria-hidden="true"]' ).forEach( ( el ) =>
+				hiddenTexts.push( el.textContent )
+			);
+
+			// Get visually hidden content
+			Array.from( element.getElementsByTagName( '*' ) ).forEach( ( el ) => {
+				const style = window.getComputedStyle( el );
+				if ( style.display === 'none' || style.visibility === 'hidden' ) {
+					hiddenTexts.push( el.textContent );
+				}
+			} );
+
+			// Remove all hidden content from text
+			let text = element.textContent;
+			hiddenTexts.forEach( ( hiddenText ) => {
+				text = text.replace( hiddenText, '' );
+			} );
+
+			return text.trim();
+		};
+
+		// Check for visible text content (excluding hidden content)
+		const textContent = getVisibleTextContent( node );
 		if ( textContent && textContent.length > 0 ) {
 			return false;
 		}

--- a/tests/jest/rules/emptyButton.test.js
+++ b/tests/jest/rules/emptyButton.test.js
@@ -205,6 +205,21 @@ describe( 'Empty Button Validation', () => {
 			html: '<span id="empty-desc1"></span><span id="empty-desc2">   </span><button aria-describedby="empty-desc1 empty-desc2"></button>',
 			shouldPass: false,
 		},
+		{
+			name: 'should fail for button with only aria-hidden content',
+			html: '<button><span aria-hidden="true">X</span></button>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for button with only visually hidden content and unlabeled icon',
+			html: '<button><span style="display: none;">Menu</span><i class="fas fa-bars"></i></button>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for button with only visibility:hidden content and unlabeled icon',
+			html: '<button><span style="visibility: hidden;">Close</span><i class="fas fa-times"></i></button>',
+			shouldPass: false,
+		},
 	];
 
 	testCases.forEach( ( testCase ) => {


### PR DESCRIPTION
This pull request enhances the `button_is_empty` accessibility check by improving how visible text content is determined and updates the corresponding test cases to cover new scenarios. The key changes include introducing logic to exclude hidden content when evaluating button text and expanding test coverage for edge cases.

### Improvements to `button_is_empty` check:

* [`src/pageScanner/checks/button-is-empty.js`](diffhunk://#diff-633a0afe57d72d359207954f7f7d48a0c43037bd45a687d72c8553f5ad93a819L4-R31): Replaced the previous text content evaluation logic with a new `getVisibleTextContent` function. This function removes text from elements that are either `aria-hidden` or visually hidden (e.g., `display: none` or `visibility: hidden`) before determining if a button is empty.

### Expanded test coverage:

* [`tests/jest/rules/emptyButton.test.js`](diffhunk://#diff-74d91bd2772ab1429c208d0b6065d3c605bb588f1e703f73dffab3ed84c7b75fR208-R222): Added new test cases to validate buttons containing only hidden content, including `aria-hidden` spans and visually hidden elements (e.g., `display: none`, `visibility: hidden`). These tests ensure that such buttons are correctly flagged as failing the `button_is_empty` rule.

Fixes #952

![Screenshot 2025-05-02 at 12 46 55 PM](https://github.com/user-attachments/assets/fa1d198f-a64c-4d9a-a19a-98a55abad791)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of empty buttons by excluding hidden or inaccessible text from accessibility checks.

- **Tests**
  - Added test cases to ensure buttons with only hidden or inaccessible content are flagged as empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->