### PR TITLE
updated: add fallback for str_get_html function with deprecation notice

### DIFF
--- a/includes/classes/class-dom-wrapper.php
+++ b/includes/classes/class-dom-wrapper.php
@@ -1,8 +1,11 @@
 <?php
 /**
- * DOM Wrapper class to provide Simple HTML DOM compatibility
+ * DOM Wrapper class to provide Simple HTML DOM compatibility.
+ *
+ * This class serves as a wrapper to enhance compatibility with Simple HTML DOM.
  *
  * @package Accessibility_Checker
+ * @since 1.23.0
  */
 
 namespace EDAC\Inc;
@@ -40,13 +43,17 @@ class DOM_Wrapper {
 		// Convert simple selectors to XPath.
 		if ( strpos( $selector, '.' ) === 0 ) {
 			// Class selector.
-			$query = "//*[contains(@class, '" . substr( $selector, 1 ) . "')]";
+			$query = "//*[contains(@class, '" . htmlspecialchars( substr( $selector, 1 ), ENT_QUOTES, 'UTF-8' ) . "')]";
 		} else {
 			// Tag selector.
 			$query = "//{$selector}";
 		}
 		
 		$elements = $xpath->query( $query );
+
+		if ( false === $elements ) {
+			return null;
+		}
 		
 		if ( null !== $idx ) {
 			return $elements->item( $idx );

--- a/includes/classes/class-dom-wrapper.php
+++ b/includes/classes/class-dom-wrapper.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * DOM Wrapper class to provide Simple HTML DOM compatibility
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Inc;
+
+/**
+ * Wrapper class for DOMDocument to provide Simple HTML DOM interface compatibility
+ */
+class DOM_Wrapper {
+	/**
+	 * The wrapped DOMDocument instance
+	 *
+	 * @var \DOMDocument
+	 */
+	private $dom;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \DOMDocument $dom The DOMDocument to wrap.
+	 */
+	public function __construct( \DOMDocument $dom ) {
+		$this->dom = $dom;
+	}
+
+	/**
+	 * Find elements by selector (Simple HTML DOM compatibility method)
+	 *
+	 * @param string $selector The selector to search for.
+	 * @param int    $idx The index to return (optional).
+	 * @return array|\DOMElement|null
+	 */
+	public function find( $selector, $idx = null ) {
+		$xpath = new \DOMXPath( $this->dom );
+		
+		// Convert simple selectors to XPath.
+		if ( strpos( $selector, '.' ) === 0 ) {
+			// Class selector.
+			$query = "//*[contains(@class, '" . substr( $selector, 1 ) . "')]";
+		} else {
+			// Tag selector.
+			$query = "//{$selector}";
+		}
+		
+		$elements = $xpath->query( $query );
+		
+		if ( null !== $idx ) {
+			return $elements->item( $idx );
+		}
+		
+		return iterator_to_array( $elements );
+	}
+
+	/**
+	 * Get the underlying DOMDocument
+	 *
+	 * @return \DOMDocument
+	 */
+	public function get_dom() {
+		return $this->dom;
+	}
+}

--- a/includes/deprecated/deprecated.php
+++ b/includes/deprecated/deprecated.php
@@ -135,15 +135,14 @@ function edac_save_post( $post_ID, $post, $update ) {
 if ( ! function_exists( 'str_get_html' ) ) {
 	/**
 	 * Fallback function for Simple HTML DOM's str_get_html
-	 * Accepts any arguments to match the original signature,
-	 * triggers a deprecation notice, and returns false.
+	 * Returns a wrapped DOMDocument instance for backwards compatibility
 	 *
 	 * @deprecated 1.23.0
 	 * @param mixed ...$args Original parameters passed to str_get_html().
-	 * @return false
+	 * @return \EDAC\Inc\DOM_Wrapper|false
 	 */
 	function str_get_html( ...$args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required for signature compatibility
 		_deprecated_function( __FUNCTION__, '1.23.0', 'DOMDocument' );
-		return false;
+		return isset( $args[0] ) ? edac_get_dom_from_html( $args[0], true ) : false;
 	}
 }

--- a/includes/deprecated/deprecated.php
+++ b/includes/deprecated/deprecated.php
@@ -131,3 +131,17 @@ function edac_save_post( $post_ID, $post, $update ) {
 	Post_Save::delete_issue_data_on_post_trashing( $post_ID, $post, $update );
 	return $post_ID;
 }
+
+if ( ! function_exists( 'str_get_html' ) ) {
+	/**
+	 * Fallback function for Simple HTML DOM's str_get_html
+	 * Returns false to gracefully handle the missing library
+	 * 
+	 * @deprecated 1.23.0
+	 * @return false
+	 */
+	function str_get_html() {
+		_deprecated_function( __FUNCTION__, '1.23.0', 'DOMDocument' );
+		return false;
+	}
+}

--- a/includes/deprecated/deprecated.php
+++ b/includes/deprecated/deprecated.php
@@ -135,12 +135,14 @@ function edac_save_post( $post_ID, $post, $update ) {
 if ( ! function_exists( 'str_get_html' ) ) {
 	/**
 	 * Fallback function for Simple HTML DOM's str_get_html
-	 * Returns false to gracefully handle the missing library
-	 * 
+	 * Accepts any arguments to match the original signature,
+	 * triggers a deprecation notice, and returns false.
+	 *
 	 * @deprecated 1.23.0
+	 * @param mixed ...$args Original parameters passed to str_get_html().
 	 * @return false
 	 */
-	function str_get_html() {
+	function str_get_html( ...$args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required for signature compatibility
 		_deprecated_function( __FUNCTION__, '1.23.0', 'DOMDocument' );
 		return false;
 	}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1046,6 +1046,28 @@ function edac_check_if_post_id_is_woocommerce_checkout_page( $post_id ) {
 }
 
 /**
+ * Create a DOMDocument from HTML string
+ * 
+ * @param string  $html The HTML content to parse.
+ * @param boolean $wrap Whether to wrap the result in a compatibility wrapper.
+ * @return \DOMDocument|\EDAC\Inc\DOM_Wrapper|false Returns DOMDocument or wrapper on success, false on failure
+ */
+function edac_get_dom_from_html( $html, $wrap = false ) {
+	libxml_use_internal_errors( true );
+	$dom = new \DOMDocument();
+	$dom->loadHTML(
+		htmlspecialchars_decode( $html, ENT_QUOTES ),
+		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+	);
+	libxml_clear_errors();
+	
+	if ( $wrap ) {
+		return new \EDAC\Inc\DOM_Wrapper( $dom );
+	}
+	return $dom;
+}
+
+/**
  * Parse HTML content to extract image or SVG elements
  * 
  * @param string $html The HTML content to parse.
@@ -1057,12 +1079,10 @@ function edac_parse_html_for_media( $html ) {
 		'svg' => null,
 	];
 
-	libxml_use_internal_errors( true );
-	$dom = new \DOMDocument();
-	$dom->loadHTML(
-		htmlspecialchars_decode( $html, ENT_QUOTES ),
-		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
-	);
+	$dom = edac_get_dom_from_html( $html );
+	if ( ! $dom ) {
+		return $result;
+	}
 	
 	$xpath = new \DOMXPath( $dom );
 	
@@ -1084,7 +1104,6 @@ function edac_parse_html_for_media( $html ) {
 		}
 	}
 	
-	libxml_clear_errors();
 	return $result;
 }
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1048,18 +1048,23 @@ function edac_check_if_post_id_is_woocommerce_checkout_page( $post_id ) {
 /**
  * Create a DOMDocument from HTML string
  * 
+ * @since 1.23.0
  * @param string  $html The HTML content to parse.
  * @param boolean $wrap Whether to wrap the result in a compatibility wrapper.
  * @return \DOMDocument|\EDAC\Inc\DOM_Wrapper|false Returns DOMDocument or wrapper on success, false on failure
  */
 function edac_get_dom_from_html( $html, $wrap = false ) {
 	libxml_use_internal_errors( true );
-	$dom = new \DOMDocument();
-	$dom->loadHTML(
+	$dom     = new \DOMDocument();
+	$success = $dom->loadHTML(
 		htmlspecialchars_decode( $html, ENT_QUOTES ),
 		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
 	);
 	libxml_clear_errors();
+
+	if ( ! $success ) {
+		return false;
+	}
 	
 	if ( $wrap ) {
 		return new \EDAC\Inc\DOM_Wrapper( $dom );
@@ -1070,6 +1075,7 @@ function edac_get_dom_from_html( $html, $wrap = false ) {
 /**
  * Parse HTML content to extract image or SVG elements
  * 
+ * @since 1.23.0
  * @param string $html The HTML content to parse.
  * @return array Array containing 'img' (string) and 'svg' (string) keys
  */


### PR DESCRIPTION
This pull request introduces a fallback function for the `str_get_html` method to handle cases where the Simple HTML DOM library is missing. The fallback function is marked as deprecated and advises the use of `DOMDocument` instead.

### Deprecated Function Addition:
* Added a fallback function `str_get_html` in `includes/deprecated/deprecated.php` to provide compatibility when the Simple HTML DOM library is unavailable. The function logs a deprecation notice for version 1.23.0 and suggests using `DOMDocument` as an alternative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fallback function that notifies users when the Simple HTML DOM library is missing and suggests using an alternative.
  - Introduced a new DOM wrapper class to enable CSS-like element selection using native DOMDocument.
  - Added a helper function to create and optionally wrap DOMDocument instances from HTML strings.

- **Documentation**
  - Displays a deprecation notice when the fallback function is triggered, referencing the recommended replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->