### PR TITLE
Fix metrics key from 'elementsCount' to 'elementCount' in density data

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -421,7 +421,7 @@ class REST_Api {
 					$post_id,
 					'_edac_density_data',
 					[
-						$metrics['elementsCount'] ?? 0,
+						$metrics['elementCount'] ?? 0,
 						$metrics['contentLength'] ?? 0,
 					]
 				);


### PR DESCRIPTION
This pull request includes a small update to the `set_post_scan_results` method in the `class-rest-api.php` file. The change corrects the key name from `elementsCount` to `elementCount` when accessing the `$metrics` array.

This is the reason that density data wasn't being properly calculated.

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
