### PR TITLE
Signup modal on welcome page doesnt always work in firefox

### DIFF
--- a/src/emailOptIn/modal.js
+++ b/src/emailOptIn/modal.js
@@ -4,7 +4,7 @@
  * This relies on the Thickbox library that is included in WordPress core which relies on jQuery.
  */
 
-/* global tb_show */
+/* global tb_show, tb_remove */
 
 import { createFocusTrap } from 'focus-trap';
 
@@ -13,6 +13,20 @@ window.edac_email_opt_in_form = window.edac_email_opt_in_form || {};
 
 export const initOptInModal = () => {
 	window.onload = function() {
+		window.addEventListener( 'mousemove', triggerModal, { once: true } );
+		window.addEventListener( 'scroll', triggerModal, { once: true } );
+	};
+};
+
+const triggerModal = ( () => {
+	let hasRun = false;
+
+	return () => {
+		if ( hasRun ) {
+			return;
+		}
+		hasRun = true;
+
 		tb_show( 'Accessibility Checker', '#TB_inline?width=600&inlineId=edac-opt-in-modal', null );
 
 		// create a loop that will wait to find the close button before trying to bind the focus trap
@@ -24,7 +38,7 @@ export const initOptInModal = () => {
 			attempts++;
 		}, 250 );
 	};
-};
+} )();
 
 const bindFocusTrap = () => {
 	const modal = document.getElementById( 'TB_window' );

--- a/src/emailOptIn/modal.js
+++ b/src/emailOptIn/modal.js
@@ -29,11 +29,19 @@ const triggerModal = ( () => {
 
 		tb_show( 'Accessibility Checker', '#TB_inline?width=600&inlineId=edac-opt-in-modal', null );
 
-		// create a loop that will wait to find the close button before trying to bind the focus trap
+		// Loop and check for the close button before trying to bind the focus trap.
 		let attempts = 0;
 		const intervalId = setInterval( () => {
-			if ( bindFocusTrap() || attempts >= 10 ) {
+			if ( bindFocusTrap() ) {
 				clearInterval( intervalId );
+			}
+			// Some browsers (firefox) have popup blocking settings that makes the modal
+			// content empty and so the button will never be found. To prevent users from
+			// being stuck in a modal we will close it after 10 attempts.
+			if ( attempts >= 10 ) {
+				clearInterval( intervalId );
+				tb_remove();
+				return;
 			}
 			attempts++;
 		}, 250 );


### PR DESCRIPTION
On firefox with certain popup blocking settings the contents of thickbox modals get emptied unless they are triggered by some user interaction. This PR changes the welcome page modal to be triggered by an interaction (scroll or mouse move) to avoid firefox emptying the modal.

It also adds a better catch for times that the thickbox fails to fill and closes the overlay after a short time to avoid people being trapped with the overlay but no modal content.

Closes: #972 

This pull request introduces changes to the `src/emailOptIn/modal.js` file to enhance the modal's behavior and improve user experience. The updates include adding event listeners to trigger the modal on user interaction, implementing safeguards to prevent infinite modal loops, and ensuring proper cleanup when the modal fails to load.

### Enhancements to modal triggering and behavior:

* Added `mousemove` and `scroll` event listeners to trigger the modal once on user interaction. (`[src/emailOptIn/modal.jsR16-R49](diffhunk://#diff-27933483526bba6df2a146e1671a6e743b467e1ab35cd542b5c2553cec6cd35bR16-R49)`)
* Introduced a `triggerModal` function with a guard (`hasRun`) to ensure the modal is only triggered once. (`[src/emailOptIn/modal.jsR16-R49](diffhunk://#diff-27933483526bba6df2a146e1671a6e743b467e1ab35cd542b5c2553cec6cd35bR16-R49)`)

### Improvements to modal error handling:

* Added logic to close the modal (`tb_remove`) after 10 unsuccessful attempts to bind the focus trap, preventing users from being stuck in an empty modal. (`[src/emailOptIn/modal.jsR16-R49](diffhunk://#diff-27933483526bba6df2a146e1671a6e743b467e1ab35cd542b5c2553cec6cd35bR16-R49)`)

### Code quality updates:

* Updated the `/* global */` declaration to include `tb_remove` for better clarity and adherence to coding standards. (`[src/emailOptIn/modal.jsL7-R7](diffhunk://#diff-27933483526bba6df2a146e1671a6e743b467e1ab35cd542b5c2553cec6cd35bL7-R7)`)

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The opt-in modal now appears only after the user's first interaction (mouse movement or scroll) on the page.
- **Bug Fixes**
  - Improved modal reliability by automatically closing it if the close button cannot be found after several attempts, preventing users from being stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->