### PR TITLE
Add @since PHPDoc tags to custom filters

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -51,6 +51,13 @@ class Enqueue_Admin {
 		$post_types        = get_option( 'edac_post_types' );
 		$current_post_type = get_post_type();
 		$page              = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
+		/**
+		 * Filters the array of admin page slugs where EDAC scripts should be enqueued.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $enabled_pages Array of page slugs.
+		 */
 		$enabled_pages     = apply_filters(
 			'edac_filter_admin_scripts_slugs',
 			[
@@ -122,6 +129,13 @@ class Enqueue_Admin {
 							$post_id,
 							[ 'edac_pageScanner' => 1 ]
 						),
+						/**
+						 * Filters the maximum allowed length for image alternative text.
+						 *
+						 * @since 1.0.0
+						 *
+						 * @param int $max_alt_length The maximum alt text length.
+						 */
 						'maxAltLength' => max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) ),
 						'version'      => EDAC_VERSION,
 						'restNonce'    => wp_create_nonce( 'wp_rest' ),

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -58,7 +58,7 @@ class Enqueue_Admin {
 		 *
 		 * @param array $enabled_pages Array of page slugs.
 		 */
-		$enabled_pages     = apply_filters(
+        $enabled_pages = apply_filters(
 			'edac_filter_admin_scripts_slugs',
 			[
 				'accessibility_checker',


### PR DESCRIPTION
This commit adds @since tags to various custom filters throughout the plugin to improve documentation and track when filters were introduced.

- Verified existing `since` tags for filters in:
    - admin/class-ajax.php (edac_ignore_permission, edac_filter_readability_content)
    - includes/helper-functions.php (edac_filter_post_types)
    - accessibility-checker.php (edac_filter_register_rules)
- Added `since` 1.0.0 (placeholder) to filters in admin/class-enqueue-admin.php:
    - edac_filter_admin_scripts_slugs
    - edac_max_alt_length
- Confirmed that 'perfmatters_lazyload' in includes/classes/class-lazyload-filter.php is a third-party filter and was correctly skipped.

<!-- Always provide a short description -->

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to customize which admin pages load specific scripts and to set the maximum length for image alternative text via new settings.
- **Documentation**
  - Improved inline documentation for new customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->