### PR TITLE
🚧 fix: Make success message an ARIA live region

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -806,7 +806,12 @@ class Ajax {
 		$edac_simplified_summary = get_post_meta( $post_id, '_edac_simplified_summary', $single = true );
 		$simplified_summary      = $edac_simplified_summary ? $edac_simplified_summary : '';
 
-		wp_send_json_success( wp_json_encode( $simplified_summary ) );
+		$response_data = [
+			'summary' => $simplified_summary,
+			'message' => esc_html__( 'Simplified summary updated successfully.', 'accessibility-checker' ),
+		];
+
+		wp_send_json_success( wp_json_encode( $response_data ) );
 	}
 
 	/**

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -255,9 +255,19 @@ const edacScriptVars = edac_script_vars;
 								},
 							} ).done( function( doneResponse ) {
 								if ( true === doneResponse.success ) {
-									const doneResponseJSON = jQuery.parseJSON(
+									const doneResponseData = jQuery.parseJSON(
 										doneResponse.data
 									);
+
+									const form = jQuery(event.target);
+									form.find('.edac-success-message').remove();
+									const successMessageElement = jQuery('<div>')
+										.addClass('edac-success-message notice notice-success is-dismissible inline')
+										.attr('role', 'status')
+										.attr('aria-live', 'polite')
+										.css({ margin: '10px 0', padding: '10px', display: 'block' })
+										.html('<p>' + doneResponseData.message + '</p>');
+									form.find('input[type="submit"]').after(successMessageElement);
 
 									refreshSummaryAndReadability();
 								} else {


### PR DESCRIPTION
This pull request includes updates to improve user feedback and data handling in the simplified summary functionality. The most important changes involve enhancing the server response structure and adding a success message display in the admin interface.

### Backend improvements:
* [`admin/class-ajax.php`](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL809-R814): Updated the `simplified_summary` method to include a more detailed response structure with a `message` field in addition to the `summary`. This provides clearer feedback for API consumers.

### Frontend enhancements:
* [`src/admin/index.js`](diffhunk://#diff-dfc37aefae3ed6e4377366f7f52efd88b9525c309c40b27392905e6fc694b381L258-R271): Added logic to display a success message in the admin interface when the simplified summary is updated. The message is styled as a dismissible notice and is dynamically inserted after the submit button.