### PR TITLE
Update new window warning fix to better handle elementor buttons

### DIFF
--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -153,6 +153,10 @@ class AddNewWindowWarningFix implements FixInterface {
 				content: " \e900";
 				font-size: var(--icon-size);
 			}
+
+			.edac-nww-external-link-icon.elementor-button-link-content:before {
+				vertical-align: middle;
+			}
 		</style>
 		<?php
 	}

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -66,7 +66,7 @@ const processLinks = () => {
 	// Remove previously appended icons to avoid duplication
 	document.querySelectorAll( '.edac-nww-external-link-icon' ).forEach( ( icon ) => icon.remove() );
 
-	document.querySelectorAll( 'a' ).forEach( ( link ) => {
+	document.querySelectorAll( 'a:not([data-anww-processed])' ).forEach( ( link ) => {
 		const onclickAttr = link.getAttribute( 'onclick' );
 
 		// Check if the link opens a new window using target="_blank"
@@ -74,6 +74,7 @@ const processLinks = () => {
 			addExternalLinkIcon( link );
 			updateAriaLabel( link );
 			addTooltipHandlers( link );
+			link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed
 		}
 
 		// Check if the link uses window.open in the onclick attribute
@@ -85,6 +86,7 @@ const processLinks = () => {
 				addExternalLinkIcon( link );
 				updateAriaLabel( link );
 				addTooltipHandlers( link );
+				link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed
 			}
 		}
 	} );

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -95,10 +95,17 @@ const processLinks = () => {
  * @param {HTMLElement} link - The link element to modify.
  */
 const addExternalLinkIcon = ( link ) => {
-	// Add icon to link
+	// Add icon to link.
 	const header = link.querySelector( 'h1, h2, h3, h4, h5, h6' );
 	if ( header ) {
 		header.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon" aria-hidden="true"></i>' );
+		return;
+	}
+
+	// If this the link is an elementor button place it alongside the content.
+	const elementorButtonContent = link.querySelector( '.elementor-button-content-wrapper' );
+	if ( elementorButtonContent ) {
+		elementorButtonContent.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon elementor-button-link-content" aria-hidden="true"></i>' );
 		return;
 	}
 

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -74,7 +74,8 @@ const processLinks = () => {
 			addExternalLinkIcon( link );
 			updateAriaLabel( link );
 			addTooltipHandlers( link );
-			link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed
+			link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed.
+			return;
 		}
 
 		// Check if the link uses window.open in the onclick attribute
@@ -86,7 +87,7 @@ const processLinks = () => {
 				addExternalLinkIcon( link );
 				updateAriaLabel( link );
 				addTooltipHandlers( link );
-				link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed
+				link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed.
 			}
 		}
 	} );

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -99,9 +99,10 @@ const addExternalLinkIcon = ( link ) => {
 	const header = link.querySelector( 'h1, h2, h3, h4, h5, h6' );
 	if ( header ) {
 		header.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon" aria-hidden="true"></i>' );
-	} else {
-		link.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon" aria-hidden="true"></i>' );
+		return;
 	}
+
+	link.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon" aria-hidden="true"></i>' );
 };
 
 /**


### PR DESCRIPTION
Adds a catch in the icon adding function to check for an elementor button class and when found place the icon inside it rather than after the entire link.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved placement of external link icons for Elementor button links, ensuring icons appear correctly alongside button content or headers.
  - Adjusted icon alignment for external link icons to achieve better vertical centering.
  - Prevented repeated processing of links opening in new windows to enhance performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->