### PR TITLE
fixed: capitalization in iframe missing title rule description

### DIFF
--- a/includes/rules.php
+++ b/includes/rules.php
@@ -108,13 +108,13 @@ return [
 		'ruleset'   => 'js',
 	],
 	[
-		'title'     => esc_html__( 'iFrame Missing Title', 'accessibility-checker' ),
+		'title'     => esc_html__( 'iframe Missing Title', 'accessibility-checker' ),
 		'info_url'  => 'https://a11ychecker.com/help1953',
 		'slug'      => 'iframe_missing_title',
 		'rule_type' => 'error',
 		'summary'   => sprintf(
 			// translators: %1$s is <code>&lt;frame&gt;</code>.
-			esc_html__( 'An iFrame Missing title error means that one or more of the iFrames on your post or page does not have an accessible title describing the contents of the iFrame. An iFrame title is an attribute that can be added to the %1$s tag to describe the contents of the frame to people using assistive technology. To fix a missing iFrame title, you will need to add a title or an aria-label attribute to the %1$s tag. The attribute should accurately describe the contents of the iFrame.', 'accessibility-checker' ),
+			esc_html__( 'An iframe Missing title error means that one or more of the iframes on your post or page does not have an accessible title describing the contents of the iframe. An iframe title is an attribute that can be added to the %1$s tag to describe the contents of the frame to people using assistive technology. To fix a missing iframe title, you will need to add a title or an aria-label attribute to the %1$s tag. The attribute should accurately describe the contents of the iframe.', 'accessibility-checker' ),
 			'<code>&lt;frame&gt;</code>'
 		),
 		'ruleset'   => 'js',


### PR DESCRIPTION
This pull request includes a minor change to improve consistency in terminology within the `includes/rules.php` file. The change standardizes the capitalization of "iframe" in error messages and descriptions.

* [`includes/rules.php`](diffhunk://#diff-40652b9b45019a70bc2344f1b523a3220a53ef38d2d326f6821588666a1d2e7aL111-R117): Updated the capitalization of "iFrame" to "iframe" in the error title and description to ensure consistency with standard terminology.

Fixes #770
