### PR TITLE
Update translation functions for better localization

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -68,7 +68,7 @@ class FixesPage implements PageInterface {
 
 		$scan_tab = [
 			'slug'  => 'fixes',
-			'label' => 'Fixes',
+			'label' => __( 'Fixes', 'accessibility-checker' ),
 			'order' => 2,
 		];
 		array_push( $settings_tab_items, $scan_tab );

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -111,7 +111,7 @@ class Admin_Notices {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -120,7 +120,7 @@ class Admin_Notices {
 
 		if ( ! $results ) {
 
-			$error = new \WP_Error( '-2', 'Update option wasn\'t successful' );
+			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -222,7 +222,7 @@ class Admin_Notices {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -231,7 +231,7 @@ class Admin_Notices {
 
 		if ( ! $results ) {
 
-			$error = new \WP_Error( '-2', 'Update option wasn\'t successful' );
+			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -310,7 +310,7 @@ class Admin_Notices {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -322,7 +322,7 @@ class Admin_Notices {
 
 		if ( ! $results ) {
 
-			$error = new \WP_Error( '-2', 'Update option wasn\'t successful' );
+			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -399,14 +399,14 @@ class Admin_Notices {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
 
 		if ( ! isset( $_REQUEST['review_action'] ) ) {
 
-			$error = new \WP_Error( '-2', 'The review action value was not set' );
+			$error = new \WP_Error( '-2', __( 'The review action value was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -419,7 +419,7 @@ class Admin_Notices {
 
 		if ( ! $results ) {
 
-			$error = new \WP_Error( '-3', 'Update option wasn\'t successful' );
+			$error = new \WP_Error( '-3', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -481,7 +481,7 @@ class Admin_Notices {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -490,7 +490,7 @@ class Admin_Notices {
 
 		if ( ! $results ) {
 
-			$error = new \WP_Error( '-2', 'Update option wasn\'t successful' );
+			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -53,14 +53,14 @@ class Ajax {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
 
 		if ( ! isset( $_REQUEST['post_id'] ) ) {
 
-			$error = new \WP_Error( '-2', 'The post ID was not set' );
+			$error = new \WP_Error( '-2', __( 'The post ID was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -170,7 +170,7 @@ class Ajax {
 
 		if ( ! $html ) {
 
-			$error = new \WP_Error( '-3', 'No summary to return' );
+			$error = new \WP_Error( '-3', __( 'No summary to return', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -193,14 +193,14 @@ class Ajax {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
 
 		if ( ! isset( $_REQUEST['post_id'] ) ) {
 
-			$error = new \WP_Error( '-2', 'The post ID was not set' );
+			$error = new \WP_Error( '-2', __( 'The post ID was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -214,7 +214,7 @@ class Ajax {
 		// Send error if table name is not valid.
 		if ( ! $table_name ) {
 
-			$error = new \WP_Error( '-3', 'Invalid table name' );
+			$error = new \WP_Error( '-3', __( 'Invalid table name', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -536,7 +536,7 @@ class Ajax {
 
 		if ( ! $html ) {
 
-			$error = new \WP_Error( '-4', 'No details to return' );
+			$error = new \WP_Error( '-4', __( 'No details to return', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -558,14 +558,14 @@ class Ajax {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
 
 		if ( ! isset( $_REQUEST['post_id'] ) ) {
 
-			$error = new \WP_Error( '-2', 'The post ID was not set' );
+			$error = new \WP_Error( '-2', __( 'The post ID was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -676,7 +676,7 @@ class Ajax {
 
 		if ( ! $html ) {
 
-			$error = new \WP_Error( '-3', 'No readability data to return' );
+			$error = new \WP_Error( '-3', __( 'No readability data to return', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -697,7 +697,7 @@ class Ajax {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -733,7 +733,7 @@ class Ajax {
 			$object = $wpdb->get_var( $wpdb->prepare( 'SELECT object FROM %i WHERE id = %d', $table_name, $first_id ) );
 
 			if ( ! $object ) {
-				$error = new \WP_Error( '-2', 'No ignore data to return' );
+				$error = new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) );
 				wp_send_json_error( $error );
 			}
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
@@ -756,7 +756,7 @@ class Ajax {
 
 		if ( ! $data ) {
 
-			$error = new \WP_Error( '-2', 'No ignore data to return' );
+			$error = new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -777,21 +777,21 @@ class Ajax {
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
 
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
 
 		if ( ! isset( $_REQUEST['post_id'] ) ) {
 
-			$error = new \WP_Error( '-2', 'The post ID was not set' );
+			$error = new \WP_Error( '-2', __( 'The post ID was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
 
 		if ( ! isset( $_REQUEST['summary'] ) ) {
 
-			$error = new \WP_Error( '-3', 'The summary was not set' );
+			$error = new \WP_Error( '-3', __( 'The summary was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -409,7 +409,7 @@ class Ajax {
 					$html .=
 						'<div class="edac-details-rule-records-labels">
 							<div class="edac-details-rule-records-labels-label" aria-hidden="true">
-								Affected Code
+								' . esc_html__( 'Affected Code', 'accessibility-checker' ) . '
 							</div>
 							<div class="edac-details-rule-records-labels-label" aria-hidden="true">
 								Image

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -76,12 +76,12 @@ class Frontend_Highlight {
 
 		// nonce security.
 		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
-			$error = new \WP_Error( '-1', 'Permission Denied' );
+			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 		}
 
 		if ( ! isset( $_REQUEST['post_id'] ) ) {
-			$error = new \WP_Error( '-2', 'The id value was not set' );
+			$error = new \WP_Error( '-2', __( 'The id value was not set', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 		}
 
@@ -89,7 +89,7 @@ class Frontend_Highlight {
 		$results = $this->get_issues( $post_id );
 
 		if ( ! $results ) {
-			$error = new \WP_Error( '-3', 'Issue query returned no results' );
+			$error = new \WP_Error( '-3', __( 'Issue query returned no results', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 		}
 
@@ -134,7 +134,7 @@ class Frontend_Highlight {
 
 		if ( ! $issues ) {
 
-			$error = new \WP_Error( '-5', 'Object query returned no results' );
+			$error = new \WP_Error( '-5', __( 'Object query returned no results', 'accessibility-checker' ) );
 			wp_send_json_error( $error );
 
 		}
@@ -143,8 +143,9 @@ class Frontend_Highlight {
 		if ( ! empty( $fixes ) ) {
 			foreach ( $fixes as $key => $fix ) {
 				// count the number of fields in the fix.
-				$fields_count = count( $fix );
-				$itteration   = 0;
+				$fields_count      = count( $fix );
+				$itteration        = 0;
+				$fix_fields_markup = '';
 				foreach ( $fix as $index => $field ) {
 					++$itteration;
 					$field_type = $field['type'] ?? 'checkbox';

--- a/admin/site-health/class-free.php
+++ b/admin/site-health/class-free.php
@@ -46,63 +46,63 @@ class Free {
 			'label'  => __( 'Accessibility Checker &mdash; Free', 'accessibility-checker' ),
 			'fields' => [
 				'version'                 => [
-					'label' => 'Version',
+					'label' => __( 'Version', 'accessibility-checker' ),
 					'value' => esc_html( EDAC_VERSION ),
 				],
 				'database_version'        => [
-					'label' => 'Database Version',
+					'label' => __( 'Database Version', 'accessibility-checker' ),
 					'value' => esc_html( EDAC_DB_VERSION ),
 				],
 				'policy_page'             => [
-					'label' => 'Policy Page',
-					'value' => esc_html( get_option( 'edac_accessibility_policy_page' ) ? get_option( 'edac_accessibility_policy_page' ) : "Unset\n" ),
+					'label' => __( 'Policy Page', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edac_accessibility_policy_page' ) ? get_option( 'edac_accessibility_policy_page' ) : __( 'Unset', 'accessibility-checker' ) ),
 				],
 				'activation_date'         => [
-					'label' => 'Activation Date',
+					'label' => __( 'Activation Date', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edac_activation_date' ) ),
 				],
 				'footer_statement'        => [
-					'label' => 'Footer Statement',
-					'value' => esc_html( get_option( 'edac_add_footer_accessibility_statement' ) ? 'Enabled' : 'Disabled' ),
+					'label' => __( 'Footer Statement', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edac_add_footer_accessibility_statement' ) ? __( 'Enabled', 'accessibility-checker' ) : __( 'Disabled', 'accessibility-checker' ) ),
 				],
 				'delete_data'             => [
-					'label' => 'Delete Data',
-					'value' => esc_html( get_option( 'edac_delete_data' ) ? 'Enabled' : 'Disabled' ),
+					'label' => __( 'Delete Data', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edac_delete_data' ) ? __( 'Enabled', 'accessibility-checker' ) : __( 'Disabled', 'accessibility-checker' ) ),
 				],
 				'include_statement_link'  => [
-					'label' => 'Include Statement Link',
-					'value' => esc_url( get_option( 'edac_include_accessibility_statement_link' ) ? 'Enabled' : 'Disabled' ),
+					'label' => __( 'Include Statement Link', 'accessibility-checker' ),
+					'value' => esc_url( get_option( 'edac_include_accessibility_statement_link' ) ? __( 'Enabled', 'accessibility-checker' ) : __( 'Disabled', 'accessibility-checker' ) ),
 				],
 				'post_types'              => [
-					'label' => 'Post Types',
-					'value' => esc_html( get_option( 'edac_post_types' ) ? implode( ', ', get_option( 'edac_post_types' ) ) : 'Unset' ),
+					'label' => __( 'Post Types', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edac_post_types' ) ? implode( ', ', get_option( 'edac_post_types' ) ) : __( 'Unset', 'accessibility-checker' ) ),
 				],
 				'simplified_sum_position' => [
-					'label' => 'Simplified Sum Position',
+					'label' => __( 'Simplified Sum Position', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edac_simplified_summary_position' ) ),
 				],
 				'simplified_sum_prompt'   => [
-					'label' => 'Simplified Sum Prompt',
+					'label' => __( 'Simplified Sum Prompt', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edac_simplified_summary_prompt' ) ),
 				],
 				'post_count'              => [
-					'label' => 'Post Count',
+					'label' => __( 'Post Count', 'accessibility-checker' ),
 					'value' => esc_html( edac_get_posts_count() ),
 				],
 				'error_count'             => [
-					'label' => 'Error Count',
+					'label' => __( 'Error Count', 'accessibility-checker' ),
 					'value' => absint( edac_get_error_count() ),
 				],
 				'warning_count'           => [
-					'label' => 'Warning Count',
+					'label' => __( 'Warning Count', 'accessibility-checker' ),
 					'value' => absint( edac_get_warning_count() ),
 				],
 				'db_table_count'          => [
-					'label' => 'DB Table Count',
+					'label' => __( 'DB Table Count', 'accessibility-checker' ),
 					'value' => absint( edac_database_table_count( 'accessibility_checker' ) ),
 				],
 				'fixes'                   => [
-					'label' => 'Fixes',
+					'label' => __( 'Fixes', 'accessibility-checker' ),
 					'value' => esc_html( wp_json_encode( $fixes ) ),
 				],
 			],

--- a/admin/site-health/class-pro.php
+++ b/admin/site-health/class-pro.php
@@ -47,47 +47,47 @@ class Pro {
 			'label'  => __( 'Accessibility Checker &mdash; Pro', 'accessibility-checker' ),
 			'fields' => [
 				'version'                => [
-					'label' => 'Version',
-					'value' => defined( 'EDACP_VERSION' ) ? esc_html( EDACP_VERSION ) : 'Unset',
+					'label' => __( 'Version', 'accessibility-checker' ),
+					'value' => defined( 'EDACP_VERSION' ) ? esc_html( EDACP_VERSION ) : __( 'Unset', 'accessibility-checker' ),
 				],
 				'database_version'       => [
-					'label' => 'Database Version',
-					'value' => defined( 'EDACP_DB_VERSION' ) ? esc_html( EDACP_DB_VERSION ) : 'Unset',
+					'label' => __( 'Database Version', 'accessibility-checker' ),
+					'value' => defined( 'EDACP_DB_VERSION' ) ? esc_html( EDACP_DB_VERSION ) : __( 'Unset', 'accessibility-checker' ),
 				],
 				'license_status'         => [
-					'label' => 'License Status',
+					'label' => __( 'License Status', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edacp_license_status' ) ),
 				],
 				'authorization_username' => [
-					'label' => 'Authorization Username',
-					'value' => esc_html( get_option( 'edacp_authorization_username' ) ? get_option( 'edacp_authorization_username' ) : 'Unset' ),
+					'label' => __( 'Authorization Username', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edacp_authorization_username' ) ? get_option( 'edacp_authorization_username' ) : __( 'Unset', 'accessibility-checker' ) ),
 				],
 				'authorization_password' => [
-					'label' => 'Authorization Password',
-					'value' => esc_html( get_option( 'edacp_authorization_password' ) ? get_option( 'edacp_authorization_password' ) : 'Unset' ),
+					'label' => __( 'Authorization Password', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edacp_authorization_password' ) ? get_option( 'edacp_authorization_password' ) : __( 'Unset', 'accessibility-checker' ) ),
 				],
 				'scan_id'                => [
-					'label' => 'Scan ID',
+					'label' => __( 'Scan ID', 'accessibility-checker' ),
 					'value' => esc_html( get_transient( 'edacp_scan_id' ) ),
 				],
 				'scan_total'             => [
-					'label' => 'Scan Total',
+					'label' => __( 'Scan Total', 'accessibility-checker' ),
 					'value' => absint( get_transient( 'edacp_scan_total' ) ),
 				],
 				'simplified_sum_heading' => [
-					'label' => 'Simplified Sum Heading',
+					'label' => __( 'Simplified Sum Heading', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edacp_simplified_summary_heading' ) ),
 				],
 				'ignore_permissions'     => [
-					'label' => 'Ignore Permissions',
-					'value' => esc_html( get_option( 'edacp_ignore_user_roles' ) ? implode( ', ', get_option( 'edacp_ignore_user_roles' ) ) : 'None' ),
+					'label' => __( 'Ignore Permissions', 'accessibility-checker' ),
+					'value' => esc_html( get_option( 'edacp_ignore_user_roles' ) ? implode( ', ', get_option( 'edacp_ignore_user_roles' ) ) : __( 'None', 'accessibility-checker' ) ),
 				],
 				'ignores_db_table_count' => [
-					'label' => 'Ignores DB Table Count',
+					'label' => __( 'Ignores DB Table Count', 'accessibility-checker' ),
 					'value' => absint( edac_database_table_count( 'accessibility_checker_global_ignores' ) ),
 				],
 				'fixes'                  => [
-					'label' => 'Fixes',
+					'label' => __( 'Fixes', 'accessibility-checker' ),
 					'value' => esc_html( wp_json_encode( $fixes ) ),
 				],
 			],

--- a/src/emailOptIn/index.js
+++ b/src/emailOptIn/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 
+import { __ } from '@wordpress/i18n';
 import {initOptInModal} from "./modal";
 
 const edac_on_submit_ok = function () {
@@ -11,7 +12,7 @@ const edac_on_submit_ok = function () {
 	fetch(edac_email_opt_in_form.ajaxurl + "?" + queryString)
 		.then(response => {
 			if (!response.ok) {
-				document.querySelector('._form-thank-you').textContent = "There was a problem. Please try again.";
+				document.querySelector('._form-thank-you').textContent = __( "There was a problem. Please try again.", 'accessibility-checker' );
 			}
 		});
 };
@@ -72,9 +73,9 @@ window._load_script = function (url, callback, isSubmit) {
 	script.onerror = function () {
 		if (isSubmit) {
 			if (script.src.length > 10000) {
-				_show_error("1", "Sorry, your submission failed. Please shorten your responses and try again.");
+				_show_error("1", __( "Sorry, your submission failed. Please shorten your responses and try again.", 'accessibility-checker' ));
 			} else {
-				_show_error("1", "Sorry, your submission failed. Please try again.");
+				_show_error("1", __( "Sorry, your submission failed. Please try again.", 'accessibility-checker' ));
 			}
 			submitButton.disabled = false;
 			submitButton.classList.remove('processing');

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -4,7 +4,7 @@
 import { computePosition, autoUpdate } from '@floating-ui/dom';
 import { createFocusTrap } from 'focus-trap';
 import { isFocusable } from 'tabbable';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { saveFixSettings } from '../common/saveFixSettingsRest';
 import { fillFixesModal, fixSettingsModalInit, openFixesModal } from './fixesModal';
 
@@ -640,10 +640,10 @@ class AccessibilityCheckerHighlight {
 			content += `<a class="edac-highlight-panel-description-reference" href="${ matchingObj.link }">Full Documentation</a>`;
 
 			// Get the code button
-			content += `<button class="edac-highlight-panel-description-code-button" aria-expanded="false" aria-controls="edac-highlight-panel-description-code">Show Code</button>`;
+			content += `<button class="edac-highlight-panel-description-code-button" aria-expanded="false" aria-controls="edac-highlight-panel-description-code">${ __( 'Show Code', 'accessibility-checker' ) }</button>`;
 
 			// title and content
-			descriptionTitle.innerHTML = matchingObj.rule_title + ' <span class="edac-highlight-panel-description-type edac-highlight-panel-description-type-' + matchingObj.rule_type + '" aria-label=" Issue type: ' + matchingObj.rule_type + '"> ' + matchingObj.rule_type + '</span>';
+			descriptionTitle.innerHTML = matchingObj.rule_title + ' <span class="edac-highlight-panel-description-type edac-highlight-panel-description-type-' + matchingObj.rule_type + '" aria-label="' + __( 'Issue type:', 'accessibility-checker' ) + ' ' + matchingObj.rule_type + '"> ' + matchingObj.rule_type + '</span>';
 
 			// content
 			descriptionContent.innerHTML = content;
@@ -740,7 +740,7 @@ class AccessibilityCheckerHighlight {
 		document.querySelector( 'body' ).classList.add( 'edac-app-disable-styles' );
 
 		this.stylesDisabled = true;
-		this.disableStylesButton.textContent = 'Enable Styles';
+		this.disableStylesButton.textContent = __( 'Enable Styles', 'accessibility-checker' );
 	}
 
 	/**
@@ -761,7 +761,7 @@ class AccessibilityCheckerHighlight {
 		document.querySelector( 'body' ).classList.remove( 'edac-app-disable-styles' );
 
 		this.stylesDisabled = false;
-		this.disableStylesButton.textContent = 'Disable Styles';
+		this.disableStylesButton.textContent = __( 'Disable Styles', 'accessibility-checker' );
 	}
 
 	/**
@@ -866,7 +866,7 @@ class AccessibilityCheckerHighlight {
 		const ignoredCount = this.countIgnored();
 		const div = document.querySelector( '.edac-highlight-panel-controls-summary' );
 
-		let textContent = 'No issues detected.';
+		let textContent = __( 'No issues detected.', 'accessibility-checker' );
 		if ( errorCount > 0 || warningCount > 0 || ignoredCount > 0 ) {
 			textContent = '';
 			// show buttons since we have issues.
@@ -874,16 +874,16 @@ class AccessibilityCheckerHighlight {
 			this.previousButton.disabled = false;
 
 			if ( errorCount >= 0 ) {
-				textContent += errorCount + ' error' + ( errorCount === 1 ? '' : 's' ) + ', ';
+				textContent += errorCount + ' ' + _n( 'error', 'errors', errorCount, 'accessibility-checker' ) + ', ';
 			}
 			if ( warningCount >= 0 ) {
-				textContent += warningCount + ' warning' + ( warningCount === 1 ? '' : 's' ) + ', ';
+				textContent += warningCount + ' ' + _n( 'warning', 'warnings', warningCount, 'accessibility-checker' ) + ', ';
 			}
 			if ( ignoredCount >= 0 ) {
-				textContent += 'and ' + ignoredCount + ' ignored issue' + ( ignoredCount === 1 ? '' : 's' ) + ' detected.';
+				textContent += __( 'and', 'accessibility-checker' ) + ' ' + ignoredCount + ' ' + _n( 'ignored issue', 'ignored issues', ignoredCount, 'accessibility-checker' ) + ' ' + __( 'detected.', 'accessibility-checker' );
 			} else {
 				// Remove the trailing comma and add "detected."
-				textContent = textContent.slice( 0, -2 ) + ' detected.';
+				textContent = textContent.slice( 0, -2 ) + ' ' + __( 'detected.', 'accessibility-checker' );
 			}
 		}
 


### PR DESCRIPTION
This pull request includes updates to improve localization throughout the codebase by replacing hardcoded strings with translatable strings using the `__()` function. These changes ensure that all user-facing text can be translated into different languages, enhancing accessibility for non-English speakers.

### Localization Improvements

#### Admin Pages
* Updated the `add_fixes_tab` method in `admin/AdminPage/FixesPage.php` to make the "Fixes" label translatable.

#### Admin Notices
* Replaced hardcoded error messages with translatable strings in multiple methods (`welcome_page_post_count_change_notice_ajax`, `edac_black_friday_notice_ajax`, `edac_gaad_notice_ajax`, `edac_review_notice_ajax`, `edac_password_protected_notice_ajax`) within `admin/class-admin-notices.php`. Examples include "Permission Denied" and "Update option wasn't successful." [[1]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL114-R114) [[2]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL123-R123) [[3]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL225-R225) [[4]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL234-R234) [[5]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL313-R313) [[6]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL325-R325) [[7]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL402-R409) [[8]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL422-R422) [[9]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL484-R484) [[10]](diffhunk://#diff-01f9bc40c0b8b13e869220612fd99ed97514e283ed783995c36c585f4256b1cbL493-R493)

#### AJAX Handlers
* Updated error messages and labels in various AJAX handler methods (`summary`, `details`, `readability`, `add_ignore`, `simplified_summary`) within `admin/class-ajax.php`. Examples include "Permission Denied," "The post ID was not set," and "No summary to return." [[1]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL56-R63) [[2]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL173-R173) [[3]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL196-R203) [[4]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL217-R217) [[5]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL412-R412) [[6]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL539-R539) [[7]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL561-R568) [[8]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL679-R679) [[9]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL700-R700) [[10]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL736-R736) [[11]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL759-R759) [[12]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL780-R794)

#### Frontend Highlight
* Made error messages translatable in the `ajax` method of `admin/class-frontend-highlight.php`. Examples include "Permission Denied" and "Issue query returned no results." [[1]](diffhunk://#diff-68f824f5d8b6cebe1f89f49f19aa21fca016a5b41e67adf665ec9e97f7839730L79-R92) [[2]](diffhunk://#diff-68f824f5d8b6cebe1f89f49f19aa21fca016a5b41e67adf665ec9e97f7839730L137-R137)

#### Site Health
* Updated labels and values in the `class-free.php` file to ensure all fields, such as "Version," "Policy Page," and "Footer Statement," are translatable.

Fixes: #384