### PR TITLE
Fix attribute typo in helper

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -49,7 +49,7 @@ export const showNotice = ( options ) => {
 		let msg = settings.msg;
 
 		if ( settings.url ) {
-			msg = msg.replace( '{link}', '<a href="' + settings.url + '" target="_blank" arial-label="' + settings.label + '">' + settings.label + '</a>' );
+                       msg = msg.replace( '{link}', '<a href="' + settings.url + '" target="_blank" aria-label="' + settings.label + '">' + settings.label + '</a>' );
 		} else {
 			msg = msg.replace( '{link}', '' );
 		}

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -49,7 +49,10 @@ export const showNotice = ( options ) => {
 		let msg = settings.msg;
 
 		if ( settings.url ) {
-			msg = msg.replace( '{link}', '<a href="' + settings.url + '" target="_blank" aria-label="' + settings.label + '">' + settings.label + '</a>' );
+			msg = msg.replace(
+				'{link}',
+				`<a href="${ encodeURI( settings.url ) }" target="_blank" aria-label="${ settings.label }">${ settings.label }</a>`
+			);
 		} else {
 			msg = msg.replace( '{link}', '' );
 		}

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -49,7 +49,7 @@ export const showNotice = ( options ) => {
 		let msg = settings.msg;
 
 		if ( settings.url ) {
-                       msg = msg.replace( '{link}', '<a href="' + settings.url + '" target="_blank" aria-label="' + settings.label + '">' + settings.label + '</a>' );
+			msg = msg.replace( '{link}', '<a href="' + settings.url + '" target="_blank" aria-label="' + settings.label + '">' + settings.label + '</a>' );
 		} else {
 			msg = msg.replace( '{link}', '' );
 		}


### PR DESCRIPTION
## Summary
- fix `arial-label` attribute typo in `src/common/helpers.js`
- small improvement to the `showNotice` function in `src/common/helpers.js`. The change ensures that URLs in notices are properly encoded using `encodeURI`, enhancing security and reliability.

------
https://chatgpt.com/codex/tasks/task_e_683fa5b62b5083289b928e7936211320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in an accessibility attribute, improving support for screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->