### PR TITLE
Fix comments for multi-dimensional arrays

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -93,9 +93,9 @@ function edac_ordinal( $number ) {
 }
 
 /**
- * Remove element from multidimensional array
+ * Remove element from multi-dimensional array
  *
- * @param array  $items The multidimensional array.
+ * @param array  $items The multi-dimensional array.
  * @param string $key The key of the element.
  * @param string $value The value of the element.
  * @return array
@@ -110,11 +110,11 @@ function edac_remove_element_with_value( $items, $key, $value ) {
 }
 
 /**
- * Filter a multi-demensional array
+ * Filter a multi-dimensional array
  *
  * @param array  $items The multi-dimensional array.
  * @param string $index The index of the element.
- * @param string $value of the array.
+ * @param string $value The value of the array.
  * @return array
  */
 function edac_filter_by_value( $items, $index, $value ) {


### PR DESCRIPTION
## Summary
- correct docblock grammar for `edac_filter_by_value`
- ensure comments consistently use "multi-dimensional"

## Testing
- `composer install` *(fails: command not found)*
- `npm run lint:php` *(fails: ./vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb159999c83288d492ca8393d1e6e