### PR TITLE
added: deprecation notice for EDAC_ANWW_ACTIVE constant

### DIFF
--- a/includes/deprecated/deprecated.php
+++ b/includes/deprecated/deprecated.php
@@ -10,6 +10,20 @@ use EDAC\Admin\Insert_Rule_Data;
 use EDAC\Admin\Purge_Post_Data;
 use EDAC\Admin\Post_Save;
 
+// Deprecated constants.
+if ( ! defined( 'EDAC_ANWW_ACTIVE' ) ) {
+	/**
+	 * Indicates whether the Accessibility New Window Warnings plugin is active.
+	 * 
+	 * @deprecated 1.24.0 This constant has been replaced by ANWW_VERSION
+	 * 
+	 * This constant was previously used to check if the Accessibility New Window Warnings plugin
+	 * was active. It is kept here for backward compatibility with plugins that may still 
+	 * depend on it. The value will be true if ANWW_VERSION is defined, false otherwise.
+	 */
+	define( 'EDAC_ANWW_ACTIVE', defined( 'ANWW_VERSION' ) );
+}
+
 /**
  * Alias of the is_plugin_active() function.
  *


### PR DESCRIPTION
This pull request introduces a deprecated constant in the `includes/deprecated/deprecated.php` file to maintain backward compatibility with plugins relying on older functionality.

* [`includes/deprecated/deprecated.php`](diffhunk://#diff-23d2a703b83b5881be8e7be7d7f8387017da4faf09baf10ce93c2ef61529ba19R13-R26): Added the `EDAC_ANWW_ACTIVE` constant to check whether the Accessibility New Window Warnings plugin is active. This constant is marked as deprecated (version 1.24.0) and is intended for backward compatibility. It evaluates to `true` if `ANWW_VERSION` is defined, and `false` otherwise.