### PR TITLE
Manually load the plugin textdomain during plugin init

### DIFF
--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -60,7 +60,7 @@ class Plugin {
 		$lazyload_filter = new Lazyload_Filter();
 		$lazyload_filter->init_hooks();
 
-		// Some WP installs can't determine load the text domain with the JIT loader so this manually loads it.
+		// Some WP installs can't load the text domain with the JIT loader, so we manually load it.
 		add_action( 'plugins_loaded', [ $this, 'init_textdomain' ] );
 	}
 

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -59,6 +59,9 @@ class Plugin {
 
 		$lazyload_filter = new Lazyload_Filter();
 		$lazyload_filter->init_hooks();
+
+		// Some WP installs can't determine load the text domain with the JIT loader so this manually loads it.
+		add_action( 'plugins_loaded', [ $this, 'init_textdomain' ] );
 	}
 
 	/**
@@ -84,5 +87,17 @@ class Plugin {
 		$fixes_manager = FixesManager::get_instance();
 		$fixes_manager->register_fixes();
 		add_action( 'rest_api_init', [ $fixes_manager, 'register_rest_routes' ] );
+	}
+
+	/**
+	 * Initialize the plugin text domain for translations.
+	 *
+	 * This method loads the plugin's text domain for translations.
+	 * It is called during the plugins_loaded action hook.
+	 *
+	 * @return void
+	 */
+	public function init_textdomain() {
+		load_plugin_textdomain( 'accessibility-checker', false, basename( dirname( EDAC_PLUGIN_FILE ) ) . '/languages' );
 	}
 }


### PR DESCRIPTION
This PR sets up to manually load the text domain as we found that in some sites the just in time loader wasn't working

TODO: setup to load translations for JS files from json and setting their domain as well

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for plugin translations by ensuring text domains are loaded correctly on all WordPress installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->