### PR TITLE
Update scan URL logic for frontpage or homepage

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -106,6 +106,16 @@ class Enqueue_Admin {
 
 				wp_enqueue_script( 'edac-editor-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/editorApp.bundle.js', false, EDAC_VERSION, false );
 
+				// If this is the frontpage or homepage preview urls won't work, use the live url.
+				if ( (int) get_option( 'page_on_front' ) === $post_id || (int) get_option( 'page_for_posts' ) === $post_id ) {
+					$scan_url = add_query_arg( 'edac_pageScanner', 1, get_permalink( $post_id ) );
+				} else {
+					$scan_url = get_preview_post_link(
+						$post_id,
+						[ 'edac_pageScanner' => 1 ]
+					);
+				}
+
 				wp_localize_script(
 					'edac-editor-app',
 					'edac_editor_app',
@@ -118,10 +128,7 @@ class Enqueue_Admin {
 						'pro'          => $pro,
 						'authOk'       => false === (bool) get_option( 'edac_password_protected', false ),
 						'debug'        => $debug,
-						'scanUrl'      => get_preview_post_link(
-							$post_id,
-							[ 'edac_pageScanner' => 1 ]
-						),
+						'scanUrl'      => $scan_url,
 						'maxAltLength' => max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) ),
 						'version'      => EDAC_VERSION,
 						'restNonce'    => wp_create_nonce( 'wp_rest' ),


### PR DESCRIPTION
This pull request updates the `maybe_enqueue_admin_and_editor_app_scripts` function in `admin/class-enqueue-admin.php` to improve the handling of the `scanUrl` for frontpage and homepage scenarios. The changes introduce conditional logic to ensure the correct URL is used for scanning, depending on the type of page being previewed.

### Changes to `scanUrl` handling:

* Added a conditional check to determine if the current page is the frontpage or the homepage. If so, the live URL is used for the `scanUrl` instead of the preview URL. This ensures functionality for these specific cases.
* Updated the `scanUrl` assignment in the localized script data to use the newly introduced `$scan_url` variable, which accounts for the conditional logic.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
