### PR TITLE
refactor: anchor existence check and add tests for broken anchor links

### DIFF
--- a/src/pageScanner/checks/anchor-exists.js
+++ b/src/pageScanner/checks/anchor-exists.js
@@ -8,6 +8,20 @@
 export default {
 	id: 'anchor_exists',
 	evaluate: ( node ) => {
-		return document.querySelector( node.getAttribute( 'href' ) ) !== null;
+		const href = node.getAttribute( 'href' );
+
+		// First try the standard CSS selector approach (finds elements with matching IDs)
+		if ( document.querySelector( href ) !== null ) {
+			return true;
+		}
+
+		// If no ID match found, check for anchor elements with matching name attribute
+		// Extract the fragment identifier (remove the # prefix)
+		const fragment = href.substring( 1 );
+
+		// Look for anchor elements with matching name attribute
+		const namedAnchor = document.querySelector( `a[name="${ fragment }"]` );
+
+		return namedAnchor !== null;
 	},
 };

--- a/src/pageScanner/checks/anchor-exists.js
+++ b/src/pageScanner/checks/anchor-exists.js
@@ -10,17 +10,20 @@ export default {
 	evaluate: ( node ) => {
 		const href = node.getAttribute( 'href' );
 
+		// Extract the fragment identifier (remove the # prefix)
+		const fragment = href.slice( 1 );
+
+		// Use CSS.escape() to safely handle special characters in selectors
+		const idSelector = `#${ CSS.escape( fragment ) }`;
+
 		// First try the standard CSS selector approach (finds elements with matching IDs)
-		if ( document.querySelector( href ) !== null ) {
+		if ( document.querySelector( idSelector ) !== null ) {
 			return true;
 		}
 
 		// If no ID match found, check for anchor elements with matching name attribute
-		// Extract the fragment identifier (remove the # prefix)
-		const fragment = href.substring( 1 );
-
-		// Look for anchor elements with matching name attribute
-		const namedAnchor = document.querySelector( `a[name="${ fragment }"]` );
+		// Also escape the fragment for the name attribute selector
+		const namedAnchor = document.querySelector( `a[name="${ CSS.escape( fragment ) }"]` );
 
 		return namedAnchor !== null;
 	},

--- a/tests/jest/rules/brokenAnchorLink.test.js
+++ b/tests/jest/rules/brokenAnchorLink.test.js
@@ -1,0 +1,105 @@
+import axe from 'axe-core';
+
+beforeAll( async () => {
+	const ruleModule = await import( '../../../src/pageScanner/rules/broken-anchor-link.js' );
+	const checkModule = await import( '../../../src/pageScanner/checks/anchor-exists.js' );
+
+	axe.configure( {
+		rules: [ ruleModule.default ],
+		checks: [ checkModule.default ],
+	} );
+} );
+
+beforeEach( () => {
+	document.body.innerHTML = '';
+
+	const style = document.createElement( 'style' );
+	style.innerHTML = `
+		.hidden { display: none; }
+		.invisible { visibility: hidden; }
+	`;
+	document.head.appendChild( style );
+} );
+
+describe( 'Broken Anchor Link Rule', () => {
+	test.each( [
+		// ❌ Failing cases - links with no matching targets
+		{
+			name: 'fails when anchor link points to non-existent ID',
+			html: '<a href="#nonexistent">Link to nowhere</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'fails when anchor link points to non-existent name',
+			html: '<a href="#missing">Link to missing anchor</a>',
+			shouldPass: false,
+		},
+
+		// ✅ Passing cases - links with valid targets
+		{
+			name: 'passes when anchor link points to element with matching ID',
+			html: '<a href="#section1">Go to section</a><div id="section1">Content</div>',
+			shouldPass: true,
+		},
+		{
+			name: 'passes when anchor link points to anchor with matching name attribute',
+			html: '<a href="#footnote1">Footnote reference</a><a name="footnote1"></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'passes when anchor link points to existing heading with ID',
+			html: '<a href="#heading">Go to heading</a><h2 id="heading">Main Heading</h2>',
+			shouldPass: true,
+		},
+		{
+			name: 'passes when multiple anchors point to same name target',
+			html: '<a href="#note1">First ref</a><a href="#note1">Second ref</a><a name="note1"></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'passes when anchor targets both ID and name (should find ID first)',
+			html: '<a href="#target">Link</a><div id="target">ID target</div><a name="target"></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'passes for complex footnote pattern',
+			html: `
+				<p>This is some text with a footnote reference <a href="#footnote1" aria-label="Footnote 1">[1]</a>.</p>
+				<div>
+					<a name="footnote1"></a>
+					<p>This is the footnote text.</p>
+				</div>
+			`,
+			shouldPass: true,
+		},
+
+		// Edge cases
+		{
+			name: 'ignores links with href="#" (empty fragment)',
+			html: '<a href="#">Empty anchor</a>',
+			shouldPass: true, // This should be ignored by the selector
+		},
+		{
+			name: 'ignores links with role="button"',
+			html: '<a href="#nowhere" role="button">Button link</a>',
+			shouldPass: true, // This should be ignored by the selector
+		},
+		{
+			name: 'handles special characters in anchor names',
+			html: '<a href="#special-chars_123">Link</a><a name="special-chars_123"></a>',
+			shouldPass: true,
+		},
+	] )( '$name', async ( { html, shouldPass } ) => {
+		document.body.innerHTML = html;
+
+		const results = await axe.run( document.body, {
+			runOnly: [ 'broken_skip_anchor_link' ],
+		} );
+
+		if ( shouldPass ) {
+			expect( results.violations.length ).toBe( 0 );
+		} else {
+			expect( results.violations.length ).toBeGreaterThan( 0 );
+		}
+	} );
+} );

--- a/tests/jest/rules/brokenAnchorLink.test.js
+++ b/tests/jest/rules/brokenAnchorLink.test.js
@@ -1,5 +1,13 @@
 import axe from 'axe-core';
 
+// Add CSS.escape polyfill for Jest environment
+if ( typeof CSS === 'undefined' || typeof CSS.escape !== 'function' ) {
+	window.CSS = window.CSS || {};
+	window.CSS.escape = function( value ) {
+		return String( value ).replace( /[!"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~\s]/g, '\\$&' );
+	};
+}
+
 beforeAll( async () => {
 	const ruleModule = await import( '../../../src/pageScanner/rules/broken-anchor-link.js' );
 	const checkModule = await import( '../../../src/pageScanner/checks/anchor-exists.js' );


### PR DESCRIPTION
This pull request enhances the functionality of the `anchor_exists` check by adding support for validating anchor links that target elements with a `name` attribute, in addition to those with an `id`. It also introduces comprehensive Jest tests to validate the behavior of the updated check across various scenarios, including edge cases.

### Enhancements to `anchor_exists` check:
* Updated `src/pageScanner/checks/anchor-exists.js` to validate anchor links by first checking for an element with a matching `id` and, if not found, looking for an anchor element with a matching `name` attribute.

### Addition of Jest tests:
* Added `tests/jest/rules/brokenAnchorLink.test.js` to cover a wide range of scenarios for anchor link validation, including:
  - Links pointing to non-existent `id` or `name` attributes.
  - Links with valid targets, including elements with `id` or `name` attributes.
  - Edge cases such as empty fragments (`href="#"`), links with `role="button"`, and anchor names containing special characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved detection of anchor links by ensuring both ID and named anchor targets are recognized, reducing false positives for broken anchor links.

- **Tests**
	- Added comprehensive tests to verify correct identification of broken and valid anchor links, including edge cases and special scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->