### PR TITLE
docs: add section on reporting security bugs to README

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,7 +194,7 @@ No, Accessibility Checker runs completely on your server and does not require yo
 
 = How can I report security bugs? =
 
-You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.]( https://patchstack.com/database/vdp/9e5fb76c-bea8-430c-8bec-89d6f38ad57a )
+You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/9e5fb76c-bea8-430c-8bec-89d6f38ad57a)
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,10 @@ Accessibility Checker was built with performance in mind and should not slow dow
 
 No, Accessibility Checker runs completely on your server and does not require you to connect to any external APIs or services for scans. This can save you thousands of dollars per year in accessibility scanning fees and is privacy-focused, ensuring that your website data stays completely under your control.
 
+= How can I report security bugs? =
+
+You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.]( https://patchstack.com/database/vdp/9e5fb76c-bea8-430c-8bec-89d6f38ad57a )
+
 == Screenshots ==
 
 1. Accessibility Checker Summary tab on a page with numerous errors and warnings.


### PR DESCRIPTION
This pull request updates the `readme.txt` file to include information about reporting security bugs. 

Documentation update:

* Added a new section explaining how to report security bugs through the Patchstack Vulnerability Disclosure Program, including a link to the reporting page. (`[readme.txtR195-R198](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R195-R198)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new FAQ entry explaining how to report security bugs, including a direct link to the Patchstack Vulnerability Disclosure Program.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->