### PR TITLE
update: average issues per post calculation to handle zero issues case

### DIFF
--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -284,7 +284,10 @@ class Scans_Stats {
 			$data['posts_without_issues'] = $wpdb->get_var( $posts_without_issues ) + $wpdb->get_var( $posts_with_just_ignored_issues );
 			$data['avg_issues_per_post']  = round( ( $data['warnings'] + $data['errors'] ) / $data['posts_scanned'], 2 );
 
-			if ( $data['avg_issues_per_post'] < 1 && 0 !== $data['avg_issues_per_post'] ) {
+			// If there are no issues at all, show 0. If there are issues but average is less than 1, show "< 1".
+			if ( 0 === $data['warnings'] && 0 === $data['errors'] ) {
+				$data['avg_issues_per_post'] = 0;
+			} elseif ( $data['avg_issues_per_post'] < 1 && 0 !== $data['avg_issues_per_post'] ) {
 				$data['avg_issues_per_post'] = '< 1';
 			}
 		}


### PR DESCRIPTION
This pull request introduces a small but meaningful change to improve the clarity of how average issues per post are displayed in the `admin/class-scans-stats.php` file. Specifically, it ensures that when there are no issues at all, the average is explicitly shown as `0`, and when the average is less than `1`, it is displayed as `"< 1"`.

Key change:

* Updated the logic in the `function ( $item )` to handle cases where there are no issues (`warnings` and `errors` both equal `0`) by explicitly setting `avg_issues_per_post` to `0`. This improves the accuracy and readability of the displayed data.