### PR TITLE
feat: Add unit tests for Admin/Settings class

### DIFF
--- a/tests/phpunit/Admin/SettingsTest.php
+++ b/tests/phpunit/Admin/SettingsTest.php
@@ -10,8 +10,25 @@ use WP_UnitTestCase;
 // If specific mocks are needed, they should be handled by WP_Mock or filters if possible.
 // Removing global shims as they likely cause conflicts with the CI's WordPress environment.
 
-// Mock Pro class definitions will be moved inside the specific tests that need them
-// to ensure they are only defined within an isolated process.
+// Mock Pro classes if they don't exist - this is for local testing if Pro plugin isn't present.
+// These are defined at the top level, guarded by class_exists, and tests using them
+// for aliasing run in separate processes.
+if ( ! class_exists( 'MockEDACPSettings', false ) ) {
+	class MockEDACPSettings {
+		public static $returnValue = ['post', 'page', 'custom_pro_type'];
+		public static function get_scannable_post_types() {
+			return self::$returnValue;
+		}
+	}
+}
+if ( ! class_exists( 'MockEqualizeDigitalAccessibilityCheckerProAdminSettings', false ) ) {
+	class MockEqualizeDigitalAccessibilityCheckerProAdminSettings {
+		public static $returnValue = ['post', 'page', 'new_custom_pro_type'];
+		public static function get_scannable_post_types() {
+			return self::$returnValue;
+		}
+	}
+}
 
 class SettingsTest extends WP_UnitTestCase {
 
@@ -148,32 +165,20 @@ class SettingsTest extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_scannable_post_types_pro_version_edacp_settings_exists() {
-		// Define mock class here to ensure it's only for this process
-		if ( ! class_exists( 'MockEDACPSettingsForTest', false ) ) {
-			class MockEDACPSettingsForTest {
-				public static $returnValue = ['post', 'page', 'custom_pro_type_edacp'];
-				public static function get_scannable_post_types() {
-					return self::$returnValue;
-				}
-			}
-		}
-
-		if (!class_exists('EDACP\Settings')) {
-			class_alias('MockEDACPSettingsForTest', 'EDACP\Settings');
-		} elseif (!is_a('EDACP\Settings', 'MockEDACPSettingsForTest', true)) {
+		// Aliasing to the globally defined (but guarded) mock classes.
+		if (!class_exists('EDACP\Settings', false)) {
+			class_alias('MockEDACPSettings', 'EDACP\Settings');
+		} elseif (!is_a('EDACP\Settings', 'MockEDACPSettings', true)) {
 			$this->markTestSkipped('Original EDACP\Settings class is present and not the mock. Cannot reliably test this scenario.');
 		}
 
 		// Ensure the newer Pro settings class does NOT exist or is not our mock for it for this specific test.
-		// If EqualizeDigital\AccessibilityCheckerPro\Admin\Settings exists and is the REAL one, this test is not valid.
 		if (class_exists('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings', false) &&
-			!is_a('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings', 'MockEqualizeDigitalAccessibilityCheckerProAdminSettingsForTest', true) ) {
-			// This is complex; ideally, we'd ensure it's not loaded.
-			// For now, if the real class exists, this test for the older pro class might be skewed.
-			// Consider if this scenario (real new pro class + mock old pro class) is truly testable/needed.
+			!is_a('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings', 'MockEqualizeDigitalAccessibilityCheckerProAdminSettings', true) ) {
+			// If the real new pro class exists, this test for the older pro class might be skewed.
 		}
 
-		$expected_types = \MockEDACPSettingsForTest::$returnValue;
+		$expected_types = \MockEDACPSettings::$returnValue;
 		$post_types = Settings::get_scannable_post_types();
 		$this->assertEquals( $expected_types, $post_types );
 	}
@@ -183,39 +188,21 @@ class SettingsTest extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_scannable_post_types_pro_version_new_settings_class_exists() {
-		// Define mock classes here
-		if ( ! class_exists( 'MockEDACPSettingsForTestNew', false ) ) {
-			class MockEDACPSettingsForTestNew { // Different name to avoid conflict if somehow same process
-				public static $returnValue = ['post', 'page', 'custom_pro_type_edacp_old_for_new_test'];
-				public static function get_scannable_post_types() {
-					return self::$returnValue;
-				}
-			}
-		}
-		if ( ! class_exists( 'MockEqualizeDigitalAccessibilityCheckerProAdminSettingsForTest', false ) ) {
-			class MockEqualizeDigitalAccessibilityCheckerProAdminSettingsForTest {
-				public static $returnValue = ['post', 'page', 'new_custom_pro_type_new'];
-				public static function get_scannable_post_types() {
-					return self::$returnValue;
-				}
-			}
-		}
-
-		// Mock new settings class to exist
-		if (!class_exists('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings')) {
-			class_alias('MockEqualizeDigitalAccessibilityCheckerProAdminSettingsForTest', 'EqualizeDigital\AccessibilityCheckerPro\Admin\Settings');
-		} elseif (!is_a('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings', 'MockEqualizeDigitalAccessibilityCheckerProAdminSettingsForTest', true)) {
+		// Aliasing to the globally defined (but guarded) mock classes.
+		if (!class_exists('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings', false)) {
+			class_alias('MockEqualizeDigitalAccessibilityCheckerProAdminSettings', 'EqualizeDigital\AccessibilityCheckerPro\Admin\Settings');
+		} elseif (!is_a('EqualizeDigital\AccessibilityCheckerPro\Admin\Settings', 'MockEqualizeDigitalAccessibilityCheckerProAdminSettings', true)) {
 			$this->markTestSkipped('Original EqualizeDigital\AccessibilityCheckerPro\Admin\Settings class is present and not the mock.');
 		}
 
 		// Also ensure the older EDACP\Settings exists (as our mock) to test precedence
-		if (!class_exists('EDACP\Settings')) {
-			class_alias('MockEDACPSettingsForTestNew', 'EDACP\Settings');
-		} elseif (!is_a('EDACP\Settings', 'MockEDACPSettingsForTestNew', true) ){
-			// This indicates the actual EDACP\Settings might be loaded and isn't our mock for this specific test run.
+		if (!class_exists('EDACP\Settings', false)) {
+			class_alias('MockEDACPSettings', 'EDACP\Settings');
+		} elseif (!is_a('EDACP\Settings', 'MockEDACPSettings', true) ){
+			// This indicates the actual EDACP\Settings might be loaded and isn't our mock.
 		}
 
-		$expected_types = \MockEqualizeDigitalAccessibilityCheckerProAdminSettingsForTest::$returnValue;
+		$expected_types = \MockEqualizeDigitalAccessibilityCheckerProAdminSettings::$returnValue;
 		$post_types = Settings::get_scannable_post_types();
 		$this->assertEquals( $expected_types, $post_types );
 	}


### PR DESCRIPTION
Adds PHPUnit tests for the EDAC\Admin\Settings class to improve code coverage.

Covers methods:
- get_scannable_post_statuses
- get_scannable_post_types (free and pro version logic)
- get_scannable_posts_count

Includes mocks for WordPress functions and Pro plugin classes to enable isolated testing.

<!-- Always provide a short description -->

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for admin settings, covering retrieval of scannable post statuses and post types in both free and Pro versions.
  * Included tests for handling various input scenarios, such as invalid types, empty results, and option value types.
  * Added mock classes and database simulations to ensure robust coverage of different environments and plugin configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->