### PR TITLE
added: plugin action links class to add Settings and Get Pro links

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -48,6 +48,9 @@ class Admin {
 		add_action( 'wp_trash_post', [ Purge_Post_Data::class, 'delete_post' ] );
 		add_action( 'save_post', [ Post_Save::class, 'delete_issue_data_on_post_trashing' ], 10, 3 );
 
+		$plugin_action_links = new Plugin_Action_Links();
+		$plugin_action_links->init_hooks();
+
 		$admin_notices = new Admin_Notices();
 		$admin_notices->init_hooks();
 

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -9,11 +9,15 @@ namespace EDAC\Admin;
 
 /**
  * Plugin Action Links handling class.
+ *
+ * @since 1.27.0
  */
 class Plugin_Action_Links {
 
 	/**
 	 * Initialize hooks.
+	 *
+	 * @since 1.27.0
 	 *
 	 * @return void
 	 */

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -55,7 +55,7 @@ class Plugin_Action_Links {
 		array_unshift( $links, $settings_link );
 
 		// Add Pro link if not already pro version.
-		if ( ! EDAC_KEY_VALID ) {
+		if ( defined( 'EDAC_KEY_VALID' ) && ! EDAC_KEY_VALID ) {
 			$go_pro_text = esc_html__( 'Get Pro', 'accessibility-checker' );
 			
 			$links['go_pro'] = sprintf( 

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Plugin Action Links class file for the Accessibility Checker plugin.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Admin;
+
+/**
+ * Plugin Action Links handling class.
+ */
+class Plugin_Action_Links {
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks(): void {
+		add_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this, 'plugin_action_links' ] );
+	}
+
+	/**
+	 * Plugin action links.
+	 *
+	 * Adds action links to the plugin list table
+	 *
+	 * Fired by `plugin_action_links` filter.
+	 *
+	 * @since 1.27.0
+	 * @access public
+	 *
+	 * @param array $links An array of plugin action links.
+	 *
+	 * @return array An array of plugin action links.
+	 */
+	public function plugin_action_links( $links ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
+		$settings_link = sprintf( 
+			'<a href="%1$s">%2$s</a>', 
+			admin_url( 'admin.php?page=accessibility_checker_settings' ), 
+			esc_html__( 'Settings', 'accessibility-checker' ) 
+		);
+
+		array_unshift( $links, $settings_link );
+
+		// Add Pro link if not already pro version.
+		if ( ! EDAC_KEY_VALID ) {
+			$go_pro_text = esc_html__( 'Get Pro', 'accessibility-checker' );
+			
+			$links['go_pro'] = sprintf( 
+				'<a href="%1$s" target="_blank" class="edac-plugin-action-links__go-pro" aria-label="%2$s">%3$s</a>', 
+				edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'plugin-action-links', 'get-pro-link', false ), 
+				esc_attr__( 'Get Accessibility Checker Pro, opens in new window', 'accessibility-checker' ),
+				$go_pro_text 
+			);
+		}
+
+		return $links;
+	}
+}

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -26,7 +26,9 @@ class Plugin_Action_Links {
 	 * @return void
 	 */
 	public function init_hooks(): void {
-		add_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this, 'plugin_action_links' ] );
+		if ( defined( 'EDAC_PLUGIN_FILE' ) ) {
+			add_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this, 'plugin_action_links' ] );
+		}
 	}
 
 	/**

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -13,6 +13,14 @@ namespace EDAC\Admin;
 class Plugin_Action_Links {
 
 	/**
+	 * Class constructor.
+	 *
+	 * Initializes the hooks for the plugin action links.
+	 */
+	public function __construct() {
+	}
+
+	/**
 	 * Initialize hooks.
 	 *
 	 * @return void
@@ -35,7 +43,7 @@ class Plugin_Action_Links {
 	 *
 	 * @return array An array of plugin action links.
 	 */
-	public function plugin_action_links( $links ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
+	public function plugin_action_links( $links ): array {
 		$settings_link = sprintf( 
 			'<a href="%1$s">%2$s</a>', 
 			admin_url( 'admin.php?page=accessibility_checker_settings' ), 

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -51,7 +51,7 @@ class Plugin_Action_Links {
 		array_unshift( $links, $settings_link );
 
 		// Add Pro link if not already pro version.
-		if ( defined( 'EDAC_KEY_VALID' ) && ! EDAC_KEY_VALID ) {
+		if ( ! defined( 'EDACP_VERSION' ) || ! EDAC_KEY_VALID ) {
 			$go_pro_text = esc_html__( 'Get Pro', 'accessibility-checker' );
 			
 			$links['go_pro'] = sprintf( 

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -13,14 +13,6 @@ namespace EDAC\Admin;
 class Plugin_Action_Links {
 
 	/**
-	 * Class constructor.
-	 *
-	 * Initializes the hooks for the plugin action links.
-	 */
-	public function __construct() {
-	}
-
-	/**
 	 * Initialize hooks.
 	 *
 	 * @return void
@@ -48,7 +40,7 @@ class Plugin_Action_Links {
 	public function add_plugin_action_links( $links ): array {
 		$settings_link = sprintf( 
 			'<a href="%1$s">%2$s</a>', 
-			admin_url( 'admin.php?page=accessibility_checker_settings' ), 
+			esc_url( admin_url( 'admin.php?page=accessibility_checker_settings' ) ), 
 			esc_html__( 'Settings', 'accessibility-checker' ) 
 		);
 
@@ -60,7 +52,7 @@ class Plugin_Action_Links {
 			
 			$links['go_pro'] = sprintf( 
 				'<a href="%1$s" target="_blank" class="edac-plugin-action-links__go-pro" aria-label="%2$s">%3$s</a>', 
-				edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'plugin-action-links', 'get-pro-link', false ), 
+				esc_url( edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'plugin-action-links', 'get-pro-link', false ) ), 
 				esc_attr__( 'Get Accessibility Checker Pro, opens in new window', 'accessibility-checker' ),
 				$go_pro_text 
 			);

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -27,12 +27,12 @@ class Plugin_Action_Links {
 	 */
 	public function init_hooks(): void {
 		if ( defined( 'EDAC_PLUGIN_FILE' ) ) {
-			add_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this, 'plugin_action_links' ] );
+			add_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this, 'add_plugin_action_links' ] );
 		}
 	}
 
 	/**
-	 * Plugin action links.
+	 * Add plugin action links.
 	 *
 	 * Adds action links to the plugin list table
 	 *
@@ -45,7 +45,7 @@ class Plugin_Action_Links {
 	 *
 	 * @return array An array of plugin action links.
 	 */
-	public function plugin_action_links( $links ): array {
+	public function add_plugin_action_links( $links ): array {
 		$settings_link = sprintf( 
 			'<a href="%1$s">%2$s</a>', 
 			admin_url( 'admin.php?page=accessibility_checker_settings' ), 

--- a/languages/accessibility-checker.pot
+++ b/languages/accessibility-checker.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-01T15:48:13+00:00\n"
+"POT-Creation-Date: 2025-07-03T20:51:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: accessibility-checker\n"
@@ -65,11 +65,12 @@ msgstr ""
 
 #: admin/AdminPage/FixesSettingType/Checkbox.php:47
 #: admin/AdminPage/FixesSettingType/Text.php:38
+#: admin/class-plugin-action-links.php:51
 msgid "Get Pro"
 msgstr ""
 
 #: admin/AdminPage/FixesSettingType/Checkbox.php:67
-#: admin/class-ajax.php:352
+#: admin/class-ajax.php:354
 msgid "Opens in a new window."
 msgstr ""
 
@@ -153,10 +154,10 @@ msgstr ""
 #: admin/class-admin-notices.php:401
 #: admin/class-admin-notices.php:489
 #: admin/class-ajax.php:56
-#: admin/class-ajax.php:210
-#: admin/class-ajax.php:575
-#: admin/class-ajax.php:713
-#: admin/class-ajax.php:793
+#: admin/class-ajax.php:212
+#: admin/class-ajax.php:577
+#: admin/class-ajax.php:715
+#: admin/class-ajax.php:795
 #: admin/class-frontend-highlight.php:79
 msgid "Permission Denied"
 msgstr ""
@@ -231,9 +232,9 @@ msgid "upgrade to pro"
 msgstr ""
 
 #: admin/class-ajax.php:63
-#: admin/class-ajax.php:217
-#: admin/class-ajax.php:582
-#: admin/class-ajax.php:800
+#: admin/class-ajax.php:219
+#: admin/class-ajax.php:584
+#: admin/class-ajax.php:802
 msgid "The post ID was not set"
 msgstr ""
 
@@ -285,67 +286,67 @@ msgid_plural "%s Ignored Items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: admin/class-ajax.php:187
+#: admin/class-ajax.php:189
 msgid "No summary to return"
 msgstr ""
 
-#: admin/class-ajax.php:231
+#: admin/class-ajax.php:233
 msgid "Invalid table name"
 msgstr ""
 
-#: admin/class-ajax.php:377
+#: admin/class-ajax.php:379
 msgid "These settings enable global fixes across your entire site."
 msgstr ""
 
-#: admin/class-ajax.php:378
+#: admin/class-ajax.php:380
 msgid "Pages may need to be resaved or a full site scan run to see fixes reflected in reports."
 msgstr ""
 
-#: admin/class-ajax.php:406
+#: admin/class-ajax.php:408
 #: build/frontendHighlighterApp.bundle.js:2
 msgid "Save"
 msgstr ""
 
-#: admin/class-ajax.php:426
+#: admin/class-ajax.php:428
 msgid "Affected Code"
 msgstr ""
 
 #. Translators: %d is the issue ID.
-#: admin/class-ajax.php:491
+#: admin/class-ajax.php:493
 #, php-format
 msgid "View Issue ID %d on website, opens a new window"
 msgstr ""
 
-#: admin/class-ajax.php:492
+#: admin/class-ajax.php:494
 msgid "View on page"
 msgstr ""
 
-#: admin/class-ajax.php:511
+#: admin/class-ajax.php:513
 msgid "Fix: "
 msgstr ""
 
-#: admin/class-ajax.php:512
+#: admin/class-ajax.php:514
 msgid "Fix"
 msgstr ""
 
-#: admin/class-ajax.php:535
+#: admin/class-ajax.php:537
 msgid "Your user account doesn't have permission to ignore this issue."
 msgstr ""
 
-#: admin/class-ajax.php:553
+#: admin/class-ajax.php:555
 msgid "No details to return"
 msgstr ""
 
-#: admin/class-ajax.php:692
+#: admin/class-ajax.php:694
 msgid "No readability data to return"
 msgstr ""
 
-#: admin/class-ajax.php:749
-#: admin/class-ajax.php:772
+#: admin/class-ajax.php:751
+#: admin/class-ajax.php:774
 msgid "No ignore data to return"
 msgstr ""
 
-#: admin/class-ajax.php:807
+#: admin/class-ajax.php:809
 msgid "The summary was not set"
 msgstr ""
 
@@ -359,6 +360,15 @@ msgstr ""
 
 #: admin/class-frontend-highlight.php:137
 msgid "Object query returned no results"
+msgstr ""
+
+#: admin/class-plugin-action-links.php:44
+#: includes/options-page.php:66
+msgid "Settings"
+msgstr ""
+
+#: admin/class-plugin-action-links.php:56
+msgid "Get Accessibility Checker Pro, opens in new window"
 msgstr ""
 
 #: admin/class-welcome-page.php:38
@@ -1179,10 +1189,6 @@ msgstr ""
 msgid "Accessibility Checker Settings"
 msgstr ""
 
-#: includes/options-page.php:66
-msgid "Settings"
-msgstr ""
-
 #: includes/options-page.php:99
 msgid "General Settings"
 msgstr ""
@@ -1351,390 +1357,390 @@ msgid "Image Missing Alternative Text"
 msgstr ""
 
 #. translators: %1$s is <code>alt=""</code>, %2$s is the <code>&lt;a&gt;</code> tag.
-#: includes/rules.php:28
+#: includes/rules.php:27
 #, php-format
 msgid "An Image Missing Alternative Text error means that your image does not have an alt attribute (%1$s) contained in the image tag (%2$s) at all. To fix an Image Missing Alternative Text error, you will need to add an alt tag to the image with appropriate text describing the purpose of the image in the page. If the image is decorative, the alt attribute can be empty, but the HTML %1$s tag still needs to be present."
 msgstr ""
 
-#: includes/rules.php:35
+#: includes/rules.php:34
 msgid "Image Empty Alternative Text"
 msgstr ""
 
 #. translators: %s is <code>alt=""</code>.
-#: includes/rules.php:42
+#: includes/rules.php:40
 #, php-format
 msgid "An Image Empty Alternative Text warning appears if you have an image with an alt attribute (%s) that is empty. Alternative text tells people who cannot see what the images is and adds additional context to the post or page. It is only correct for alternative text to be empty if the image is purely decorative, like a border or decorative icon. To fix an Image Empty Alternative Text warning, you need to determine if the image is decorative or if adds something meaningful to the page. If it is not decorative, you need to add appropriate alternative text to describe the image's purpose. If the image is decorative, then you would leave the alternative text blank and “Ignore” the warning."
 msgstr ""
 
-#: includes/rules.php:48
+#: includes/rules.php:46
 msgid "Low-quality Alternative Text"
 msgstr ""
 
-#: includes/rules.php:53
+#: includes/rules.php:50
 msgid "A Low-quality Alternative Text warning appears when the alternative text on an image contains keywords that are unnecessary in alternative text (such as \"image\" or \"graphic\"), a file extension (such as .JPG), that may be describing a decorative image (such as \"spacer\" or \"arrow\"). To fix this warning, you will need to rewrite the alternative text for any images that flagged the Low-Quality Alternative Text warning, ensuring the alternative text is accurate, unique, contextually appropriate, and does not contain redundant or unnecessary descriptors. If the image is purely decorative, it is correct to leave the alternative text blank."
 msgstr ""
 
-#: includes/rules.php:57
+#: includes/rules.php:54
 msgid "Linked Image Missing Alternative Text"
 msgstr ""
 
 #. translators: %s is <code>alt=""</code>.
-#: includes/rules.php:64
+#: includes/rules.php:60
 #, php-format
 msgid "A Linked Image Missing Alternative Text error appears when an image that is linked to a URL does not have an alt attribute (%s) in the image tag at all. Linked images must have accurate alternative text that describes where the link goes so that screen reader users know where the link is pointing. To resolve this error you need to add meaningful alt text to the image. Your alt text should describe the link purpose not what the image looks like."
 msgstr ""
 
-#: includes/rules.php:70
+#: includes/rules.php:66
 msgid "Linked Image Empty Alternative Text"
 msgstr ""
 
 #. translators: %s is <code>alt=""</code>.
-#: includes/rules.php:77
+#: includes/rules.php:72
 #, php-format
 msgid "A Linked Image Empty Alternative Text error appears when an image that is linked to a URL has an alt attribute (%s) with nothing in it. Linked images must have accurate alternative text that describes where the link goes so that screen reader users know where the link is pointing. To resolve this error you need to add meaningful alt text to the image. Your alt text should describe the link purpose not what the image looks like."
 msgstr ""
 
-#: includes/rules.php:83
+#: includes/rules.php:78
 msgid "Duplicate Alternative Text"
 msgstr ""
 
-#: includes/rules.php:88
+#: includes/rules.php:82
 msgid "Duplicate Alternative Text warnings appear when the alternative text for an image on your post or page is identical to nearby or adjacent text, including the image’s title or caption. This warning also occurs if two images on the page have the same alternative text. To resolve this warning, you will need to change the text of either one or both elements that flagged the Duplicate Alternative Text warning, ensuring that all images have unique alt text and that you are not repeating your alt text in your image titles and captions."
 msgstr ""
 
-#: includes/rules.php:92
+#: includes/rules.php:86
 msgid "Incorrect Heading Order"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;h3&gt;</code>, %2$s is <code>&lt;h1&gt;</code>, %3$s is <code>&lt;h2&gt;</code>.
-#: includes/rules.php:99
+#: includes/rules.php:92
 #, php-format
 msgid "An Incorrect Heading Order error means your heading structure has skipped over a level. For example, if your page structure has a level 3 heading (%1$s) under a level 1 heading (%2$s), an \"Incorrect Heading Order\" error will be flagged because there is no %3$s tag between the H1 and H3. To fix incorrect heading order errors, you will need to either change the incorrect heading level to the correct heading level, or add content with the correct heading level in between the two already existing levels."
 msgstr ""
 
-#: includes/rules.php:110
+#: includes/rules.php:103
 msgid "Empty Paragraph Tag"
 msgstr ""
 
-#: includes/rules.php:115
+#: includes/rules.php:107
 msgid "An Empty Paragraph Tag warning means there is a paragraph tag present that does not contain content. These may be announced by screen readers or create confusion for users. To fix this warning, remove the empty paragraphs from the page. If you need to add spacing between sections, this should be done with padding, margins, or a spacer block."
 msgstr ""
 
-#: includes/rules.php:119
+#: includes/rules.php:111
 msgid "iframe Missing Title"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;iframe&gt;</code>.
-#: includes/rules.php:126
+#: includes/rules.php:117
 #, php-format
 msgid "An iframe Missing title error means that one or more of the iframes on your post or page does not have an accessible title describing the contents of the iframe. An iframe title is an attribute that can be added to the %1$s tag to describe the contents of the frame to people using assistive technology. To fix a missing iframe title, you will need to add a title or an aria-label attribute to the %1$s tag. The attribute should accurately describe the contents of the iframe."
 msgstr ""
 
-#: includes/rules.php:135
+#: includes/rules.php:126
 msgid "Missing Subheadings"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;h1&gt;</code>, %2$s is <code>&lt;h6&gt;</code>.
-#: includes/rules.php:142
+#: includes/rules.php:132
 #, php-format
 msgid "A warning about missing headings means that your post or page does not contain any heading elements (%1$s–%2$s) within the content of the post or page body section, which can make it especially difficult for screen reader users to navigate through the content on the page. To fix a page with no headings, you will need to add heading elements. At a minimum, every page should have one %1$s tag, which is typically the page title. Add additional subheadings as appropriate for your content. If you have determined that headings are definitely not needed on the page, then you can “Ignore” the warning."
 msgstr ""
 
-#: includes/rules.php:150
+#: includes/rules.php:140
 msgid "Text Justified"
 msgstr ""
 
-#: includes/rules.php:155
+#: includes/rules.php:144
 msgid "A Text Justified warning appears in Accessibility Checker when text with more than 200 characters on your post or page is styled with justified alignment (text-align:justify). To fix this warning, remove the justified styling from the specified text elements."
 msgstr ""
 
-#: includes/rules.php:159
+#: includes/rules.php:148
 msgid "Link Opens New Window or Tab"
 msgstr ""
 
 #. translators: %s is the link to the plugin, with text "Accessibility New Window Warnings" linked.
-#: includes/rules.php:166
+#: includes/rules.php:154
 #, php-format
 msgid "A Link Opens New Window or Tab warning appears when there is a link on your website that has been set to open in a new tab or window when clicked. It is considered best practice to not open new tabs or windows with links. If links do open new tabs or windows, there must be a visual and auditory warning announcing that the link will open a new window or tab so that users will expect that behavior and know how to go back after clicking the link. To fix this warning, either change the link not to open in a new tab or ensure \"opens new window\" is included in the link text then \"Ignore\" the warning. To automatically add notices to all links on your site and dismiss all these warnings, install our free %s plugin."
 msgstr ""
 
-#: includes/rules.php:167
+#: includes/rules.php:155
 msgid "Accessibility New Window Warnings"
 msgstr ""
 
-#: includes/rules.php:179
+#: includes/rules.php:167
 msgid "Image Map Missing Alternative Text"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;area&gt;</code>, %2$s is <code>alt=""</code>.
-#: includes/rules.php:186
+#: includes/rules.php:173
 #, php-format
 msgid "The Image Map Missing Alternative Text error means that one of the %1$s elements within your image map does not have alternative text added in an %2$s attribute. To fix this error, you will need to add missing alt text to any area tags that do not have alt text. The alt text needs to describe the function of the link contained in the area, not necessarily describe what the area looks like."
 msgstr ""
 
-#: includes/rules.php:196
+#: includes/rules.php:183
 msgid "Tab Order Modified"
 msgstr ""
 
 #. translators: %s is <code>tabindex="1"</code>.
-#: includes/rules.php:203
+#: includes/rules.php:189
 #, php-format
 msgid "A Tab Order Modified Warning appears when the logical tab order on the page has been changed by adding an attribute for tabindex that is greater than 0 to an HTML element (for example, %s). This can cause navigation issues for keyboard-only users. To resolve a Tab Order Modified warning you need to view the front end of your website on the page or post where the tab order has been modified and test to see if the modification is correct or not. If the tab order modification does not cause problems, then you can \"Ignore\" the warning. If the modified tab order causes information to be presented out of order, then you need to remove the tabindex attribute from the flagged element."
 msgstr ""
 
-#: includes/rules.php:213
+#: includes/rules.php:199
 msgid "Empty Heading Tag"
 msgstr ""
 
 #. translators: %s is <code>&lt;h1&gt;&lt;/h1&gt;</code>.
-#: includes/rules.php:220
+#: includes/rules.php:205
 #, php-format
 msgid "An Empty Heading Tag error means that there is a heading tag present on your post or page that does not contain content. In code, this error would look like this: %s. To fix an empty heading, you will need to add content to the heading tag that has flagged the Empty Heading Tag error or remove the empty tag if it is not needed on your page."
 msgstr ""
 
-#: includes/rules.php:226
+#: includes/rules.php:211
 msgid "Empty Link"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;a&gt;</code>, %2$s is <code>aria-hidden="true"</code>, %3$s is <code>aria-label</code>.
-#: includes/rules.php:233
+#: includes/rules.php:217
 #, php-format
 msgid "An Empty Link error means that one of the links present on the web page is empty or contains no text describing where the link will go if clicked. This commonly occurs with links that contain webfonts, icon fonts, and SVGs, or when a link has accidentally been created in the content editor. To fix an empty link error, you will need to find the link that is being flagged and add descriptive text to it. You will need to either: add text content within an empty %1$s element or, if your link contains an SVG or Webfont icon, hide that element with %2$s and add an %3$s attribute to the %1$s tag or screen reader text. The text or label you add should be descriptive of wherever the link points and not ambiguous."
 msgstr ""
 
-#: includes/rules.php:241
+#: includes/rules.php:225
 msgid "Empty Button"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;button&gt;</code>, %2$s is <code>&lt;input&gt;</code>.
-#: includes/rules.php:248
+#: includes/rules.php:231
 #, php-format
 msgid "An Empty Button error means that one of the buttons present on the web page is empty or contains no text describing the function of the button. Or, if it is an image button, the image contained in the button is missing alternative text. To fix an empty button error, you will need to find the button that is being flagged and add descriptive text to it. You will need to either: add text content within an empty %1$s element, add a value attribute to an %2$s that is missing one, or add alternative text to a button image. The text should be descriptive of whatever your button is being used for or the action that the button triggers."
 msgstr ""
 
-#: includes/rules.php:255
+#: includes/rules.php:238
 msgid "Image Long Alternative Text"
 msgstr ""
 
-#: includes/rules.php:260
+#: includes/rules.php:242
 msgid "An Image Long Alternative Text warning appears if there are more than 100 characters in your alternative text. Alternative text is meant to be descriptive of the image but in a succinct manner, without being too wordy. To fix this warning, you need to shorten your alt text for any images that have been flagged to 100 characters or less. If you have determined that your alternative text is good as-is, then \"Ignore\" the warning."
 msgstr ""
 
-#: includes/rules.php:264
+#: includes/rules.php:246
 msgid "ARIA Hidden"
 msgstr ""
 
-#: includes/rules.php:269
+#: includes/rules.php:250
 msgid "The ARIA Hidden warning appears when content on your post or page has been hidden using the aria-hidden=\"true\" attribute. When this attribute is added to an HTML element, screen readers will not read it out to users. Sometimes it is correct for the element to be hidden from screen readers (such as with a decorative icon) but other times this is not correct. When you see this warning, you need to determine if the element is supposed to be hidden from people who are blind or visually impaired. If it is correctly hidden, \"Ignore\" the warning. If it is incorrectly hidden and should be visible, remove the aria-hidden=\"true\" attribute to resolve the warning."
 msgstr ""
 
-#: includes/rules.php:276
+#: includes/rules.php:257
 msgid "Empty Table Header"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;th&gt;</code>, %2$s is <code>&lt;th&gt;&lt;/th&gt;</code>.
-#: includes/rules.php:283
+#: includes/rules.php:263
 #, php-format
 msgid "An Empty Table Header error means that one of the table headers on your post or page does not contain any text. This means that the %1$s element is present but looks like this %2$s with nothing between the opening and closing tags. To fix an empty table header, you need to find the correct HTML element (%1$s) and add text to it that describes the row or column that it applies to."
 msgstr ""
 
-#: includes/rules.php:290
+#: includes/rules.php:270
 msgid "Link to MS Office File"
 msgstr ""
 
-#: includes/rules.php:295
+#: includes/rules.php:274
 msgid "A Link to MS Office File warning means that one or more of the links on your page or post directs to a file with one of the following file extensions: .doc, .docx, .xls, .xlsx, .ppt, .pptx, .pps or .ppsx. This warning appears when an MS Office file is present as a reminder to manually test your Word documents, PowerPoint presentations, and Excel spreadsheets for accessibility and to confirm that they conform to all relevant WCAG guidelines. To resolve a Link to MS Office File warning, you need to: (1) ensure a direct link to view or download the document is present if you're using a plugin to embed it on the page; (2) ensure the link to the document warns users it is a link to a document by displaying the specific file extension in the link anchor; and (3) test and remediate your MS Office file for accessibility errors. After determining your file is fully accessible, you can safely “Ignore” the warning."
 msgstr ""
 
-#: includes/rules.php:299
+#: includes/rules.php:278
 msgid "Link to PDF"
 msgstr ""
 
-#: includes/rules.php:304
+#: includes/rules.php:282
 msgid "A Link to PDF warning means that one or more of the links on your page or post directs to a PDF file. This warning is a reminder to manually test the linked PDF for accessibility and to confirm that it conforms to all relevant WCAG guidelines. To resolve a Link to PDF warning, you need to: (1) ensure a direct link to view or download the document is present if you're using a plugin to embed it on the page; (2) ensure the link to the document warns users it is a link to a document by displaying the specific file extension in the link anchor; and (3) test and remediate your document for accessibility errors. After determining your file is fully accessible, you can safely “Ignore” the warning."
 msgstr ""
 
-#: includes/rules.php:308
+#: includes/rules.php:286
 msgid "Link to Non-HTML File"
 msgstr ""
 
-#: includes/rules.php:313
+#: includes/rules.php:290
 msgid "A  Link to Non-HTML Document warning means that one or more of the links on your page or post directs to a file with one of the following file extensions: .rtf, .wpd, .ods, .odt, .odp, .sxw, .sxc, .sxd, .sxi, .pages, or .key. This warning is a reminder to manually test the linked document for accessibility and to confirm that it conforms to all relevant WCAG guidelines. To resolve a Link to Non-HTML Document warning, you need to: (1) ensure a direct link to view or download the document is present if you're using a plugin to embed it on the page; (2) ensure the link to the document warns users it is a link to a document by displaying the specific file extension in the link anchor; and (3) test and remediate your document for accessibility errors. After determining your file is fully accessible, you can safely “Ignore” the warning."
 msgstr ""
 
-#: includes/rules.php:317
+#: includes/rules.php:294
 msgid "Long Description Invalid"
 msgstr ""
 
 #. translators: %s is <code>longdesc=""</code>.
-#: includes/rules.php:324
+#: includes/rules.php:300
 #, php-format
 msgid "The Long Description Invalid error means that a long description attribute (%s) on an image does not have an appropriate URL, filename, or file extension. It may also mean that the long description is not a URL, or it has been left blank. The longdesc attribute is not fully supported opens a new window by HTML5, browsers, and all screen readers. Due to this lack of support, the best fix for this error is to remove longdesc from your image tag completely."
 msgstr ""
 
-#: includes/rules.php:330
+#: includes/rules.php:306
 msgid "Missing Form Label"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;input&gt;</code>, %2$s is <code>&lt;label&gt;</code>, %3$s is <code>for=""</code>.
-#: includes/rules.php:337
+#: includes/rules.php:312
 #, php-format
 msgid "A Missing Form Label error is triggered when an %1$s (form field) is present in your form and but is not associated with a %2$s element. This could mean the label is present but is missing a %3$s attribute to connect it to the applicable field or there could be no label present at all and only an %1$s tag. To fix missing form label errors, you will need to determine how the field and form were created and then add field labels or a correct %3$s attribute to existing labels that are not connected to a field."
 msgstr ""
 
-#: includes/rules.php:350
+#: includes/rules.php:325
 msgid "Ambiguous Anchor Text"
 msgstr ""
 
-#: includes/rules.php:355
+#: includes/rules.php:329
 msgid "Ambiguous Anchor Text errors appear when there is linked text that has no meaning outside of its surrounding content. Common examples of this include linking phrases like \"click here\" or \"learn more.\" To resolve this error, change the link text to be less generic so that it has meaning if heard on its own."
 msgstr ""
 
-#: includes/rules.php:359
+#: includes/rules.php:333
 msgid "Underlined Text"
 msgstr ""
 
 #. translators: %s is <code>&lt;u&gt;</code>.
-#: includes/rules.php:366
+#: includes/rules.php:339
 #, php-format
 msgid "An Underlined Text warning appears if any text on your page is wrapped in an HTML underline tag (%1$s). In an online environment, underlined text is generally used to indicate linked text and it is not considered a best practice to underline text for emphasis only. To fix underlined text, you will need to remove the %1$s element from the text or CSS styles that are making it underlined. Try using other stylization, such as italics, colored text, or bolding to emphasize or differentiate between words or phrases."
 msgstr ""
 
-#: includes/rules.php:372
+#: includes/rules.php:345
 msgid "Broken Skip or Anchor Link"
 msgstr ""
 
-#: includes/rules.php:377
+#: includes/rules.php:349
 msgid "An anchor link, sometimes called a jump link, is a link that, rather than opening a new page or URL when clicked, jumps or scrolls you to a different section on the same page. These links go to an element that starts with a hashtag rather than a full URL. For example, you might scroll someone to the about section of your home page by linking to #about. Broken Skip or Anchor Link errors appear when there is a link that targets another section on the same page but there is not an element present on the page that has the referenced id. This error will also appear if you are linking to just a #. To resolve this error, manually test the link to confirm it works and then either fix it or \"Ignore\" the error as applicable."
 msgstr ""
 
-#: includes/rules.php:381
+#: includes/rules.php:353
 msgid "Missing Table Header"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;td&gt;</code>, %2$s is <code>&lt;th&gt;</code>.
-#: includes/rules.php:388
+#: includes/rules.php:359
 #, php-format
 msgid "A Missing Table Header error means that one of your tables contains data (information contained in a %1$s tag) that does not have a corresponding header (%2$s) tag. When looking at the HTML for your form, there will be more %1$s elements in a row than %2$s elements in the table. To fix a missing table header, you need to find the section of code that has fewer %2$s elements in it than should be present for the number of rows or columns of data, and add one or more additional %2$s elements containing text that describes the data in that row or column."
 msgstr ""
 
-#: includes/rules.php:395
+#: includes/rules.php:366
 msgid "Duplicate Form Label"
 msgstr ""
 
-#: includes/rules.php:400
+#: includes/rules.php:370
 msgid "Duplicate Form Label errors appear when there is more than one label associated with a single field on a form. If there are too many form labels present, a screen reader may not be able to successfully read the form fields to help a visually impaired user navigate through and complete the form. To fix duplicate form label errors, you will need to determine how the field and form were created and then ensure that each field has only one label associated with it."
 msgstr ""
 
-#: includes/rules.php:405
+#: includes/rules.php:375
 msgid "Text Too Small"
 msgstr ""
 
-#: includes/rules.php:410
+#: includes/rules.php:379
 msgid "A Text Too Small warning occurs when there is text on your website that is less than 10px in size. The warning is an indication that you may want to rethink the font size and make it larger so that it can be more easily read without a user needing zoom in on their browser. To fix text that is too small, you will need to ensure that all text elements on your website are at least 10 points."
 msgstr ""
 
-#: includes/rules.php:414
+#: includes/rules.php:383
 msgid "Possible Heading"
 msgstr ""
 
-#: includes/rules.php:419
+#: includes/rules.php:387
 msgid "A Possible Heading warning occurs when there is text on a page that appears to be a heading, but has not been coded with proper heading tags. This warning is appears if there are short phrases or strings of text less than 50 characters in length that are formatted in a way which suggests they might be being used as headers (they are 20 pixels or bigger, or are 16 pixels or bigger and bold and/or italicized). To fix a Possible Heading warning, you will need to determine if the flagged text is indeed intended to be a heading. If so, you need to change it from a paragraph to a heading at the proper level. If it is not supposed to be a heading then you can safely “Ignore” the warning."
 msgstr ""
 
-#: includes/rules.php:423
+#: includes/rules.php:391
 msgid "Blinking or Scrolling Content"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;blink&gt;</code>, %2$s is <code>&lt;marquee&gt;</code>, %3$s is <code>text-decoration: blink</code>.
-#: includes/rules.php:430
+#: includes/rules.php:397
 #, php-format
 msgid "Blinking or Scrolling Content errors appear when elements on your website have a blinking or scrolling function applied to them either via CSS or in the HTML. Specifically, the following will create this error: the %1$s or %2$s HTML tags or CSS %3$s. To resolve this error remove the HTML tags or CSS that is causing content to blink."
 msgstr ""
 
-#: includes/rules.php:439
+#: includes/rules.php:406
 msgid "Insufficient Color Contrast"
 msgstr ""
 
-#: includes/rules.php:444
+#: includes/rules.php:410
 msgid "Insufficient Color Contrast errors means that we have identified that one or more of the color combinations on your post or page do not meet the minimum color contrast ratio of 4.5:1. Depending upon how your site is built there may be \"false positives\" for this error as some colors are contained in different HTML layers on the page. To fix an Insufficient Color Contrast error, you will need to ensure that flagged elements meet the minimum required ratio of 4.5:1. To do so, you will need to find the hexadecimal codes of your foreground and background color, and test them in a color contrast checker. If these color codes have a ratio of 4.5:1 or greater you can “Ignore” this error. If the color codes do not have a ratio of at least 4.5:1, you will need to make adjustments to your colors."
 msgstr ""
 
-#: includes/rules.php:448
+#: includes/rules.php:414
 msgid "Missing Transcript"
 msgstr ""
 
-#: includes/rules.php:453
+#: includes/rules.php:418
 msgid "A missing transcript error means that there is an audio or video clip on your website that does not have a transcript or there is a transcript but it is not labelled as a transcript or is positioned more than 25 characters away from the embedded or linked to media. To fix a missing transcript error, you will need to create a transcript for any of the video or audio clips that have been flagged as missing a transcript. Once you have created the transcript, you can either add the transcript content directly within your post or page or link to the transcript if you’re including it as a downloadable doc or PDF file. You need to explicitly include the word “transcript” within a heading before the transcript on the page or in the link to your file, and it needs to be within 25 characters of the audio or video embed or link."
 msgstr ""
 
-#: includes/rules.php:457
+#: includes/rules.php:422
 msgid "Broken ARIA Reference"
 msgstr ""
 
-#: includes/rules.php:462
+#: includes/rules.php:426
 msgid "Broken ARIA Reference errors appear if an aria-labeledby or aria-describedby element is present on the page or post but its reference target does not exist. This means that the element being referred to by the specific ARIA attribute you are using either does not have a proper label or descriptor, or it is not present on the page. To fix a broken ARIA reference, you will need to find the ARIA elements that are being flagged, and ensure that their reference targets are present and properly labeled."
 msgstr ""
 
-#: includes/rules.php:467
+#: includes/rules.php:431
 msgid "Missing Language Declaration"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;html&gt;</code>, %2$s is <code>lang=""</code>, %3$s is <code>xml:lang=""</code>.
-#: includes/rules.php:474
+#: includes/rules.php:437
 #, php-format
 msgid "A language declaration is an HTML attribute that denotes the default language of the content on a page or post. Language declarations should be coded into your website theme and appear automatically in the head of the website. A Missing Language Declaration error appears if the %1$s tag on the page does not contain a %2$s or %3$s attribute, or one of these attributes is present but is empty. To fix a Missing Language Declaration error, you will need to edit your theme files to add the missing language attribute to the HTML tag at the very top of your website header. If you are using a theme that receives updates, then you will need to make the change in a child theme to ensure the fix does not get overwritten when you next update your theme."
 msgstr ""
 
-#: includes/rules.php:488
+#: includes/rules.php:451
 msgid "Image Animated GIF"
 msgstr ""
 
-#: includes/rules.php:493
+#: includes/rules.php:455
 msgid "Image Animated GIF warnings appear when there is an animated GIF on your post or page. This warning is a reminder to manually review any animated GIFs on your website for their accessibility and/or to reconsider using animated GIFs, replacing them instead with static images or videos. To resolve this warning, you need to review any GIFs that are present to ensure that they meet all applicable guidelines for accessibility and then either “Ignore” the warning or remove the GIF from your page or post if it is not accessible."
 msgstr ""
 
-#: includes/rules.php:498
+#: includes/rules.php:460
 msgid "A Video is Present"
 msgstr ""
 
-#: includes/rules.php:503
+#: includes/rules.php:464
 msgid "Because videos frequently contain accessibility problems, many of which can only be identified by a person, The A Video is Present warning appears anytime a video is detected on a post or page as a reminder that you need to manually test your video for accessibility. To resolve this warning, you need to visit the front end of your website and confirm that the video in the warning is accessible. Once you have fully tested the video for accessibility, you need to fix any errors that may be present and then can “Ignore” the warning to mark it as complete."
 msgstr ""
 
-#: includes/rules.php:507
+#: includes/rules.php:468
 msgid "A Slider is Present"
 msgstr ""
 
-#: includes/rules.php:512
+#: includes/rules.php:472
 msgid "Because sliders frequently contain accessibility problems, many of which can only be identified by a person, the A Slider is Present warning appears anytime a slider is detected on a post or page as a reminder that you need to manually test your slider for accessibility. To resolve this warning, you need to visit the front end of your website and confirm all sliders on the page are accessible. Once you have fully tested your sliders for accessibility, you need to fix any errors that may be present and then can “Ignore” the warning to mark it as complete."
 msgstr ""
 
-#: includes/rules.php:516
+#: includes/rules.php:476
 msgid "Missing Title"
 msgstr ""
 
 #. translators: %1$s is <code>&lt;title&gt;</code>, %2$s is <code>og:title</code>.
-#: includes/rules.php:523
+#: includes/rules.php:482
 #, php-format
 msgid "A Missing Title error means that your post or page does not contain a title element (%1$s or %2$s). This could happen if the theme fails to add a title tag, or if the title field of a post or page has been left blank in the WordPress edit screen. To fix a page with no titles, you will need to add title elements. First, determine if the title is missing because you left the page or post title field blank in the editor. If so, fill it in. If a title is filled in and visible on the backend then the code in the of your web page needs to be edited to include a %1$s tag or %2$s meta tag."
 msgstr ""
 
-#: includes/rules.php:535
+#: includes/rules.php:494
 msgid "Improper Use of Link"
 msgstr ""
 
 #. translators: %1$s is <code>href</code>, %2$s is <code>#</code>, %3$s is <code>role="button"</code>, %4$s is <code>&lt;button&gt;</code>, %5$s is <code>role="button"</code>, %6$s is <code>&lt;a&gt;</code>.
-#: includes/rules.php:542
+#: includes/rules.php:500
 #, php-format
 msgid "An Improper Use of Link error appears if you have links that are missing an %1$s attribute or are only linked to a %2$s, and do not have %3$s on them. Links should be used to direct people to other parts of your site. Any other functionality that triggers an action should be a button. To resolve this error you need to recode the link to use a %4$s tag (preferable) or add %5$s to the existing %6$s tag. If the element is a toggle button (such as an accordion), additional ARIA attributes are required."
 msgstr ""
 
-#: includes/rules.php:553
+#: includes/rules.php:511
 msgid "Zooming and Scaling Disabled"
 msgstr ""
 
-#: includes/rules.php:558
+#: includes/rules.php:515
 msgid "Zooming is disabled via viewport meta tag that includes `user-scalable=no` or a `maximum-scale` value of less than 2. This limits low-vision users that want to increase text sizes, zoom into the page or who use a magnifier."
 msgstr ""
 
@@ -1821,12 +1827,12 @@ msgstr ""
 msgid "...and more"
 msgstr ""
 
-#: partials/pro-callout.php:45
+#: partials/pro-callout.php:47
 #: partials/welcome-page.php:215
 msgid "Get Accessibility Checker Pro"
 msgstr ""
 
-#: partials/pro-callout.php:55
+#: partials/pro-callout.php:57
 #: partials/welcome-page.php:223
 msgid "Or activate your license key here."
 msgstr ""

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -2002,3 +2002,15 @@
 	color: variables.$color-gray;
 	text-decoration: none;
 }
+
+.edac-plugin-action-links {
+  &__go-pro {
+    color: variables.$color-red;
+    font-weight: bold;
+    &:hover,
+    &:focus {
+      color: variables.$color-red;
+      text-decoration: underline;
+    }
+  }
+}

--- a/tests/phpunit/Admin/PluginActionLinksTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksTest.php
@@ -24,6 +24,39 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 	 */
 	protected function setUp(): void {
 		$this->plugin_action_links = new Plugin_Action_Links();
+		
+		// Set up mock function and constants for all tests.
+		$this->setupMocks();
+	}
+
+	/**
+	 * Set up mocks and constants for testing.
+	 */
+	private function setupMocks(): void {
+		// Define constants if not already defined.
+		if ( ! defined( 'EDAC_PLUGIN_FILE' ) ) {
+			define( 'EDAC_PLUGIN_FILE', __FILE__ );
+		}
+		
+		if ( ! defined( 'EDAC_KEY_VALID' ) ) {
+			define( 'EDAC_KEY_VALID', false );
+		}
+
+		// Mock the edac_link_wrapper function if it doesn't exist.
+		if ( ! function_exists( 'edac_link_wrapper' ) ) {
+			/**
+			 * Mock the edac_link_wrapper function.
+			 *
+			 * @param string $url      The URL to wrap.
+			 * @param string $source   The source parameter.
+			 * @param string $campaign The campaign parameter.
+			 * @param bool   $unused   Unused parameter for compatibility.
+			 * @return string The wrapped URL.
+			 */
+			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
+			}
+		}
 	}
 
 	/**
@@ -50,11 +83,6 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 	 * Test that init_hooks registers the filter when EDAC_PLUGIN_FILE is defined.
 	 */
 	public function test_init_hooks_registers_filter_when_constant_defined() {
-		// Define the constant for this test.
-		if ( ! defined( 'EDAC_PLUGIN_FILE' ) ) {
-			define( 'EDAC_PLUGIN_FILE', __FILE__ );
-		}
-
 		// Clear any existing filters.
 		remove_all_filters( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ) );
 
@@ -95,27 +123,6 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 	 * Test that add_plugin_action_links adds pro link when EDAC_KEY_VALID is false.
 	 */
 	public function test_add_plugin_action_links_adds_pro_link_when_not_pro() {
-		// Define the constant as false for this test.
-		if ( ! defined( 'EDAC_KEY_VALID' ) ) {
-			define( 'EDAC_KEY_VALID', false );
-		}
-
-		// Mock the edac_link_wrapper function if it doesn't exist.
-		if ( ! function_exists( 'edac_link_wrapper' ) ) {
-			/**
-			 * Mock the edac_link_wrapper function.
-			 *
-			 * @param string $url      The URL to wrap.
-			 * @param string $source   The source parameter.
-			 * @param string $campaign The campaign parameter.
-			 * @param bool   $unused   Unused parameter for compatibility.
-			 * @return string The wrapped URL.
-			 */
-			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
-			}
-		}
-
 		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
 		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
 
@@ -158,27 +165,6 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 	 * Test that add_plugin_action_links includes proper accessibility attributes.
 	 */
 	public function test_add_plugin_action_links_includes_accessibility_attributes() {
-		// Define the constant as false for this test.
-		if ( ! defined( 'EDAC_KEY_VALID' ) ) {
-			define( 'EDAC_KEY_VALID', false );
-		}
-
-		// Mock the edac_link_wrapper function if it doesn't exist.
-		if ( ! function_exists( 'edac_link_wrapper' ) ) {
-			/**
-			 * Mock the edac_link_wrapper function.
-			 *
-			 * @param string $url      The URL to wrap.
-			 * @param string $source   The source parameter.
-			 * @param string $campaign The campaign parameter.
-			 * @param bool   $unused   Unused parameter for compatibility.
-			 * @return string The wrapped URL.
-			 */
-			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
-			}
-		}
-
 		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
 		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
 

--- a/tests/phpunit/Admin/PluginActionLinksTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksTest.php
@@ -62,7 +62,7 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 		$this->plugin_action_links->init_hooks();
 
 		// Check that the filter was added.
-		$this->assertTrue(
+		$this->assertNotFalse(
 			has_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this->plugin_action_links, 'add_plugin_action_links' ] ),
 			'Filter was not registered'
 		);

--- a/tests/phpunit/Admin/PluginActionLinksTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Class PluginActionLinksTest
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Plugin_Action_Links;
+
+/**
+ * Plugin Action Links test case.
+ */
+class PluginActionLinksTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance of the Plugin_Action_Links class.
+	 *
+	 * @var Plugin_Action_Links $plugin_action_links.
+	 */
+	private $plugin_action_links;
+
+	/**
+	 * Set up the test fixture.
+	 */
+	protected function setUp(): void {
+		$this->plugin_action_links = new Plugin_Action_Links();
+	}
+
+	/**
+	 * Test that the init_hooks method exists.
+	 */
+	public function test_init_hooks_method_exists() {
+		$this->assertTrue(
+			method_exists( $this->plugin_action_links, 'init_hooks' ),
+			'Class does not have method init_hooks'
+		);
+	}
+
+	/**
+	 * Test that the add_plugin_action_links method exists.
+	 */
+	public function test_add_plugin_action_links_method_exists() {
+		$this->assertTrue(
+			method_exists( $this->plugin_action_links, 'add_plugin_action_links' ),
+			'Class does not have method add_plugin_action_links'
+		);
+	}
+
+	/**
+	 * Test that init_hooks registers the filter when EDAC_PLUGIN_FILE is defined.
+	 */
+	public function test_init_hooks_registers_filter_when_constant_defined() {
+		// Define the constant for this test.
+		if ( ! defined( 'EDAC_PLUGIN_FILE' ) ) {
+			define( 'EDAC_PLUGIN_FILE', __FILE__ );
+		}
+
+		// Clear any existing filters.
+		remove_all_filters( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ) );
+
+		// Initialize hooks.
+		$this->plugin_action_links->init_hooks();
+
+		// Check that the filter was added.
+		$this->assertTrue(
+			has_filter( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ), [ $this->plugin_action_links, 'add_plugin_action_links' ] ),
+			'Filter was not registered'
+		);
+	}
+
+	/**
+	 * Test that add_plugin_action_links returns an array.
+	 */
+	public function test_add_plugin_action_links_returns_array() {
+		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
+
+		$this->assertIsArray( $result, 'Method should return an array' );
+	}
+
+	/**
+	 * Test that add_plugin_action_links adds settings link.
+	 */
+	public function test_add_plugin_action_links_adds_settings_link() {
+		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
+
+		// Settings link should be the first element.
+		$first_link = reset( $result );
+		$this->assertStringContainsString( 'Settings', $first_link, 'Settings link not found' );
+		$this->assertStringContainsString( 'accessibility_checker_settings', $first_link, 'Settings link does not point to correct page' );
+	}
+
+	/**
+	 * Test that add_plugin_action_links adds pro link when EDAC_KEY_VALID is false.
+	 */
+	public function test_add_plugin_action_links_adds_pro_link_when_not_pro() {
+		// Define the constant as false for this test.
+		if ( ! defined( 'EDAC_KEY_VALID' ) ) {
+			define( 'EDAC_KEY_VALID', false );
+		}
+
+		// Mock the edac_link_wrapper function if it doesn't exist.
+		if ( ! function_exists( 'edac_link_wrapper' ) ) {
+			/**
+			 * Mock the edac_link_wrapper function.
+			 *
+			 * @param string $url      The URL to wrap.
+			 * @param string $source   The source parameter.
+			 * @param string $campaign The campaign parameter.
+			 * @param bool   $unused   Unused parameter for compatibility.
+			 * @return string The wrapped URL.
+			 */
+			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
+			}
+		}
+
+		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
+
+		$this->assertArrayHasKey( 'go_pro', $result, 'Pro link not found in result' );
+		$this->assertStringContainsString( 'Get Pro', $result['go_pro'], 'Pro link does not contain expected text' );
+		$this->assertStringContainsString( 'target="_blank"', $result['go_pro'], 'Pro link does not open in new window' );
+		$this->assertStringContainsString( 'edac-plugin-action-links__go-pro', $result['go_pro'], 'Pro link does not have correct CSS class' );
+	}
+
+	/**
+	 * Test that add_plugin_action_links preserves existing links.
+	 */
+	public function test_add_plugin_action_links_preserves_existing_links() {
+		$input_links = [
+			'edit'       => '<a href="#">Edit</a>',
+			'deactivate' => '<a href="#">Deactivate</a>',
+		];
+
+		$result = $this->plugin_action_links->add_plugin_action_links( $input_links );
+
+		$this->assertArrayHasKey( 'edit', $result, 'Edit link was not preserved' );
+		$this->assertArrayHasKey( 'deactivate', $result, 'Deactivate link was not preserved' );
+		$this->assertEquals( '<a href="#">Edit</a>', $result['edit'], 'Edit link content was modified' );
+		$this->assertEquals( '<a href="#">Deactivate</a>', $result['deactivate'], 'Deactivate link content was modified' );
+	}
+
+	/**
+	 * Test that add_plugin_action_links properly escapes URLs.
+	 */
+	public function test_add_plugin_action_links_escapes_urls() {
+		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
+
+		// Check that the settings link is properly escaped.
+		$first_link = reset( $result );
+		$this->assertStringContainsString( 'href="', $first_link, 'Settings link href is not properly quoted' );
+	}
+
+	/**
+	 * Test that add_plugin_action_links includes proper accessibility attributes.
+	 */
+	public function test_add_plugin_action_links_includes_accessibility_attributes() {
+		// Define the constant as false for this test.
+		if ( ! defined( 'EDAC_KEY_VALID' ) ) {
+			define( 'EDAC_KEY_VALID', false );
+		}
+
+		// Mock the edac_link_wrapper function if it doesn't exist.
+		if ( ! function_exists( 'edac_link_wrapper' ) ) {
+			/**
+			 * Mock the edac_link_wrapper function.
+			 *
+			 * @param string $url      The URL to wrap.
+			 * @param string $source   The source parameter.
+			 * @param string $campaign The campaign parameter.
+			 * @param bool   $unused   Unused parameter for compatibility.
+			 * @return string The wrapped URL.
+			 */
+			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
+			}
+		}
+
+		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
+
+		if ( isset( $result['go_pro'] ) ) {
+			$this->assertStringContainsString( 'aria-label=', $result['go_pro'], 'Pro link does not have aria-label attribute' );
+			$this->assertStringContainsString( 'opens in new window', $result['go_pro'], 'Pro link aria-label does not indicate new window' );
+		}
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	protected function tearDown(): void {
+		// Clean up any filters that were added during tests.
+		if ( defined( 'EDAC_PLUGIN_FILE' ) ) {
+			remove_all_filters( 'plugin_action_links_' . plugin_basename( EDAC_PLUGIN_FILE ) );
+		}
+	}
+}

--- a/tests/phpunit/Admin/PluginActionLinksTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksTest.php
@@ -126,10 +126,17 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 		$input_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
 		$result      = $this->plugin_action_links->add_plugin_action_links( $input_links );
 
-		$this->assertArrayHasKey( 'go_pro', $result, 'Pro link not found in result' );
-		$this->assertStringContainsString( 'Get Pro', $result['go_pro'], 'Pro link does not contain expected text' );
-		$this->assertStringContainsString( 'target="_blank"', $result['go_pro'], 'Pro link does not open in new window' );
-		$this->assertStringContainsString( 'edac-plugin-action-links__go-pro', $result['go_pro'], 'Pro link does not have correct CSS class' );
+		// Check the condition under which the pro link should appear.
+		if ( defined( 'EDAC_KEY_VALID' ) && ! EDAC_KEY_VALID ) {
+			// Pro link should be present when EDAC_KEY_VALID is false.
+			$this->assertArrayHasKey( 'go_pro', $result, 'Pro link not found in result when EDAC_KEY_VALID is false' );
+			$this->assertStringContainsString( 'Get Pro', $result['go_pro'], 'Pro link does not contain expected text' );
+			$this->assertStringContainsString( 'target="_blank"', $result['go_pro'], 'Pro link does not open in new window' );
+			$this->assertStringContainsString( 'edac-plugin-action-links__go-pro', $result['go_pro'], 'Pro link does not have correct CSS class' );
+		} else {
+			// Pro link should not be present when EDAC_KEY_VALID is true or undefined.
+			$this->assertArrayNotHasKey( 'go_pro', $result, 'Pro link should not be present when EDAC_KEY_VALID is true or undefined' );
+		}
 	}
 
 	/**
@@ -172,6 +179,34 @@ class PluginActionLinksTest extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'aria-label=', $result['go_pro'], 'Pro link does not have aria-label attribute' );
 			$this->assertStringContainsString( 'opens in new window', $result['go_pro'], 'Pro link aria-label does not indicate new window' );
 		}
+	}
+
+	/**
+	 * Test that add_plugin_action_links does not add pro link when EDAC_KEY_VALID is true.
+	 */
+	public function test_add_plugin_action_links_does_not_add_pro_link_when_pro() {
+		// Skip this test if EDAC_KEY_VALID is already defined, as constants cannot be redefined.
+		if ( defined( 'EDAC_KEY_VALID' ) ) {
+			$this->markTestSkipped( 'EDAC_KEY_VALID constant is already defined and cannot be redefined for this test' );
+		}
+
+		// Mark test as incomplete due to architectural limitation.
+		$this->markTestIncomplete(
+			'This test cannot be properly implemented without refactoring the Plugin_Action_Links class. ' .
+			'The class needs dependency injection or a mocking mechanism for constants to enable proper testing ' .
+			'of both pro and non-pro scenarios within the same test suite.'
+		);
+
+		/*
+		 * When the Plugin_Action_Links class is refactored to support dependency injection,
+		 * this test should verify that the pro link is not added when the license is valid.
+		 * 
+		 * Expected behavior:
+		 * - Set EDAC_KEY_VALID constant to true
+		 * - Call add_plugin_action_links with test data
+		 * - Assert that 'go_pro' key is not present in the result array
+		 * - Verify that existing links are preserved
+		 */
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces functionality to add custom action links to the plugin list table, including a "Settings" link and a "Get Pro" link for non-pro users. It also includes related styling for these links. The most important changes are the addition of the `Plugin_Action_Links` class, integration of its hooks in the admin initialization, and styling updates for the "Get Pro" link.

### Functional changes:
* **Added `Plugin_Action_Links` class**: Implements the functionality to display custom plugin action links ("Settings" and "Get Pro") in the plugin list table.
* **Integrated `Plugin_Action_Links` hooks**: Updated the `admin/class-admin.php` file to initialize the hooks for `Plugin_Action_Links` during admin initialization.

### Styling changes:
* **Added styles for "Get Pro" link**: Updated `accessibility-checker-admin.scss` to include bold red text and hover/focus effects for the "Get Pro" link.

![Screenshot 2025-07-03 at 4 24 52 PM](https://github.com/user-attachments/assets/c015f043-32ea-4351-bc35-3c6c6751cf16)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Settings" and "Get Pro" action links to the plugin list for easier access to the plugin's settings and upgrade options.

* **Style**
  * Introduced new styles for the plugin action links, including a distinct appearance for the "Get Pro" link with enhanced color and emphasis on hover and focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->