### PR TITLE
Change UNIQUE KEY to PRIMARY KEY for id column, bump db version to 1.0.4

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -40,7 +40,7 @@ if ( ! defined( 'EDAC_VERSION' ) ) {
 
 // Current database version.
 if ( ! defined( 'EDAC_DB_VERSION' ) ) {
-	define( 'EDAC_DB_VERSION', '1.0.3' );
+	define( 'EDAC_DB_VERSION', '1.0.4' );
 }
 
 // Plugin Folder Path.

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -59,7 +59,7 @@ class Update_Database {
 				ignre_user bigint(20) NULL,
 				ignre_date timestamp NULL,
 				ignre_comment mediumtext NULL,
-				UNIQUE KEY id (id),
+				PRIMARY KEY (id),
 				KEY postid_index (postid)
 			) $charset_collate;";
 

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -43,9 +43,9 @@ class Update_Database {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepare above, Safe variable used for table name, caching not required for one time operation.
 		if ( EDAC_DB_VERSION !== $db_version || $wpdb->get_var( $query ) !== $table_name ) {
 
-			// If going from db version of below 1.0.3 then drop the UNIQUE index on `id` column, it
+			// If going from db version of below 1.0.4 then drop the UNIQUE index on `id` column, it
 			// is replaced by a PRIMARY KEY that has a PRIMARY index that constrains uniqueness.
-			if ( version_compare( $db_version, '1.0.3', '<' ) ) {
+			if ( version_compare( $db_version, '1.0.4', '<' ) ) {
 				// phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Swapping from UNIQUE to PRIMARY indexing.
 				$wpdb->query( "ALTER TABLE $table_name DROP INDEX id" );
 			}


### PR DESCRIPTION
This pull request includes updates to the database schema and versioning for the accessibility checker plugin. The changes ensure better database integrity and version tracking.

### Database versioning:
* Updated the `EDAC_DB_VERSION` constant from `1.0.3` to `1.0.4` in `accessibility-checker.php` to reflect the new database changes.

### Database schema:
* Changed the `id` column in the `edac_update_database` method from a `UNIQUE KEY` to a `PRIMARY KEY` to enforce stricter uniqueness and indexing in `admin/class-update-database.php`.

Fixes: #1054 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal database version to 1.0.4.
  * Improved database structure by replacing a unique index with a primary key for better data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->