### PR TITLE
Fix: Improve SQLite compatibility for WordPress Playground

### DIFF
--- a/admin/class-purge-post-data.php
+++ b/admin/class-purge-post-data.php
@@ -81,16 +81,59 @@ class Purge_Post_Data {
 		}
 
 		global $wpdb;
+		$ac_table = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
+		$postmeta_table = $wpdb->postmeta;
+		$site_id = get_current_blog_id();
+		$meta_key_like = '_edac%';
+
+		if ( ! $ac_table ) {
+			return false;
+		}
+
+		// Step 1: Find all post IDs of the given post_type that have associated records in the ac_table
+		// and also have the specific meta_key in postmeta.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		$sql_select_post_ids = $wpdb->prepare(
+			"SELECT DISTINCT T2.postid
+			 FROM %i AS T1
+			 JOIN %i AS T2 ON T1.post_id = T2.postid
+			 WHERE T1.meta_key LIKE %s
+			   AND T2.siteid = %d
+			   AND T2.type = %s",
+			$postmeta_table,    // T1
+			$ac_table,          // T2
+			$meta_key_like,
+			$site_id,
+			$post_type
+		);
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
-		return $wpdb->query(
-			$wpdb->prepare(
-				"DELETE T1,T2 from $wpdb->postmeta as T1 JOIN %i as T2 ON T1.post_id = T2.postid WHERE T1.meta_key like %s and T2.siteid=%d and T2.type=%s",
-				edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' ),
-				'_edac%',
-				get_current_blog_id(),
-				$post_type
-			)
+		$post_ids_to_affect = $wpdb->get_col( $sql_select_post_ids );
+
+		if ( empty( $post_ids_to_affect ) ) {
+			return true; // No records match the criteria
+		}
+
+		$post_ids_placeholders = implode( ', ', array_fill( 0, count( $post_ids_to_affect ), '%d' ) );
+
+		// Step 2: Delete from postmeta table
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		$sql_delete_postmeta = $wpdb->prepare(
+			"DELETE FROM %i WHERE meta_key LIKE %s AND post_id IN ( $post_ids_placeholders )",
+			array_merge( [ $postmeta_table, $meta_key_like ], $post_ids_to_affect )
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		$wpdb->query( $sql_delete_postmeta );
+
+		// Step 3: Delete from accessibility_checker table
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		$sql_delete_ac_data = $wpdb->prepare(
+			"DELETE FROM %i WHERE siteid = %d AND type = %s AND postid IN ( $post_ids_placeholders )",
+			array_merge( [ $ac_table, $site_id, $post_type ], $post_ids_to_affect )
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		$wpdb->query( $sql_delete_ac_data );
+
+		return true;
 	}
 }

--- a/admin/class-purge-post-data.php
+++ b/admin/class-purge-post-data.php
@@ -81,10 +81,10 @@ class Purge_Post_Data {
 		}
 
 		global $wpdb;
-		$ac_table = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
-		$postmeta_table = $wpdb->postmeta;
-		$site_id = get_current_blog_id();
-		$meta_key_like = '_edac%';
+		$ac_table        = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
+		$postmeta_table  = $wpdb->postmeta;
+		$site_id         = get_current_blog_id();
+		$meta_key_like   = '_edac%';
 
 		if ( ! $ac_table ) {
 			return false;
@@ -92,47 +92,52 @@ class Purge_Post_Data {
 
 		// Step 1: Find all post IDs of the given post_type that have associated records in the ac_table
 		// and also have the specific meta_key in postmeta.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$sql_select_post_ids = $wpdb->prepare(
-			"SELECT DISTINCT T2.postid
-			 FROM %i AS T1
-			 JOIN %i AS T2 ON T1.post_id = T2.postid
-			 WHERE T1.meta_key LIKE %s
-			   AND T2.siteid = %d
-			   AND T2.type = %s",
-			$postmeta_table,    // T1
-			$ac_table,          // T2
+			'SELECT DISTINCT T2.postid
+			FROM %i AS T1
+			JOIN %i AS T2 ON T1.post_id = T2.postid
+			WHERE T1.meta_key LIKE %s
+			AND T2.siteid = %d
+			AND T2.type = %s',
+			$postmeta_table, // T1.
+			$ac_table,       // T2.
 			$meta_key_like,
 			$site_id,
 			$post_type
 		);
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 		$post_ids_to_affect = $wpdb->get_col( $sql_select_post_ids );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		if ( empty( $post_ids_to_affect ) ) {
-			return true; // No records match the criteria
+			return true; // No records match the criteria.
 		}
+
+		// Sanitize all post IDs to ensure they are integers.
+		$post_ids_to_affect = array_map( 'absint', $post_ids_to_affect );
 
 		$post_ids_placeholders = implode( ', ', array_fill( 0, count( $post_ids_to_affect ), '%d' ) );
 
-		// Step 2: Delete from postmeta table
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		// Step 2: Delete from postmeta table.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$query_args_postmeta = array_merge( [ $meta_key_like ], $post_ids_to_affect );
 		$sql_delete_postmeta = $wpdb->prepare(
-			"DELETE FROM %i WHERE meta_key LIKE %s AND post_id IN ( $post_ids_placeholders )",
-			array_merge( [ $postmeta_table, $meta_key_like ], $post_ids_to_affect )
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"DELETE FROM {$postmeta_table} WHERE meta_key LIKE %s AND post_id IN ( {$post_ids_placeholders} )",
+			$query_args_postmeta
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 		$wpdb->query( $sql_delete_postmeta );
 
-		// Step 3: Delete from accessibility_checker table
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+		// Step 3: Delete from accessibility_checker table.
+		$query_args_ac = array_merge( [ $site_id, $post_type ], $post_ids_to_affect );
 		$sql_delete_ac_data = $wpdb->prepare(
-			"DELETE FROM %i WHERE siteid = %d AND type = %s AND postid IN ( $post_ids_placeholders )",
-			array_merge( [ $ac_table, $site_id, $post_type ], $post_ids_to_affect )
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"DELETE FROM {$ac_table} WHERE siteid = %d AND type = %s AND postid IN ( {$post_ids_placeholders} )",
+			$query_args_ac
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 		$wpdb->query( $sql_delete_ac_data );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		return true;
 	}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -219,7 +219,9 @@ function edac_get_valid_table_name( $table_name ) {
 
 	// Verify that the table actually exists in the database.
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+	// Use SQLite compatible query to check for table existence.
+	$query = $wpdb->prepare( 'SELECT name FROM sqlite_master WHERE type="table" AND name=%s', $table_name );
+	if ( $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) !== $table_name && $wpdb->get_var( $query ) !== $table_name ) {
 		// Table does not exist.
 		return null;
 	}


### PR DESCRIPTION
NOTE: initially drafted by Jules

- Modified `edac_get_valid_table_name` to use SQLite-compatible query for checking table existence.
- Refactored `delete_cpt_posts` in `class-purge-post-data.php` to replace MySQL-specific multi-table DELETE syntax with a multi-step approach compatible with SQLite.
- Reviewed other SQL queries; they generally use standard SQL and $wpdb->prepare, requiring no changes for SQLite compatibility.

<!-- Always provide a short description -->

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
