### PR TITLE
Update make-pot workflow to trigger only on specific pull request types

### DIFF
--- a/.github/workflows/make-pot.yml
+++ b/.github/workflows/make-pot.yml
@@ -8,11 +8,20 @@ on:
         required: false
         default: 'develop'
   pull_request:
-    branches:
-      - develop
+    types:
+      - opened
 
 jobs:
   make-pot:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          startsWith(github.event.pull_request.title, 'automatic_translations_') ||
+          startsWith(github.event.pull_request.title, 'tm_edits_')
+        )
+      )
     runs-on: ubuntu-latest
     services:
       mysql:

--- a/.github/workflows/make-pot.yml
+++ b/.github/workflows/make-pot.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
 
 jobs:
   make-pot:


### PR DESCRIPTION
The workflow now runs for pull requests with titles starting with 'automatic_translations_' or 'tm_edits_', it can still be run with manual dispatch.

<!-- Always provide a short description -->

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow to only run on pull requests with specific title prefixes or when manually triggered, reducing unnecessary job executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->