### PR TITLE
Fix: Standardize plugin path construction

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -486,7 +486,7 @@ class Ajax {
 
 						$landmark          = isset( $row['landmark'] ) ? esc_html( $row['landmark'] ) : '';
 						$landmark_selector = isset( $row['landmark_selector'] ) ? $row['landmark_selector'] : '';
-						
+
 						if ( $landmark && $landmark_selector ) {
 							$landmark_url = add_query_arg(
 								[
@@ -495,7 +495,7 @@ class Ajax {
 								],
 								get_the_permalink( $postid )
 							);
-							
+
 							// translators: %s is the landmark type (e.g., "Header", "Navigation", "Main").
 							$landmark_aria_label = sprintf( __( 'View %s landmark on website, opens a new window', 'accessibility-checker' ), ucwords( $landmark ) );
 							// translators: %s is the landmark type (e.g., "Header", "Navigation", "Main").
@@ -678,7 +678,7 @@ class Ajax {
 
 				$html .=
 					'<li class="edac-readability-list-item edac-readability-summary-position">
-					<span class="edac-readability-list-item-icon"><img src="' . EDAC_PLUGIN_URL . 'assets/images/warning-icon-yellow.png" alt="" width="22"></span>
+					<span class="edac-readability-list-item-icon"><img src="' . esc_url( EDAC_PLUGIN_URL . 'assets/images/warning-icon-yellow.png' ) . '" alt="" width="22"></span>
 					<p class="edac-readability-list-item-title">Simplified summary is not being automatically inserted into the content.</p>
 						<p class="edac-readability-list-item-description">Your Prompt for Simplified Summary is set to "never." If you would like the simplified summary to be displayed automatically, you can change this on the <a href="' . get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=accessibility_checker_settings">settings page</a>.</p>
 				</li>';
@@ -696,7 +696,7 @@ class Ajax {
 
 				$html .=
 					'<li class="edac-readability-list-item edac-readability-summary-position">
-					<span class="edac-readability-list-item-icon"><img src="' . EDAC_PLUGIN_URL . 'assets/images/warning-icon-yellow.png" alt="" width="22"></span>
+					<span class="edac-readability-list-item-icon"><img src="' . esc_url( EDAC_PLUGIN_URL . 'assets/images/warning-icon-yellow.png' ) . '" alt="" width="22"></span>
 					<p class="edac-readability-list-item-title">Simplified summary is not being automatically inserted into the content.</p>
 						<p class="edac-readability-list-item-description">Your Simplified Summary location is set to "manually" which requires a function be added to your page template. If you would like the simplified summary to be displayed automatically, you can change this on the <a href="' . get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=accessibility_checker_settings">settings page</a>.</p>
 				</li>';

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -678,7 +678,7 @@ class Ajax {
 
 				$html .=
 					'<li class="edac-readability-list-item edac-readability-summary-position">
-					<span class="edac-readability-list-item-icon"><img src="' . plugin_dir_url( __FILE__ ) . 'assets/images/warning-icon-yellow.png" alt="" width="22"></span>
+					<span class="edac-readability-list-item-icon"><img src="' . EDAC_PLUGIN_URL . 'assets/images/warning-icon-yellow.png" alt="" width="22"></span>
 					<p class="edac-readability-list-item-title">Simplified summary is not being automatically inserted into the content.</p>
 						<p class="edac-readability-list-item-description">Your Prompt for Simplified Summary is set to "never." If you would like the simplified summary to be displayed automatically, you can change this on the <a href="' . get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=accessibility_checker_settings">settings page</a>.</p>
 				</li>';
@@ -696,7 +696,7 @@ class Ajax {
 
 				$html .=
 					'<li class="edac-readability-list-item edac-readability-summary-position">
-					<span class="edac-readability-list-item-icon"><img src="' . plugin_dir_url( __FILE__ ) . 'assets/images/warning-icon-yellow.png" alt="" width="22"></span>
+					<span class="edac-readability-list-item-icon"><img src="' . EDAC_PLUGIN_URL . 'assets/images/warning-icon-yellow.png" alt="" width="22"></span>
 					<p class="edac-readability-list-item-title">Simplified summary is not being automatically inserted into the content.</p>
 						<p class="edac-readability-list-item-description">Your Simplified Summary location is set to "manually" which requires a function be added to your page template. If you would like the simplified summary to be displayed automatically, you can change this on the <a href="' . get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=accessibility_checker_settings">settings page</a>.</p>
 				</li>';

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -125,7 +125,7 @@ class Enqueue_Admin {
 						'postID'       => $post_id,
 						'edacUrl'      => esc_url_raw( get_site_url() ),
 						'edacApiUrl'   => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
-						'baseurl'      => EDAC_PLUGIN_URL,
+						'baseurl'      => esc_url_raw( EDAC_PLUGIN_URL ),
 						'active'       => $active,
 						'pro'          => $pro,
 						'authOk'       => false === (bool) get_option( 'edac_password_protected', false ),

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -125,7 +125,7 @@ class Enqueue_Admin {
 						'postID'       => $post_id,
 						'edacUrl'      => esc_url_raw( get_site_url() ),
 						'edacApiUrl'   => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
-						'baseurl'      => plugin_dir_url( __DIR__ ),
+						'baseurl'      => EDAC_PLUGIN_URL,
 						'active'       => $active,
 						'pro'          => $pro,
 						'authOk'       => false === (bool) get_option( 'edac_password_protected', false ),

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -37,7 +37,7 @@ class Enqueue_Admin {
 	 * @return void
 	 */
 	public static function enqueue_styles() {
-		wp_enqueue_style( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/css/admin.css', [], EDAC_VERSION, 'all' );
+		wp_enqueue_style( 'edac', EDAC_PLUGIN_URL . 'build/css/admin.css', [], EDAC_VERSION, 'all' );
 	}
 
 	/**
@@ -75,7 +75,7 @@ class Enqueue_Admin {
 
 			global $post;
 			$post_id = is_object( $post ) ? $post->ID : null;
-			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', [ 'jquery' ], EDAC_VERSION, false );
+			wp_enqueue_script( 'edac', EDAC_PLUGIN_URL . 'build/admin.bundle.js', [ 'jquery' ], EDAC_VERSION, false );
 			wp_set_script_translations( 'edac', 'accessibility-checker', plugin_dir_path( EDAC_PLUGIN_FILE ) . 'languages' );
 
 			wp_localize_script(
@@ -105,7 +105,7 @@ class Enqueue_Admin {
 					$debug = false;
 				}
 
-				wp_enqueue_script( 'edac-editor-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/editorApp.bundle.js', false, EDAC_VERSION, false );
+				wp_enqueue_script( 'edac-editor-app', EDAC_PLUGIN_URL . 'build/editorApp.bundle.js', false, EDAC_VERSION, false );
 				wp_set_script_translations( 'edac-editor-app', 'accessibility-checker', plugin_dir_path( EDAC_PLUGIN_FILE ) . 'languages' );
 
 				// If this is the frontpage or homepage, preview URLs won't work. Use the live URL.

--- a/admin/opt-in/class-email-opt-in.php
+++ b/admin/opt-in/class-email-opt-in.php
@@ -53,8 +53,8 @@ class Email_Opt_In {
 	 */
 	public function enqueue_scripts() {
 
-		wp_enqueue_style( 'email-opt-in-form', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/css/emailOptIn.css', false, EDAC_VERSION, 'all' );
-		wp_enqueue_script( 'email-opt-in-form', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/emailOptIn.bundle.js', false, EDAC_VERSION, true );
+		wp_enqueue_style( 'email-opt-in-form', EDAC_PLUGIN_URL . 'build/css/emailOptIn.css', false, EDAC_VERSION, 'all' );
+		wp_enqueue_script( 'email-opt-in-form', EDAC_PLUGIN_URL . 'build/emailOptIn.bundle.js', false, EDAC_VERSION, true );
 		wp_set_script_translations( 'email-opt-in-form', 'accessibility-checker', plugins_url( 'languages', EDAC_PLUGIN_FILE ) );
 
 		wp_localize_script(

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -90,8 +90,8 @@ class Enqueue_Frontend {
 		if ( $active ) {
 
 
-			wp_enqueue_style( 'edac-frontend-highlighter-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/css/frontendHighlighterApp.css', false, EDAC_VERSION, 'all' );
-			wp_enqueue_script( 'edac-frontend-highlighter-app', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/frontendHighlighterApp.bundle.js', false, EDAC_VERSION, false );
+			wp_enqueue_style( 'edac-frontend-highlighter-app', EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css', false, EDAC_VERSION, 'all' );
+			wp_enqueue_script( 'edac-frontend-highlighter-app', EDAC_PLUGIN_URL . 'build/frontendHighlighterApp.bundle.js', false, EDAC_VERSION, false );
 
 			wp_localize_script(
 				'edac-frontend-highlighter-app',
@@ -107,7 +107,7 @@ class Enqueue_Frontend {
 					'appCssUrl'        => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,
 					'widgetPosition'   => get_option( 'edac_frontend_highlighter_position', 'right' ),
 					'editorLink'       => get_edit_post_link( $post_id ),
-					'scannerBundleUrl' => plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/pageScanner.bundle.js',
+					'scannerBundleUrl' => EDAC_PLUGIN_URL . 'build/pageScanner.bundle.js',
 				]
 			);
 

--- a/partials/pro-callout.php
+++ b/partials/pro-callout.php
@@ -9,7 +9,7 @@
 <div class="edac-pro-callout">
 	<img
 		class="edac-pro-callout-icon"
-		src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/edac-emblem.png"
+		src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/edac-emblem.png"
 		alt="<?php esc_attr_e( 'Equalize Digital Logo', 'accessibility-checker' ); ?>"
 	>
 	<h4 class="edac-pro-callout-title">

--- a/partials/pro-callout.php
+++ b/partials/pro-callout.php
@@ -9,7 +9,7 @@
 <div class="edac-pro-callout">
 	<img
 		class="edac-pro-callout-icon"
-		src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/edac-emblem.png"
+		src="<?php echo esc_url( EDAC_PLUGIN_URL . 'assets/images/edac-emblem.png' ); ?>"
 		alt="<?php esc_attr_e( 'Equalize Digital Logo', 'accessibility-checker' ); ?>"
 	>
 	<h4 class="edac-pro-callout-title">

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -37,7 +37,7 @@ use EDAC\Admin\Welcome_Page;
 
 		<div class="edac-welcome-header-right">
 				<a href="<?php edac_link_wrapper( 'https://equalizedigital.com/?utm_source=accessibility-checker&utm_medium=software', 'welcome-page', 'logo-link' ); ?>" target="_blank">
-					<img src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/accessibility-checker-logo-transparent-bg.svg" alt="<?php esc_attr_e( 'Link to Equalize Digital Website', 'accessibility-checker' ); ?>">
+					<img rc="<?php echo esc_url( EDAC_PLUGIN_URL . 'assets/images/accessibility-checker-logo-transparent-bg.svg' ); ?>" alt="<?php esc_attr_e( 'Link to Equalize Digital Website', 'accessibility-checker' ); ?>">
 				</a>
 			</div>
 		</div>

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -37,7 +37,7 @@ use EDAC\Admin\Welcome_Page;
 
 		<div class="edac-welcome-header-right">
 				<a href="<?php edac_link_wrapper( 'https://equalizedigital.com/?utm_source=accessibility-checker&utm_medium=software', 'welcome-page', 'logo-link' ); ?>" target="_blank">
-					<img src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/accessibility-checker-logo-transparent-bg.svg" alt="<?php esc_attr_e( 'Link to Equalize Digital Website', 'accessibility-checker' ); ?>">
+					<img src="<?php echo esc_url( EDAC_PLUGIN_URL ); ?>assets/images/accessibility-checker-logo-transparent-bg.svg" alt="<?php esc_attr_e( 'Link to Equalize Digital Website', 'accessibility-checker' ); ?>">
 				</a>
 			</div>
 		</div>


### PR DESCRIPTION
Replaced inconsistent uses of `plugin_dir_url( __DIR__ )` and `plugin_dir_url( __FILE__ )` with the `EDAC_PLUGIN_URL` constant to ensure correct asset path resolution throughout the plugin.

Fixes #1019 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated image source URLs throughout the admin interface, welcome page, and frontend to use a consistent base plugin URL, ensuring more reliable loading of icons, logos, and assets. No visible changes to functionality or layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->