### PR TITLE
Add a fix class to define the setting and labels for new fix

### DIFF
--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -76,7 +76,7 @@ class AddFileSizeAndTypeToLinkedFilesFix implements FixInterface {
 			'label'       => esc_html__( 'Add File Size & Type To Links', 'accessibility-checker' ),
 			'labelledby'  => 'add_file_size_and_type_to_linked_files',
 			'description' => esc_html__( 'Add the file size and type to linked files that may trigger a download.', 'accessibility-checker' ),
-			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+			'upsell'      => ! ( property_exists( $this, 'is_pro' ) && $this->is_pro ),
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8492,
 		];

--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -76,7 +76,7 @@ class AddFileSizeAndTypeToLinkedFilesFix implements FixInterface {
 			'label'       => esc_html__( 'Add File Size & Type To Links', 'accessibility-checker' ),
 			'labelledby'  => 'add_file_size_and_type_to_linked_files',
 			'description' => esc_html__( 'Add the file size and type to linked files that may trigger a download.', 'accessibility-checker' ),
-			'upsell'      => ! ( property_exists( $this, 'is_pro' ) && $this->is_pro ),
+			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
 			'fix_slug'    => $this->get_slug(),
 			'help_id'     => 8492,
 		];

--- a/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
+++ b/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
@@ -75,13 +75,13 @@ class AddSpacebarSupportToLinksWithButtonRoleFix implements FixInterface {
 	 */
 	public function get_fields_array( array $fields = [] ): array {
 
-		$fields[ 'edac_fix_' . $this->get_slug() ] = [
+		$fields[ 'edac_fix_' . self::get_slug() ] = [
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Add Spacebar Support to Links with Button Role', 'accessibility-checker' ),
 			'labelledby'  => 'add_spacebar_support_to_links_with_button_role',
 			'description' => esc_html__( 'Ensure links with role="button" respond to spacebar keypress for better accessibility.', 'accessibility-checker' ),
 			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
-			'fix_slug'    => $this->get_slug(),
+			'fix_slug'    => self::get_slug(),
 			'help_id'     => 0000,
 		];
 

--- a/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
+++ b/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Fix for adding file size and type to linked files.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+/**
+ * Fix for adding file size and type to linked files.
+ *
+ * @since 1.16.0
+ */
+class AddSpacebarSupportToLinksWithButtonRoleFix implements FixInterface {
+
+	/**
+	 * The slug for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'add_spacebar_support_to_links_with_button_role';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return sprintf(
+			/* translators: %1$s is a html role attribute with value of 'button' */
+			__( 'Add spacebar handling to links with %1$s"', 'accessibility-checker' ),
+			'role="button'
+		);
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_fancyname(): string {
+		return __( 'Add Spacebar Support to Links converted to Buttons', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'none';
+	}
+
+	/**
+	 * Register anything needed for the fix.
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ],
+		);
+	}
+
+	/**
+	 * Get the settings fields for the fix.
+	 *
+	 * @param array $fields The array of fields that are already registered, if any.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+
+		$fields[ 'edac_fix_' . $this->get_slug() ] = [
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Add Spacebar Support to Links with Button Role', 'accessibility-checker' ),
+			'labelledby'  => 'add_spacebar_support_to_links_with_button_role',
+			'description' => esc_html__( 'Ensure links with role="button" respond to spacebar keypress for better accessibility.', 'accessibility-checker' ),
+			'upsell'      => isset( $this->is_pro ) && $this->is_pro ? false : true,
+			'fix_slug'    => $this->get_slug(),
+			'help_id'     => 0000,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Run the fix.
+	 */
+	public function run(): void {
+		// Intentionally left empty.
+	}
+}

--- a/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
+++ b/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Fix for adding file size and type to linked files.
+ * Fix for adding spacebar support to links with role="button".
  *
  * @package accessibility-checker
  */
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 /**
- * Fix for adding file size and type to linked files.
+ * Fix for adding spacebar support to links with role="button".
  *
  * @since 1.16.0
  */

--- a/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
+++ b/includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php
@@ -33,8 +33,8 @@ class AddSpacebarSupportToLinksWithButtonRoleFix implements FixInterface {
 	public static function get_nicename(): string {
 		return sprintf(
 			/* translators: %1$s is a html role attribute with value of 'button' */
-			__( 'Add spacebar handling to links with %1$s"', 'accessibility-checker' ),
-			'role="button'
+			__( 'Add spacebar handling to links with %1$s', 'accessibility-checker' ),
+			'role="button"'
 		);
 	}
 

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -11,6 +11,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddFileSizeAndTypeToLinkedFil
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddLabelToUnlabelledFormFieldsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddMissingOrEmptyPageTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddNewWindowWarningFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddSpacebarSupportToLinksWithButtonRoleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\BlockPDFUploadsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
@@ -139,6 +140,7 @@ class FixesManager {
 				AddMissingOrEmptyPageTitleFix::class,
 				AddLabelToUnlabelledFormFieldsFix::class,
 				AddNewWindowWarningFix::class,
+				AddSpacebarSupportToLinksWithButtonRoleFix::class,
 			]
 		);
 		foreach ( $fixes as $fix ) {


### PR DESCRIPTION
This pull request introduces the base for a new fix to add spacebar support to links with the `role="button"` attribute. The changes include the creation of a new fix class, integration of the fix into the system, and updates to the relevant manager class. This will be a pro fix so it does not include the JS here right now.

### New Fix Implementation:
* Added a new class `AddSpacebarSupportToLinksWithButtonRoleFix` in `includes/classes/Fixes/Fix/AddSpacebarSupportToLinksWithButtonRoleFix.php`. This class defines the slug, nicename, and settings for the fix, and ensures links with `role="button"` respond to spacebar keypresses for better accessibility.

### Integration into Fixes Manager:
* Updated `includes/classes/Fixes/FixesManager.php` to include the new fix:
  - Added the `AddSpacebarSupportToLinksWithButtonRoleFix` class to the `use` statements.
  - Registered the new fix in the `load_fixes` method to ensure it is loaded and applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accessibility fix to support spacebar keypress activation for links with a button role. This can be enabled or disabled in the plugin settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->