### PR TITLE
Refactor disabilities list to enum

### DIFF
--- a/includes/classes/Rules/AffectedDisabilities.php
+++ b/includes/classes/Rules/AffectedDisabilities.php
@@ -39,57 +39,41 @@ final class AffectedDisabilities {
 	public const DYSLEXIA          = 'dyslexia';
 
 	/**
-	 * Map of disability constants to English labels.
-	 *
-	 * @var array<string,string>
-	 */
-	private static $labels = [
-		self::ADHD              => 'ADHD',
-		self::BLIND             => 'Blind',
-		self::COGNITIVE         => 'Cognitive',
-		self::COLORBLIND        => 'Colorblind',
-		self::DEAF              => 'Deaf',
-		self::DEAFBLIND         => 'Deafblind',
-		self::DYSLEXIA          => 'Dyslexia',
-		self::HARD_OF_HEARING   => 'Hard of hearing',
-		self::LANGUAGE_LEARNERS => 'Language learners',
-		self::LOW_VISION        => 'Low-vision',
-		self::MOBILITY          => 'Mobility',
-		self::SEIZURE           => 'Seizure disorders',
-		self::VESTIBULAR        => 'Vestibular disorders',
-	];
-
-	/**
-	 * Cached translated labels.
-	 *
-	 * @var array<string,string>|null
-	 */
-	private static $translated_labels = null;
-
-	/**
 	 * Get translated label for a disability key.
 	 *
 	 * @param string $key Disability key constant.
 	 * @return string Translated label.
 	 */
 	public static function get_label( string $key ): string {
-		$labels = self::get_all_labels();
-		return $labels[ $key ] ?? '';
-	}
-
-	/**
-	 * Get all disability labels translated.
-	 *
-	 * @return array<string,string> Array of key => label pairs.
-	 */
-	public static function get_all_labels(): array {
-		if ( null === self::$translated_labels ) {
-			self::$translated_labels = [];
-			foreach ( self::$labels as $key => $label ) {
-				// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
-				self::$translated_labels[ $key ] = esc_html__( $label, 'accessibility-checker' );
-			}
+		switch ( $key ) {
+			case self::BLIND:
+				return esc_html__( 'Blind', 'accessibility-checker' );
+			case self::LOW_VISION:
+				return esc_html__( 'Low-vision', 'accessibility-checker' );
+			case self::DEAFBLIND:
+				return esc_html__( 'Deafblind', 'accessibility-checker' );
+			case self::MOBILITY:
+				return esc_html__( 'Mobility', 'accessibility-checker' );
+			case self::COLORBLIND:
+				return esc_html__( 'Colorblind', 'accessibility-checker' );
+			case self::COGNITIVE:
+				return esc_html__( 'Cognitive', 'accessibility-checker' );
+			case self::SEIZURE:
+				return esc_html__( 'Seizure disorders', 'accessibility-checker' );
+			case self::VESTIBULAR:
+				return esc_html__( 'Vestibular disorders', 'accessibility-checker' );
+			case self::DEAF:
+				return esc_html__( 'Deaf', 'accessibility-checker' );
+			case self::HARD_OF_HEARING:
+				return esc_html__( 'Hard of hearing', 'accessibility-checker' );
+			case self::LANGUAGE_LEARNERS:
+				return esc_html__( 'Language learners', 'accessibility-checker' );
+			case self::ADHD:
+				return esc_html__( 'ADHD', 'accessibility-checker' );
+			case self::DYSLEXIA:
+				return esc_html__( 'Dyslexia', 'accessibility-checker' );
+			default:
+				return '';
 		}
-		return self::$translated_labels;
 	}
 }

--- a/includes/classes/Rules/AffectedDisabilities.php
+++ b/includes/classes/Rules/AffectedDisabilities.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Enumeration of disabilities affected by accessibility issues.
+ *
+ * @package EqualizeDigital\AccessibilityChecker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Rules;
+
+/**
+ * Defines constants for affected disabilities and provides translated labels.
+ */
+class AffectedDisabilities {
+	public const BLIND             = 'blind';
+	public const LOW_VISION        = 'low_vision';
+	public const DEAFBLIND         = 'deafblind';
+	public const MOBILITY          = 'mobility';
+	public const COLORBLIND        = 'colorblind';
+	public const COGNITIVE         = 'cognitive';
+	public const SEIZURE           = 'seizure_disorders';
+	public const VESTIBULAR        = 'vestibular_disorders';
+	public const DEAF              = 'deaf';
+	public const HARD_OF_HEARING   = 'hard_of_hearing';
+	public const LANGUAGE_LEARNERS = 'language_learners';
+	public const ADHD              = 'adhd';
+	public const DYSLEXIA          = 'dyslexia';
+
+	/**
+	 * Map of disability constants to English labels.
+	 *
+	 * @var array<string,string>
+	 */
+	private static $labels = [
+		self::ADHD              => 'ADHD',
+		self::BLIND             => 'Blind',
+		self::COGNITIVE         => 'Cognitive',
+		self::COLORBLIND        => 'Colorblind',
+		self::DEAF              => 'Deaf',
+		self::DEAFBLIND         => 'Deafblind',
+		self::DYSLEXIA          => 'Dyslexia',
+		self::HARD_OF_HEARING   => 'Hard of hearing',
+		self::LANGUAGE_LEARNERS => 'Language learners',
+		self::LOW_VISION        => 'Low-vision',
+		self::MOBILITY          => 'Mobility',
+		self::SEIZURE           => 'Seizure disorders',
+		self::VESTIBULAR        => 'Vestibular disorders',
+	];
+
+	/**
+	 * Cached translated labels.
+	 *
+	 * @var array<string,string>|null
+	 */
+	private static $translated_labels = null;
+
+	/**
+	 * Get translated label for a disability key.
+	 *
+	 * @param string $key Disability key constant.
+	 * @return string Translated label.
+	 */
+	public static function get_label( string $key ): string {
+		$labels = self::get_all_labels();
+		return $labels[ $key ] ?? '';
+	}
+
+	/**
+	 * Get all disability labels translated.
+	 *
+	 * @return array<string,string> Array of key => label pairs.
+	 */
+	public static function get_all_labels(): array {
+		if ( null === self::$translated_labels ) {
+			self::$translated_labels = [];
+			foreach ( self::$labels as $key => $label ) {
+				// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+				self::$translated_labels[ $key ] = esc_html__( $label, 'accessibility-checker' );
+			}
+		}
+		return self::$translated_labels;
+	}
+}

--- a/includes/classes/Rules/AffectedDisabilities.php
+++ b/includes/classes/Rules/AffectedDisabilities.php
@@ -2,15 +2,28 @@
 /**
  * Enumeration of disabilities affected by accessibility issues.
  *
+ * Defines constants for affected disabilities and provides translated labels.
+ * This class is a static utility and should not be extended or instantiated.
+ *
  * @package EqualizeDigital\AccessibilityChecker
  */
 
 namespace EqualizeDigital\AccessibilityChecker\Rules;
 
 /**
+ * Enumeration of disabilities affected by accessibility issues.
+ *
  * Defines constants for affected disabilities and provides translated labels.
+ * This class is a static utility and should not be extended or instantiated.
+ *
+ * @package EqualizeDigital\AccessibilityChecker
  */
-class AffectedDisabilities {
+final class AffectedDisabilities {
+	/**
+	 * Prevent instantiation.
+	 */
+	private function __construct() {}
+
 	public const BLIND             = 'blind';
 	public const LOW_VISION        = 'low_vision';
 	public const DEAFBLIND         = 'deafblind';

--- a/includes/classes/Rules/Rule/AriaHiddenRule.php
+++ b/includes/classes/Rules/Rule/AriaHiddenRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * AriaHidden Rule class.
@@ -54,9 +55,9 @@ class AriaHiddenRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 			'combines'              => [
 				'aria_hidden_validation',

--- a/includes/classes/Rules/Rule/BrokenAriaReferenceRule.php
+++ b/includes/classes/Rules/Rule/BrokenAriaReferenceRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * BrokenAriaReference Rule class.
@@ -45,10 +46,10 @@ class BrokenAriaReferenceRule implements RuleInterface {
 			'wcag'                  => '4.1.2',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::MOBILITY,
 			],
 			'combines'              => [ 'aria_broken_reference' ],
 			'ruleset'               => 'js',

--- a/includes/classes/Rules/Rule/BrokenSkipAnchorLinkRule.php
+++ b/includes/classes/Rules/Rule/BrokenSkipAnchorLinkRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * BrokenSkipAnchorLink Rule class.
@@ -42,10 +43,10 @@ class BrokenSkipAnchorLinkRule implements RuleInterface {
 			'wcag'                  => '2.4.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::MOBILITY,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ColorContrastFailureRule.php
+++ b/includes/classes/Rules/Rule/ColorContrastFailureRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ColorContrastFailure Rule class.
@@ -46,8 +47,8 @@ class ColorContrastFailureRule implements RuleInterface {
 			'wcag'                  => '1.4.3',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Colorblind', 'accessibility-checker' ),
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::COLORBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/DuplicateFormLabelRule.php
+++ b/includes/classes/Rules/Rule/DuplicateFormLabelRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * DuplicateFormLabel Rule class.
@@ -47,10 +48,10 @@ class DuplicateFormLabelRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 			'combines'              => [ 'form-field-multiple-labels' ],
 		];

--- a/includes/classes/Rules/Rule/EmptyButtonRule.php
+++ b/includes/classes/Rules/Rule/EmptyButtonRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * EmptyButton Rule class.
@@ -64,10 +65,10 @@ class EmptyButtonRule implements RuleInterface {
 			'wcag'                  => '4.1.2',
 			'severity'              => 1, // Critical.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/EmptyHeadingTagRule.php
+++ b/includes/classes/Rules/Rule/EmptyHeadingTagRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * EmptyHeadingTag Rule class.
@@ -50,9 +51,9 @@ class EmptyHeadingTagRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/EmptyLinkRule.php
+++ b/includes/classes/Rules/Rule/EmptyLinkRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * EmptyLink Rule class.
@@ -52,10 +53,10 @@ class EmptyLinkRule implements RuleInterface {
 			'wcag'                  => '2.4.4',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/EmptyParagraphTagRule.php
+++ b/includes/classes/Rules/Rule/EmptyParagraphTagRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * EmptyParagraphTag Rule class.
@@ -50,10 +51,10 @@ class EmptyParagraphTagRule implements RuleInterface {
 			'wcag'                  => '0.1',
 			'severity'              => 4, // Low.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/EmptyTableHeaderRule.php
+++ b/includes/classes/Rules/Rule/EmptyTableHeaderRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * EmptyTableHeader Rule class.
@@ -54,10 +55,10 @@ class EmptyTableHeaderRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/IframeMissingTitleRule.php
+++ b/includes/classes/Rules/Rule/IframeMissingTitleRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * IframeMissingTitle Rule class.
@@ -54,10 +55,10 @@ class IframeMissingTitleRule implements RuleInterface {
 			'wcag'                  => '4.1.2',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::MOBILITY,
 			],
 			'combines'              => [
 				'frame-title',

--- a/includes/classes/Rules/Rule/ImageMapMissingAltTextRule.php
+++ b/includes/classes/Rules/Rule/ImageMapMissingAltTextRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImageMapMissingAltText Rule class.
@@ -55,9 +56,9 @@ class ImageMapMissingAltTextRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 			'combines'              => [
 				'area-alt',

--- a/includes/classes/Rules/Rule/ImgAltEmptyRule.php
+++ b/includes/classes/Rules/Rule/ImgAltEmptyRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgAltEmpty Rule class.
@@ -51,9 +52,9 @@ class ImgAltEmptyRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ImgAltInvalidRule.php
+++ b/includes/classes/Rules/Rule/ImgAltInvalidRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgAltInvalid Rule class.
@@ -38,9 +39,9 @@ class ImgAltInvalidRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ImgAltLongRule.php
+++ b/includes/classes/Rules/Rule/ImgAltLongRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgAltLong Rule class.
@@ -50,10 +51,10 @@ class ImgAltLongRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 4, // Low.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ImgAltMissingRule.php
+++ b/includes/classes/Rules/Rule/ImgAltMissingRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgAltMissing Rule class.
@@ -56,9 +57,9 @@ class ImgAltMissingRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ImgAltRedundantRule.php
+++ b/includes/classes/Rules/Rule/ImgAltRedundantRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgAltRedundant Rule class.
@@ -38,9 +39,9 @@ class ImgAltRedundantRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ImgAnimatedGifRule.php
+++ b/includes/classes/Rules/Rule/ImgAnimatedGifRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgAnimatedGif Rule class.
@@ -45,9 +46,9 @@ class ImgAnimatedGifRule implements RuleInterface {
 			'wcag'                  => '2.2.2',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Seizure disorders', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Vestibular disorders', 'accessibility-checker' ),
+				AffectedDisabilities::SEIZURE,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::VESTIBULAR,
 			],
 			'ruleset'               => 'js',
 			'combines'              => [ 'img_animated' ],

--- a/includes/classes/Rules/Rule/ImgLinkedAltEmptyRule.php
+++ b/includes/classes/Rules/Rule/ImgLinkedAltEmptyRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgLinkedAltEmpty Rule class.
@@ -38,9 +39,9 @@ class ImgLinkedAltEmptyRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 1, // Critical.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/ImgLinkedAltMissingRule.php
+++ b/includes/classes/Rules/Rule/ImgLinkedAltMissingRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * ImgLinkedAltMissing Rule class.
@@ -42,9 +43,9 @@ class ImgLinkedAltMissingRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/IncorrectHeadingOrderRule.php
+++ b/includes/classes/Rules/Rule/IncorrectHeadingOrderRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * IncorrectHeadingOrder Rule class.
@@ -55,11 +56,11 @@ class IncorrectHeadingOrderRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 			'combines'              => [
 				'heading-order',

--- a/includes/classes/Rules/Rule/LinkAmbiguousTextRule.php
+++ b/includes/classes/Rules/Rule/LinkAmbiguousTextRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * LinkAmbiguousText Rule class.
@@ -50,11 +51,11 @@ class LinkAmbiguousTextRule implements RuleInterface {
 			'wcag'                  => '2.4.4',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/LinkBlankRule.php
+++ b/includes/classes/Rules/Rule/LinkBlankRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\{
 	PreventLinksOpeningNewWindowFix,
 	AddNewWindowWarningFix
@@ -46,11 +47,11 @@ class LinkBlankRule implements RuleInterface {
 			'wcag'                  => '3.2.2',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 			'combines'              => [
 				'link_blank',

--- a/includes/classes/Rules/Rule/LinkImproperRule.php
+++ b/includes/classes/Rules/Rule/LinkImproperRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * LinkImproper Rule class.
@@ -58,10 +59,10 @@ class LinkImproperRule implements RuleInterface {
 			'wcag'                  => '4.1.2',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::MOBILITY,
 			],
 			'ruleset'               => 'js',
 		];

--- a/includes/classes/Rules/Rule/LinkMsOfficeFileRule.php
+++ b/includes/classes/Rules/Rule/LinkMsOfficeFileRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * LinkMsOfficeFile Rule class.
@@ -66,12 +67,12 @@ class LinkMsOfficeFileRule implements RuleInterface {
 			'wcag'                  => '0.3',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
-				esc_html__( 'Colorblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
+				AffectedDisabilities::COLORBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/LinkNonHtmlFileRule.php
+++ b/includes/classes/Rules/Rule/LinkNonHtmlFileRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * LinkNonHtmlFile Rule class.
@@ -33,12 +34,12 @@ class LinkNonHtmlFileRule implements RuleInterface {
 			'wcag'                  => '0.3',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
-				esc_html__( 'Colorblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
+				AffectedDisabilities::COLORBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/LinkPdfRule.php
+++ b/includes/classes/Rules/Rule/LinkPdfRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * LinkPdf Rule class.
@@ -50,12 +51,12 @@ class LinkPdfRule implements RuleInterface {
 			'wcag'                  => '0.3',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
-				esc_html__( 'Colorblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
+				AffectedDisabilities::COLORBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/LongDescriptionInvalidRule.php
+++ b/includes/classes/Rules/Rule/LongDescriptionInvalidRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * LongDescriptionInvalid Rule class.
@@ -58,9 +59,9 @@ class LongDescriptionInvalidRule implements RuleInterface {
 			'wcag'                  => '1.1.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/MetaViewportRule.php
+++ b/includes/classes/Rules/Rule/MetaViewportRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\MetaViewportScalableFix;
 
 /**
@@ -54,7 +55,7 @@ class MetaViewportRule implements RuleInterface {
 			'wcag'                  => '1.4.4',
 			'severity'              => 1, // Critical.
 			'affected_disabilities' => [
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
+				AffectedDisabilities::LOW_VISION,
 			],
 			'ruleset'               => 'js',
 			'combines'              => [ 'meta-viewport' ],

--- a/includes/classes/Rules/Rule/MissingFormLabelRule.php
+++ b/includes/classes/Rules/Rule/MissingFormLabelRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\{
 	AddLabelToUnlabelledFormFieldsFix,
 	CommentSearchLabelFix
@@ -63,11 +64,11 @@ class MissingFormLabelRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 1, // Critical.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 			'combines'              => [ 'label' ],
 			'fixes'                 => [

--- a/includes/classes/Rules/Rule/MissingHeadingsRule.php
+++ b/includes/classes/Rules/Rule/MissingHeadingsRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * MissingHeadings Rule class.
@@ -55,11 +56,11 @@ class MissingHeadingsRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/MissingLangAttrRule.php
+++ b/includes/classes/Rules/Rule/MissingLangAttrRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 
 /**
@@ -58,8 +59,8 @@ class MissingLangAttrRule implements RuleInterface {
 			'wcag'                  => '3.1.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::DEAFBLIND,
 			],
 			'combines'              => [ 'html-lang-valid', 'html-has-lang' ],
 			'ruleset'               => 'js',

--- a/includes/classes/Rules/Rule/MissingTableHeaderRule.php
+++ b/includes/classes/Rules/Rule/MissingTableHeaderRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * MissingTableHeader Rule class.
@@ -55,10 +56,10 @@ class MissingTableHeaderRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/MissingTitleRule.php
+++ b/includes/classes/Rules/Rule/MissingTitleRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddMissingOrEmptyPageTitleFix;
 
 /**
@@ -48,10 +49,10 @@ class MissingTitleRule implements RuleInterface {
 			'wcag'                  => '2.4.2',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::MOBILITY,
 			],
 			'ruleset'               => 'js',
 			'combines'              => [ 'document-title' ],

--- a/includes/classes/Rules/Rule/MissingTranscriptRule.php
+++ b/includes/classes/Rules/Rule/MissingTranscriptRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * MissingTranscript Rule class.
@@ -41,11 +42,11 @@ class MissingTranscriptRule implements RuleInterface {
 			'wcag'                  => '1.2.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Deaf', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Hard of hearing', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Language learners', 'accessibility-checker' ),
+				AffectedDisabilities::DEAF,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::HARD_OF_HEARING,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::LANGUAGE_LEARNERS,
 			],
 			'ruleset'               => 'js',
 		];

--- a/includes/classes/Rules/Rule/PossibleHeadingRule.php
+++ b/includes/classes/Rules/Rule/PossibleHeadingRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * PossibleHeading Rule class.
@@ -47,10 +48,10 @@ class PossibleHeadingRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/SliderPresentRule.php
+++ b/includes/classes/Rules/Rule/SliderPresentRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * SliderPresent Rule class.
@@ -41,11 +42,11 @@ class SliderPresentRule implements RuleInterface {
 			'wcag'                  => '0.3',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 			'ruleset'               => 'js',
 		];

--- a/includes/classes/Rules/Rule/TabOrderModifiedRule.php
+++ b/includes/classes/Rules/Rule/TabOrderModifiedRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 
 /**
@@ -57,11 +58,11 @@ class TabOrderModifiedRule implements RuleInterface {
 			'wcag'                  => '2.4.3',
 			'severity'              => 2, // High.
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Mobility', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::MOBILITY,
 			],
 			'combines'              => [ 'tabindex' ],
 			'fixes'                 => [

--- a/includes/classes/Rules/Rule/TextBlinkingScrollingRule.php
+++ b/includes/classes/Rules/Rule/TextBlinkingScrollingRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * TextBlinkingScrolling Rule class.
@@ -48,9 +49,9 @@ class TextBlinkingScrollingRule implements RuleInterface {
 			'wcag'                  => '2.2.2',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Seizure disorders', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'ADHD', 'accessibility-checker' ),
+				AffectedDisabilities::SEIZURE,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::ADHD,
 			],
 			'combines'              => [ 'blink', 'marquee' ],
 		];

--- a/includes/classes/Rules/Rule/TextJustifiedRule.php
+++ b/includes/classes/Rules/Rule/TextJustifiedRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * TextJustified Rule class.
@@ -50,9 +51,9 @@ class TextJustifiedRule implements RuleInterface {
 			'wcag'                  => '1.4.8',
 			'severity'              => 4, // Low.
 			'affected_disabilities' => [
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Dyslexia', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DYSLEXIA,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/TextSmallRule.php
+++ b/includes/classes/Rules/Rule/TextSmallRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * TextSmall Rule class.
@@ -46,7 +47,7 @@ class TextSmallRule implements RuleInterface {
 			'wcag'                  => '1.4.4',
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
+				AffectedDisabilities::LOW_VISION,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/UnderlinedTextRule.php
+++ b/includes/classes/Rules/Rule/UnderlinedTextRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * UnderlinedText Rule class.
@@ -43,8 +44,8 @@ class UnderlinedTextRule implements RuleInterface {
 			'wcag'                  => '1.3.1',
 			'severity'              => 4, // Low.
 			'affected_disabilities' => [
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::COGNITIVE,
 			],
 		];
 	}

--- a/includes/classes/Rules/Rule/VideoPresentRule.php
+++ b/includes/classes/Rules/Rule/VideoPresentRule.php
@@ -8,6 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
 
 /**
  * VideoPresent Rule class.
@@ -41,13 +42,13 @@ class VideoPresentRule implements RuleInterface {
 			'wcag'                  => '0.3',
 			'severity'              => 1, // Critical..
 			'affected_disabilities' => [
-				esc_html__( 'Blind', 'accessibility-checker' ),
-				esc_html__( 'Low-vision', 'accessibility-checker' ),
-				esc_html__( 'Deafblind', 'accessibility-checker' ),
-				esc_html__( 'Cognitive', 'accessibility-checker' ),
-				esc_html__( 'Language learners', 'accessibility-checker' ),
-				esc_html__( 'Deaf', 'accessibility-checker' ),
-				esc_html__( 'Hard of hearing', 'accessibility-checker' ),
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::DEAFBLIND,
+				AffectedDisabilities::COGNITIVE,
+				AffectedDisabilities::LANGUAGE_LEARNERS,
+				AffectedDisabilities::DEAF,
+				AffectedDisabilities::HARD_OF_HEARING,
 			],
 			'ruleset'               => 'js',
 		];


### PR DESCRIPTION
## Summary
- create new `AffectedDisabilities` enum
- reference enum constants from rule definitions

## Testing
- `composer lint`
- `composer check-cs`
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

Fixes: https://linear.app/equalize-digital/issue/PRO-209/make-the-affected-disabilities-list-an-enum

------
https://chatgpt.com/codex/tasks/task_e_68804f0869988328b25e60d30f14ff0d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized and centralized the list of disabilities affected by accessibility issues, ensuring consistent labeling and translation across the platform.

* **Refactor**
  * Updated all accessibility rules to reference a unified set of disability labels, improving maintainability and consistency in how affected disabilities are displayed to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->