### PR TITLE
Add a filter to `get_scannable_post_statuses`

### DIFF
--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -18,7 +18,10 @@ class Settings {
 	 * @var array
 	 */
 	public static function get_scannable_post_statuses() {
-		return [ 'publish', 'future', 'draft', 'pending', 'private' ];
+		return apply_filters(
+			'edac_scannable_post_statuses',
+			[ 'publish', 'future', 'draft', 'pending', 'private' ]
+		);
 	}
 
 

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -18,6 +18,11 @@ class Settings {
 	 * @var array
 	 */
 	public static function get_scannable_post_statuses() {
+		/**
+		 * Filter the list of post statuses that are scannable.
+		 *
+		 * @since 1.29.0
+		 */
 		return apply_filters(
 			'edac_scannable_post_statuses',
 			[ 'publish', 'future', 'draft', 'pending', 'private' ]

--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -19,9 +19,11 @@ class Settings {
 	 */
 	public static function get_scannable_post_statuses() {
 		/**
-		 * Filter the list of post statuses that are scannable.
+		 * Filters the list of post statuses that are scannable.
 		 *
 		 * @since 1.29.0
+		 *
+		 * @param array $scannable_post_statuses List of scannable post statuses.
 		 */
 		return apply_filters(
 			'edac_scannable_post_statuses',


### PR DESCRIPTION
This pull request introduces a change to make the list of scannable post statuses filterable in the `admin/class-settings.php` file. This enhancement improves flexibility by allowing developers to modify the list of post statuses dynamically.

* [`admin/class-settings.php`](diffhunk://#diff-b825f493538a13f917f49c96a5f34aefab1d1e5f5143b191b12ba07c72718678L21-R29): Updated the `get_scannable_post_statuses` method to use the `apply_filters` function, enabling developers to filter the list of scannable post statuses via the `edac_scannable_post_statuses` filter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the list of scannable post statuses through a WordPress filter, allowing greater flexibility for external integrations.

* **Documentation**
  * Updated documentation to describe the new filter and its availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->