### PR TITLE
Remove password protection features

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -33,7 +33,6 @@ class Admin_Notices {
 		add_action( 'wp_ajax_edac_black_friday_notice_ajax', [ $this, 'edac_black_friday_notice_ajax' ] );
 		add_action( 'wp_ajax_edac_gaad_notice_ajax', [ $this, 'edac_gaad_notice_ajax' ] );
 		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
-		add_action( 'wp_ajax_edac_password_protected_notice_ajax', [ $this, 'edac_password_protected_notice_ajax' ] );
 		add_action( 'wp_ajax_edac_welcome_page_post_count_change_notice_dismiss_ajax', [ $this, 'welcome_page_post_count_change_notice_ajax' ] );
 		// Save fixes transient on save.
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
@@ -54,7 +53,6 @@ class Admin_Notices {
 		add_action( 'admin_notices', [ $this, 'edac_black_friday_notice' ] );
 		add_action( 'admin_notices', [ $this, 'edac_gaad_notice' ] );
 		add_action( 'admin_notices', [ $this, 'edac_review_notice' ] );
-		add_action( 'admin_notices', [ $this, 'edac_password_protected_notice' ] );
 		add_action( 'admin_notices', [ $this, 'welcome_page_post_count_change_notice' ] );
 	}
 
@@ -426,82 +424,6 @@ class Admin_Notices {
 		wp_send_json_success( wp_json_encode( $results ) );
 	}
 
-	/**
-	 * Password Protected Notice Text
-	 *
-	 * @return string
-	 */
-	public function edac_password_protected_notice_text() {
-		/**
-		 * Filter the password protected notice text.
-		 *
-		 * @since 1.4.0
-		 *
-		 * @param string $text The password protected notice text.
-		 */
-		return apply_filters(
-			'edac_filter_password_protected_notice_text',
-			sprintf(
-				// translators: %s is the link to upgrade to pro, with "upgrade to pro" as the anchor text.
-				esc_html__( 'Whoops! It looks like your website is currently password protected. The free version of Accessibility Checker can only scan live websites. To scan this website for accessibility problems either remove the password protection or %s. Scan results may be stored from a previous scan.', 'accessibility-checker' ),
-				sprintf(
-					'<a href="%3$s" target="_blank" aria-label="%1$s">%2$s</a>',
-					esc_attr__( 'Upgrade to accessibility checker pro. Opens in a new window.', 'accessibility-checker' ),
-					esc_html__( 'upgrade to pro', 'accessibility-checker' ),
-					edac_generate_link_type(
-						[
-							'utm-campaign' => 'password-protected-notice',
-							'utm-content'  => 'upgrade-to-pro',
-						]
-					)
-				)
-			)
-		);
-	}
-
-	/**
-	 * Password Protected Notice
-	 *
-	 * @return string
-	 */
-	public function edac_password_protected_notice() {
-		if ( (bool) get_option( 'edac_password_protected' )
-			&& ! (bool) get_option( 'edac_password_protected_notice_dismiss' )
-		) {
-			echo wp_kses( '<div class="edac_password_protected_notice notice notice-error is-dismissible"><p>' . $this->edac_password_protected_notice_text() . '</p></div>', 'post' );
-			return;
-		}
-	}
-
-	/**
-	 * Password Protected Admin Notice Ajax
-	 *
-	 * @return void
-	 *
-	 *  - '-1' means that nonce could not be varified
-	 *  - '-2' means that update option wasn't successful
-	 */
-	public function edac_password_protected_notice_ajax() {
-
-		// nonce security.
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
-
-			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-
-		}
-
-		$results = update_option( 'edac_password_protected_notice_dismiss', true );
-
-		if ( ! $results ) {
-
-			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-
-		}
-
-		wp_send_json_success( wp_json_encode( $results ) );
-	}
 
 	/**
 	 * Save a transient to indicate that the fixes settings have been updated.

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -68,13 +68,6 @@ class Ajax {
 		$html            = [];
 		$html['content'] = '';
 
-		// password check.
-		if ( (bool) get_option( 'edac_password_protected' ) === true ) {
-			$admin_notices              = new \EDAC\Admin\Admin_Notices();
-			$notice_text                = $admin_notices->edac_password_protected_notice_text();
-			$html['password_protected'] = $notice_text;
-			$html['content']           .= '<div class="edac-summary-notice">' . $notice_text . '</div>';
-		}
 
 		$post_id                   = (int) $_REQUEST['post_id'];
 		$summary                   = ( new Summary_Generator( $post_id ) )->generate_summary();

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -128,7 +128,6 @@ class Enqueue_Admin {
 						'baseurl'      => plugin_dir_url( __DIR__ ),
 						'active'       => $active,
 						'pro'          => $pro,
-						'authOk'       => false === (bool) get_option( 'edac_password_protected', false ),
 						'debug'        => $debug,
 						'scanUrl'      => $scan_url,
 						'maxAltLength' => max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) ),

--- a/admin/site-health/class-pro.php
+++ b/admin/site-health/class-pro.php
@@ -58,14 +58,6 @@ class Pro {
 					'label' => __( 'License Status', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edacp_license_status' ) ),
 				],
-				'authorization_username' => [
-					'label' => __( 'Authorization Username', 'accessibility-checker' ),
-					'value' => esc_html( get_option( 'edacp_authorization_username' ) ? get_option( 'edacp_authorization_username' ) : __( 'Unset', 'accessibility-checker' ) ),
-				],
-				'authorization_password' => [
-					'label' => __( 'Authorization Password', 'accessibility-checker' ),
-					'value' => esc_html( get_option( 'edacp_authorization_password' ) ? get_option( 'edacp_authorization_password' ) : __( 'Unset', 'accessibility-checker' ) ),
-				],
 				'scan_id'                => [
 					'label' => __( 'Scan ID', 'accessibility-checker' ),
 					'value' => esc_html( get_transient( 'edacp_scan_id' ) ),

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -499,31 +499,6 @@ const edacScriptVars = edac_script_vars;
 			} );
 		}
 
-		/**
-		 * Password Protected Notice Ajax
-		 */
-		if ( jQuery( '.edac_password_protected_notice' ).length ) {
-			jQuery( '.edac_password_protected_notice' ).on( 'click', function() {
-				edacPasswordProtectedNoticeAjax();
-			} );
-		}
-
-		function edacPasswordProtectedNoticeAjax() {
-			jQuery.ajax( {
-				url: ajaxurl,
-				method: 'GET',
-				data: {
-					action: 'edac_password_protected_notice_ajax',
-					nonce: edacScriptVars.nonce,
-				},
-			} ).done( function( response ) {
-				if ( true === response.success ) {
-					const responseJSON = jQuery.parseJSON( response.data );
-				} else {
-					//console.log(response);
-				}
-			} );
-		}
 
 		/**
 		 * GAAD Notice Ajax

--- a/src/editorApp/index.js
+++ b/src/editorApp/index.js
@@ -7,14 +7,11 @@ window.addEventListener( 'DOMContentLoaded', () => {
 	// eslint-disable-next-line camelcase
 	const SCANNABLE_POST_TYPE = edac_editor_app.active;
 
-	if ( SCANNABLE_POST_TYPE ) {
-		// eslint-disable-next-line camelcase
-		if ( edac_editor_app.authOk === '1' ) {
-			setTimeout( function() {
-				initCheckPage();
-			}, 250 ); // Allow page load to fire before init, otherwise we'll have to wait for iframe to load.
-		}
-	}
+       if ( SCANNABLE_POST_TYPE ) {
+               setTimeout( function() {
+                       initCheckPage();
+               }, 250 ); // Allow page load to fire before init, otherwise we'll have to wait for iframe to load.
+       }
 
 	document.addEventListener( 'edac-fix-settings-saved', function( event ) {
 		if ( event.detail.success ) {

--- a/tests/phpunit/Admin/AdminNoticesTest.php
+++ b/tests/phpunit/Admin/AdminNoticesTest.php
@@ -80,30 +80,4 @@ class AdminNoticesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'https://equalizedigital.com/accessibility-checker/pricing/', $message );
 	}
 
-	/**
-	 * Test that the edac_password_protected_notice_text function exists.
-	 */
-	public function test_edac_password_protected_notice_text_exists() {
-		$this->assertTrue(
-			method_exists( $this->admin_notices, 'edac_password_protected_notice_text' ),
-			'Class does not have method edac_password_protected_notice_text'
-		);
-	}
-
-	/**
-	 * Test that the edac_password_protected_notice_text function returns a string.
-	 */
-	public function test_edac_password_protected_notice_text_returns_string() {
-		$this->assertIsString( $this->admin_notices->edac_password_protected_notice_text() );
-	}
-
-	/**
-	 * Test that the edac_password_protected_notice_text function contains the expected notice message.
-	 */
-	public function test_edac_password_protected_notice_text_contains_notice_message() {
-		$message = $this->admin_notices->edac_password_protected_notice_text();
-		$this->assertStringContainsString( 'Whoops! It looks like your website is currently password protected.', $message );
-		$this->assertStringContainsString( 'The free version of Accessibility Checker can only scan live websites.', $message );
-		$this->assertStringContainsString( 'Scan results may be stored from a previous scan.', $message );
-	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -32,8 +32,6 @@ if ( true === (bool) $delete_data ) {
 		'edac_frontend_highlighter_position',
 		'edac_delete_data',
 		'edac_review_notice',
-		'edac_authorization_password',
-		'edac_authorization_username',
 		'edac_gaad_notice_dismiss',
 		'edac_black_friday_2023_notice_dismiss',
 	];


### PR DESCRIPTION
## Summary
- drop password protection admin notice hooks
- remove password protected check from ajax callbacks
- stop exposing auth status in localized JS
- update editor script to always load scanner
- prune authorization details from site health
- clean up uninstall list and tests

## Testing
- `composer lint`
- `composer test` *(fails: Could not find WordPress test library)*

------
https://chatgpt.com/codex/tasks/task_e_68818e92d8a483289b677f416c9e350b