### PR TITLE
Add rescan button to highlighter

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -385,7 +385,7 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
                                         <div>
-                                                <button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'text-domain' ) }</button>
+                                                <button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
                                                 <button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
                                         </div>
 				</div>

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -368,14 +368,14 @@ class AccessibilityCheckerHighlight {
 
 		const newElement = `
 			<div id="edac-highlight-panel" class="edac-highlight-panel edac-highlight-panel--${ widgetPosition }">
-			<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="Accessibility Checker Tools"></button>
-			<div id="edac-highlight-panel-description" class="edac-highlight-panel-description" role="dialog" aria-labelledby="edac-highlight-panel-description-title" tabindex="0">
-			<button class="edac-highlight-panel-description-close edac-highlight-panel-controls-close" aria-label="Close">×</button>
-				<div id="edac-highlight-panel-description-title" class="edac-highlight-panel-description-title"></div>
-				<div class="edac-highlight-panel-description-content"></div>
-				<div id="edac-highlight-panel-description-code" class="edac-highlight-panel-description-code"><code></code></div>
-			</div>
-			<div id="edac-highlight-panel-controls" class="edac-highlight-panel-controls" tabindex="0">
+				<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="Accessibility Checker Tools"></button>
+				<div id="edac-highlight-panel-description" class="edac-highlight-panel-description" role="dialog" aria-labelledby="edac-highlight-panel-description-title" tabindex="0">
+				<button class="edac-highlight-panel-description-close edac-highlight-panel-controls-close" aria-label="Close">×</button>
+					<div id="edac-highlight-panel-description-title" class="edac-highlight-panel-description-title"></div>
+					<div class="edac-highlight-panel-description-content"></div>
+					<div id="edac-highlight-panel-description-code" class="edac-highlight-panel-description-code"><code></code></div>
+				</div>
+				<div id="edac-highlight-panel-controls" class="edac-highlight-panel-controls" tabindex="0">
 				<button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="Close">×</button>
 				<div class="edac-highlight-panel-controls-title">Accessibility Checker</div>
 				<div class="edac-highlight-panel-controls-summary">Loading...</div>
@@ -384,12 +384,11 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-previous" disabled="true"><span aria-hidden="true">« </span>Previous</button>
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
-                                        <div>
-                                                <button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
-                                                <button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
-                                        </div>
+					<div>
+						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
+						<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
+					</div>
 				</div>
-
 			</div>
 			</div>
 		`;

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -51,6 +51,7 @@ class AccessibilityCheckerHighlight {
 		} );
 
 		this.disableStylesButton = document.querySelector( '#edac-highlight-disable-styles' );
+		this.rescanButton = document.querySelector( '#edac-highlight-rescan' );
 		this.stylesDisabled = false;
 		this.originalCss = [];
 
@@ -95,6 +96,12 @@ class AccessibilityCheckerHighlight {
 				this.disableStyles();
 			}
 		} );
+
+		if ( this.rescanButton ) {
+			this.rescanButton.addEventListener( 'click', () => {
+				this.rescanPage();
+			} );
+		}
 
 		// Open panel if a URL parameter exists
 		if ( this.urlParameter ) {
@@ -377,9 +384,10 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-previous" disabled="true"><span aria-hidden="true">« </span>Previous</button>
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
-					<div>
-						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'text-domain' ) }</button>
-					</div>
+                                        <div>
+                                                <button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'text-domain' ) }</button>
+                                                <button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
+                                        </div>
 				</div>
 
 			</div>
@@ -1205,6 +1213,19 @@ class AccessibilityCheckerHighlight {
 				self.showWait( false );
 				self.showScanError( __( 'Error saving scan results.', 'accessibility-checker' ) );
 			} );
+	}
+
+	/**
+	 * Trigger a full rescan of the current page and reload issues.
+	 */
+	rescanPage() {
+		this.removeHighlightButtons();
+		this._scanAttempted = true;
+		this.kickoffScan();
+		setTimeout( () => {
+			this._scanAttempted = false;
+			this.panelOpen();
+		}, 5000 );
 	}
 
 	/**

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -20,6 +20,7 @@ class AccessibilityCheckerHighlight {
 
 		this.settings = { ...defaultSettings, ...settings };
 		this._scanAttempted = false;
+		this._isRescanning = false;
 
 		this.highlightPanel = this.addHighlightPanel();
 		this.nextButton = document.querySelector( '#edac-highlight-next' );
@@ -385,8 +386,8 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
 					<div>
-						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
 						<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
+						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
 					</div>
 				</div>
 			</div>
@@ -1218,11 +1219,16 @@ class AccessibilityCheckerHighlight {
 	 * Trigger a full rescan of the current page and reload issues.
 	 */
 	rescanPage() {
+		// Prevent multiple concurrent rescans
+		if ( this._isRescanning ) {
+			return;
+		}
+		this._isRescanning = true;
+
 		this.removeHighlightButtons();
-		this._scanAttempted = true;
 		this.kickoffScan();
 		setTimeout( () => {
-			this._scanAttempted = false;
+			this._isRescanning = false;
 			this.panelOpen();
 		}, 5000 );
 	}

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -357,8 +357,6 @@ body {
 			}
 
 			&-buttons {
-				display: grid !important;
-				grid-template-columns: repeat(2, 1fr) !important;
 
 				button {
 					all: unset;


### PR DESCRIPTION
## Summary
- add rescan button markup in frontend highlighter
- wire up button to kickoff the page scan and reload issues

## Testing
- `npm run lint:js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881aabb9ee4832883b59c6c755e9a40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Rescan This Page" button to the accessibility checker panel, allowing users to manually refresh and update detected accessibility issues.
* **Bug Fixes**
  * Improved button layout in the accessibility checker panel by adjusting styles for better alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->