### PR TITLE
Add AI Generate Summary feature

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -236,37 +236,56 @@ const edacScriptVars = edac_script_vars;
 
 					jQuery( '#edac-readability-panel' ).html( responseJSON );
 
-					// Simplified Summary on click
-					jQuery( '.edac-readability-simplified-summary' ).submit(
-						function( event ) {
-							event.preventDefault();
+                                        // Simplified Summary on click
+                                        jQuery( '.edac-readability-simplified-summary' ).submit(
+                                                function ( event ) {
+                                                        event.preventDefault();
 
-							// var postID = wp.data.select("core/editor").getCurrentPostId();
-							const summary = jQuery( '#edac-readability-text' ).val();
+                                                        const summary = jQuery( '#edac-readability-text' ).val();
 
-							jQuery.ajax( {
-								url: ajaxurl,
-								method: 'GET',
-								data: {
-									action: 'edac_update_simplified_summary',
-									post_id: postID,
-									summary,
-									nonce: edacScriptVars.nonce,
-								},
-							} ).done( function( doneResponse ) {
-								if ( true === doneResponse.success ) {
-									const doneResponseJSON = jQuery.parseJSON(
-										doneResponse.data
-									);
+                                                        jQuery.ajax( {
+                                                                url: ajaxurl,
+                                                                method: 'GET',
+                                                                data: {
+                                                                        action: 'edac_update_simplified_summary',
+                                                                        post_id: postID,
+                                                                        summary,
+                                                                        nonce: edacScriptVars.nonce,
+                                                                },
+                                                        } ).done( function ( doneResponse ) {
+                                                                if ( true === doneResponse.success ) {
+                                                                        const doneResponseJSON = jQuery.parseJSON( doneResponse.data );
 
-									refreshSummaryAndReadability();
-								} else {
-									// eslint-disable-next-line no-console
-									console.log( doneResponse );
-								}
-							} );
-						}
-					);
+                                                                        refreshSummaryAndReadability();
+                                                                } else {
+                                                                        // eslint-disable-next-line no-console
+                                                                        console.log( doneResponse );
+                                                                }
+                                                        } );
+                                                }
+                                        );
+
+                                        jQuery( document ).on( 'click', '#edac-ai-generate-summary', function ( event ) {
+                                                event.preventDefault();
+
+                                                jQuery.ajax( {
+                                                        url: ajaxurl,
+                                                        method: 'GET',
+                                                        data: {
+                                                                action: 'edac_ai_generate_summary',
+                                                                post_id: postID,
+                                                                nonce: edacScriptVars.nonce,
+                                                        },
+                                                } ).done( function ( aiResponse ) {
+                                                        if ( true === aiResponse.success ) {
+                                                                const aiText = jQuery.parseJSON( aiResponse.data );
+                                                                jQuery( '#edac-readability-text' ).val( aiText );
+                                                        } else {
+                                                                // eslint-disable-next-line no-console
+                                                                console.log( aiResponse );
+                                                        }
+                                                } );
+                                        } );
 				} else {
 					// eslint-disable-next-line no-console
 					console.log( response );


### PR DESCRIPTION
## Summary
- add AI Generate Summary button to readability meta form
- hook new ajax handler
- implement JS for AI summary generation
- implement PHP endpoint using AI Services

## Testing
- `composer lint`
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_688279fd9ff8832887c9f79c4056eb5b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "AI Generate Summary" button to the readability form, allowing users to automatically generate a simplified summary of a post using AI services.
* **User Interface**
  * Updated the readability form to include the new AI summary generation button for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->