### PR TITLE
Add At a Glance dashboard item

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -10,6 +10,7 @@ namespace EDAC\Admin;
 use EDAC\Admin\SiteHealth\Information;
 use EDAC\Admin\Purge_Post_Data;
 use EDAC\Admin\Post_Save;
+use EDAC\Admin\Dashboard_Glance;
 use EqualizeDigital\AccessibilityChecker\Admin\Upgrade_Promotion;
 use EqualizeDigital\AccessibilityChecker\Admin\Admin_Footer_Text;
 
@@ -58,6 +59,9 @@ class Admin {
 
 		$widgets = new Widgets();
 		$widgets->init_hooks();
+		
+		$dashboard_glance = new Dashboard_Glance();
+		$dashboard_glance->init_hooks();
 
 		$site_health_info = new Information();
 		$site_health_info->init_hooks();

--- a/admin/class-dashboard-glance.php
+++ b/admin/class-dashboard-glance.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Class file for adding Accessibility Checker info to the At a Glance widget.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Admin;
+
+use EDAC\Admin\Helpers;
+use EDAC\Admin\Scans_Stats;
+
+/**
+ * Class that hooks into the At a Glance dashboard widget.
+ */
+class Dashboard_Glance {
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_filter( 'dashboard_glance_items', [ $this, 'add_glance_item' ] );
+	}
+
+	/**
+	 * Adds an accessibility summary item to the At a Glance widget.
+	 *
+	 * @param array $items Existing glance items.
+	 * @return array
+	 */
+	public function add_glance_item( $items ) {
+		if ( ! Helpers::current_user_can_see_widgets_and_notices() ) {
+			return $items;
+		}
+
+		$scans_stats = new Scans_Stats();
+		$summary     = $scans_stats->summary();
+
+		$issues = (int) $summary['distinct_errors'] + (int) $summary['distinct_warnings'];
+		$count  = Helpers::format_number( $issues );
+
+		$text = sprintf(
+			/* translators: %s: number of issues */
+			_n(
+				'Accessibility: %s issue open.',
+				'Accessibility: %s issues open.',
+				$issues,
+				'accessibility-checker'
+			),
+			$count
+		);
+
+		if ( ! ( defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID ) ) {
+			$link  = edac_generate_link_type(
+				[
+					'utm-campaign' => 'glance-widget',
+					'utm-content'  => 'upgrade-to-edacp',
+				],
+				'pro'
+			);
+			$text .= ' <a href="' . esc_url( $link ) . '">' . esc_html__( 'Fix with Accessibility Checker Pro', 'accessibility-checker' ) . '</a>';
+		}
+
+		$items[] = $text;
+		return $items;
+	}
+}


### PR DESCRIPTION
## Summary
- show accessibility issue count in the default At a Glance widget
- register new dashboard glance class in Admin

## Testing
- `composer lint`
- `composer check-cs`
- `composer test` *(fails: WordPress test library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68830b62ce448328bbcaeaa5d6e96d6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a summary of open accessibility issues to the WordPress "At a Glance" dashboard widget, including error and warning counts.
  * Introduced a promotional link for upgrading to the Pro version if applicable.

* **Improvements**
  * Dashboard now provides clearer visibility into accessibility issues directly from the admin overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->