### PR TITLE
Add clear issues button to frontend highlighter

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -1258,6 +1258,16 @@ class AccessibilityCheckerHighlight {
 			return;
 		}
 
+		// Validate required parameters
+		if ( ! edacFrontendHighlighterApp?.edacUrl || ! edacFrontendHighlighterApp?.postID ) {
+			const summary = document.querySelector( '.edac-highlight-panel-controls-summary' );
+			if ( summary ) {
+				summary.textContent = __( 'Error: Missing required parameters.', 'accessibility-checker' );
+				summary.classList.add( 'edac-error' );
+			}
+			return;
+		}
+
 		this.clearIssuesButton.disabled = true;
 		this.clearIssuesButton.textContent = __( 'Clearing...', 'accessibility-checker' );
 		const summary = document.querySelector( '.edac-highlight-panel-controls-summary' );


### PR DESCRIPTION
## Summary
- add clear issues button to highlight panel markup
- wire up button and implement `clearIssues` handler
- support toast messages via `showNotice`

## Testing
- `npm run lint:js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883132332b8832896f298a1ad6bd55f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Clear Issues" button to the accessibility checker panel, allowing logged-in users to clear all saved accessibility issues for the current post.
  * The button provides confirmation prompts, displays progress and error messages, and updates the issue count upon completion.

* **Documentation**
  * Clarified in comments that error messages are displayed in the panel summary area instead of popup notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->