### PR TITLE
Add front-end highlighter issue type filters

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -484,7 +484,8 @@ class AccessibilityCheckerHighlight {
 		}
 
 		const issue = this.issues.find( ( i ) => i.id === id );
-		this.currentButtonIndex = this.issues.findIndex( ( i ) => i.id === id );
+		const listForIndex = this.filteredIssues && this.filteredIssues.length ? this.filteredIssues : this.issues;
+		this.currentButtonIndex = listForIndex.findIndex( ( i ) => i.id === id );
 
 		const tooltip = issue.tooltip;
 		const element = issue.element;
@@ -955,6 +956,9 @@ class AccessibilityCheckerHighlight {
 				// Remove the trailing comma and add "detected."
 				textContent = textContent.slice( 0, -2 ) + ' ' + __( 'detected.', 'accessibility-checker' );
 			}
+		} else {
+			this.nextButton.disabled = true;
+			this.previousButton.disabled = true;
 		}
 
 		div.textContent = textContent;

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -2,6 +2,10 @@
 @use "../../common/sass/variables";
 @use "../../common/sass/helpers";
 
+.edac-hidden {
+       display: none !important;
+}
+
 body {
 	&.edac-app-disable-styles {
 		//   padding: .5rem (46px + 46px ) !important; //make sure button is visible
@@ -59,10 +63,15 @@ body {
 		position: absolute !important;
 		z-index: 2147483646 !important;
 
-		&-error {
-			background: transparent url("../images/highlight-icon-error.svg") center center no-repeat !important;
-			background-size: 40px 40px !important;
-		}
+                &-error {
+                        background: transparent url("../images/highlight-icon-error.svg") center center no-repeat !important;
+                        background-size: 40px 40px !important;
+                }
+
+                &-contrast {
+                        background: transparent url("../images/highlight-icon-error.svg") center center no-repeat !important;
+                        background-size: 40px 40px !important;
+                }
 
 		&-warning {
 			background: transparent url("../images/highlight-icon-warning.svg") center center no-repeat !important;
@@ -104,19 +113,30 @@ body {
 
 		}
 
-		@media screen and (max-width: calc(variables.$extra-small-screen-width)) {
+                @media screen and (max-width: calc(variables.$extra-small-screen-width)) {
 
-			.edac-highlight-panel-controls-buttons {
-				display: flex !important;
-				justify-content: space-around;
+                        .edac-highlight-panel-controls-buttons {
+                                display: flex !important;
+                                justify-content: space-around;
 
 				button {
 					padding: 4px 7px !important;
 					margin-right: 0px !important;
 				}
-			}
+                        }
 
-		}
+                }
+
+                .edac-highlight-panel-filters {
+                        margin: 10px 0 !important;
+
+                        label {
+                                margin-right: 10px !important;
+                                font-size: 12px !important;
+                                display: inline-block !important;
+                        }
+                }
+
 
 		* {
 			all: unset;


### PR DESCRIPTION
## Summary
- add issue type filter checkboxes in front-end highlighter panel
- support filtering of errors, contrast errors, and warnings
- style new filter controls and hide elements via `.edac-hidden`
- update navigation and counts to respect active filters

## Testing
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_6883d86cc41483289dc9f2385cfdd676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filter controls to the accessibility issues panel, allowing users to show or hide issues by category (error, contrast, warning).
  * Issue counts and navigation now reflect the selected filters.
  * Contrast issues are now categorized and counted separately in the summary.

* **Style**
  * Improved visual styling for filter controls and issue buttons, including new contrast icons and better layout for small screens.
  * Added a hidden class for improved UI control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->