### PR TITLE
Fix settings tab input sanitation

### DIFF
--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -41,7 +41,7 @@ if ( is_array( $settings_tab_items ) ) {
 
 // Get the active tab from the $_GET param.
 $default_tab  = null;
-$settings_tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : $default_tab; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification and sanitization not required for tab display.
+$settings_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : $default_tab; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verification not required for tab display.
 $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items, 'slug' ), true ) !== false ) ? $settings_tab : $default_tab;
 ?>
 


### PR DESCRIPTION
## Summary
- unslash `$_GET['tab']` before sanitizing in the settings page

## Testing
- `composer lint`
- `composer check-cs`
- `composer test` *(fails: Could not find wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68856691b908832898e7a1f2b09b57fa