### PR TITLE
Fix aria-hidden span text detection

### DIFF
--- a/src/pageScanner/checks/aria-hidden-valid-usage.js
+++ b/src/pageScanner/checks/aria-hidden-valid-usage.js
@@ -61,10 +61,25 @@ export default {
 
 			// Check for visible text (excluding the aria-hidden element)
 			for ( const child of parentNode.childNodes ) {
-				if ( child !== node &&
-					child.nodeType === Node.TEXT_NODE &&
-					child.textContent.trim() ) {
+				if ( child === node ) {
+					continue;
+				}
+
+				// Direct text node
+				if ( child.nodeType === Node.TEXT_NODE &&
+                                        child.textContent.trim() ) {
 					return true;
+				}
+
+				// Text within an element node
+				if ( child.nodeType === Node.ELEMENT_NODE &&
+                                        ! child.hasAttribute( 'aria-hidden' ) ) {
+					const style = window.getComputedStyle( child );
+					if ( style.display !== 'none' &&
+                                                style.visibility !== 'hidden' &&
+                                                child.textContent.trim() ) {
+						return true;
+					}
 				}
 			}
 		}

--- a/tests/jest/rules/ariaHiddenValid.test.js
+++ b/tests/jest/rules/ariaHiddenValid.test.js
@@ -40,6 +40,11 @@ describe( 'Aria Hidden Validation', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'should pass for button with visible text in span',
+			html: '<button type="button"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect></svg><span>Menu</span></button>',
+			shouldPass: true,
+		},
+		{
 			name: 'should pass for link with aria-label',
 			html: '<a href="/about" aria-label="About Us"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect></svg></a>',
 			shouldPass: true,
@@ -52,6 +57,11 @@ describe( 'Aria Hidden Validation', () => {
 		{
 			name: 'should pass for link with visible text',
 			html: '<a href="/about"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect></svg>About Us</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for link with visible text in span',
+			html: '<a href="/about"><span>About Us</span><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5"></rect></svg></a>',
 			shouldPass: true,
 		},
 		{


### PR DESCRIPTION
## Summary
- treat sibling elements with text as visible content for aria-hidden
- add tests for buttons/links with text in a `<span>`

## Testing
- `npm run lint`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_688569a0d3108328832fb6a466bea42d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility validation to better detect visible text within buttons and links, including cases where text is wrapped inside elements like <span> and not just as direct text nodes.

* **Tests**
  * Added new tests to ensure buttons and links with visible text inside a <span> element are correctly recognized as accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes: https://linear.app/equalize-digital/issue/PRO-195/aria-hidden-warning-not-seeing-adjacent-text