### PR TITLE
Fix duplicate alt detection on repeated images

### DIFF
--- a/src/pageScanner/checks/img-alt-redundant-check.js
+++ b/src/pageScanner/checks/img-alt-redundant-check.js
@@ -67,9 +67,33 @@ export default {
 		// Make sure the alt text map is available and filled.
 		initializeAltTextMap();
 
-		// Check if current alt text appears in multiple images
-		if ( altTextMap.has( alt ) && altTextMap.get( alt ).length > 1 ) {
-			return false;
+		// Check if current alt text appears in multiple images.
+		// If duplicates exist, only flag when those images use a different
+		// source and link destination. Repeated use of the exact same
+		// image or link should not be considered redundant.
+		if ( altTextMap.has( alt ) ) {
+			const matches = altTextMap
+				.get( alt )
+				.filter( ( img ) => img !== node );
+
+			if ( matches.length > 0 ) {
+				const nodeSrc = node.getAttribute( 'src' );
+				const nodeHref = node.closest( 'a' )?.getAttribute( 'href' );
+
+				const problematic = matches.filter( ( img ) => {
+					const src = img.getAttribute( 'src' );
+					const href = img.closest( 'a' )?.getAttribute( 'href' );
+
+					const sameSrc = src === nodeSrc;
+					const sameHref = nodeHref && href && href === nodeHref;
+
+					return ! sameSrc && ! sameHref;
+				} );
+
+				if ( problematic.length > 0 ) {
+					return false;
+				}
+			}
 		}
 
 		// If no redundant text found, pass.

--- a/tests/jest/rules/imgAltRedundant.test.js
+++ b/tests/jest/rules/imgAltRedundant.test.js
@@ -39,6 +39,11 @@ describe( 'Image Alt Redundant Validation', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'should fail when images with duplicate alt text link to different URLs',
+			html: '<a href="/page1"><img src="logo1.svg" alt="Home"></a><a href="/page2"><img src="logo2.svg" alt="Home"></a>',
+			shouldPass: false,
+		},
+		{
 			name: 'should fail when image alt and title are identical',
 			html: '<img src="image.jpg" alt="sample" title="sample">',
 			shouldPass: false,

--- a/tests/jest/rules/imgAltRedundant.test.js
+++ b/tests/jest/rules/imgAltRedundant.test.js
@@ -29,6 +29,16 @@ describe( 'Image Alt Redundant Validation', () => {
 			shouldPass: false,
 		},
 		{
+			name: 'should pass when identical images share the same alt text',
+			html: '<img src="logo.svg" alt="logo"><img src="logo.svg" alt="logo">',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass when images link to the same URL with duplicate alt text',
+			html: '<a href="/home"><img src="logo1.svg" alt="Home"></a><a href="/home"><img src="logo2.svg" alt="Home"></a>',
+			shouldPass: true,
+		},
+		{
 			name: 'should fail when image alt and title are identical',
 			html: '<img src="image.jpg" alt="sample" title="sample">',
 			shouldPass: false,


### PR DESCRIPTION
## Summary
- refine duplicate alt text rule to ignore repeated src or link
- add Jest tests for repeated image src and linked images

## Testing
- `npm run lint:js`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68856b89ba54832886b3df32a663ab58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of redundant alt text for images, reducing false positives when identical images or images linking to the same URL share the same alt text.

* **Tests**
  * Added test cases to ensure that duplicate alt text is allowed for identical images and for images wrapped in links to the same destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes: #987
Fixes: https://linear.app/equalize-digital/issue/PRO-214/duplicate-alt-needs-refinement