### PR TITLE
Add simplified summary Gutenberg block

### DIFF
--- a/blocks/simplified-summary/block.json
+++ b/blocks/simplified-summary/block.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": 2,
+  "name": "accessibility-checker/simplified-summary",
+  "title": "Simplified Summary",
+  "category": "widgets",
+  "icon": "excerpt-view",
+  "description": "Displays the Simplified Summary for the post.",
+  "editorScript": "file:../../build/simplifiedSummaryBlock.bundle.js",
+  "supports": {
+    "html": false
+  }
+}

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -12,6 +12,7 @@ use EDAC\Admin\Meta_Boxes;
 use EDAC\Admin\Orphaned_Issues_Cleanup;
 use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
+use EDAC\Inc\Simplified_Summary_Block;
 
 /**
  * Main plugin functionality class.
@@ -62,8 +63,11 @@ class Plugin {
 		$accessibility_statement = new Accessibility_Statement();
 		$accessibility_statement->init_hooks();
 
-		$simplified_summary = new Simplified_Summary();
-		$simplified_summary->init_hooks();
+				$simplified_summary = new Simplified_Summary();
+				$simplified_summary->init_hooks();
+
+				$simplified_summary_block = new Simplified_Summary_Block();
+				$simplified_summary_block->init_hooks();
 
 		$lazyload_filter = new Lazyload_Filter();
 		$lazyload_filter->init_hooks();

--- a/includes/classes/class-simplified-summary-block.php
+++ b/includes/classes/class-simplified-summary-block.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Simplified Summary Block.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Inc;
+
+/**
+ * Class that registers the Simplified Summary block.
+ */
+class Simplified_Summary_Block {
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_action( 'init', [ $this, 'register_block' ] );
+	}
+
+	/**
+	 * Register the block type.
+	 *
+	 * @return void
+	 */
+	public function register_block() {
+		$block_path = EDAC_PLUGIN_DIR . 'blocks/simplified-summary/block.json';
+
+		if ( ! file_exists( $block_path ) ) {
+			return;
+		}
+
+		wp_register_script(
+			'edac-simplified-summary-block',
+			plugins_url( 'build/simplifiedSummaryBlock.bundle.js', EDAC_PLUGIN_FILE ),
+			[ 'wp-blocks', 'wp-element', 'wp-i18n' ],
+			EDAC_VERSION,
+			false
+		);
+
+		register_block_type(
+			$block_path,
+			[
+				'editor_script'   => 'edac-simplified-summary-block',
+				'render_callback' => [ $this, 'render_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Render callback for the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 *
+	 * @return string
+	 */
+	public function render_callback( $attributes, $content, $block ) {
+		$post_id = $block->context['postId'] ?? get_the_ID();
+		$summary = new Simplified_Summary();
+		return $summary->simplified_summary_markup( $post_id );
+	}
+}

--- a/src/blocks/simplified-summary/index.js
+++ b/src/blocks/simplified-summary/index.js
@@ -1,0 +1,16 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType( 'accessibility-checker/simplified-summary', {
+	title: __( 'Simplified Summary', 'accessibility-checker' ),
+	icon: 'excerpt-view',
+	category: 'widgets',
+	description: __( 'Displays the Simplified Summary for the post.', 'accessibility-checker' ),
+	supports: {
+		html: false,
+	},
+	edit: () => {
+		return wp.element.createElement( 'p', null, __( 'Simplified Summary will display on the frontend.', 'accessibility-checker' ) );
+	},
+	save: () => null,
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,9 @@ module.exports = {
 			'./src/emailOptIn/index.js',
 			'./src/emailOptIn/sass/email-opt-in.scss',
 		],
+		simplifiedSummaryBlock: [
+			'./src/blocks/simplified-summary/index.js',
+		],
 		frontendFixes: [
 			'./src/frontendFixes/index.js',
 		],
@@ -102,5 +105,7 @@ module.exports = {
 	externals: {
 		// Exclude WordPress core scripts and styles from the build.
 		'@wordpress/i18n': [ 'wp', 'i18n' ],
+		'@wordpress/blocks': [ 'wp', 'blocks' ],
+		'@wordpress/element': [ 'wp', 'element' ],
 	},
 };


### PR DESCRIPTION
## Summary
- introduce Simplified Summary block metadata and JS
- load new block via Simplified_Summary_Block class
- register block from plugin init
- build the new block with webpack

## Testing
- `npm run lint`
- `npm run test:php` *(fails: docker not found)*
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_688a504dfc60832894c593023b36a9ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Simplified Summary" block for WordPress, allowing users to display a simplified summary of a post within the block editor.
  * The block is available under the "widgets" category and is dynamically rendered on the frontend.
  * Added support for localization and improved integration with the block editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->