### PR TITLE
Add onboarding wizard

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -100,6 +100,17 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/deactivation.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/helper-functions.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/options-page.php';
 
+// Redirect to onboarding wizard on first activation.
+add_action( 'admin_init', function () {
+       if ( get_option( 'edac_redirect_onboarding' ) ) {
+               delete_option( 'edac_redirect_onboarding' );
+               if ( ! isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- simple redirect.
+                       wp_safe_redirect( admin_url( 'admin.php?page=accessibility_checker_onboarding' ) );
+                       exit;
+               }
+       }
+} );
+
 /**
  * Filters and Actions
  */

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -12,6 +12,7 @@ use EDAC\Admin\Purge_Post_Data;
 use EDAC\Admin\Post_Save;
 use EqualizeDigital\AccessibilityChecker\Admin\Upgrade_Promotion;
 use EqualizeDigital\AccessibilityChecker\Admin\Admin_Footer_Text;
+use EDAC\Admin\Onboarding_Wizard;
 
 /**
  * Admin handling class.
@@ -68,8 +69,11 @@ class Admin {
 		$plugin_row_meta = new Plugin_Row_Meta();
 		$plugin_row_meta->init_hooks();
 		
-		$admin_footer_text = new Admin_Footer_Text();
-		$admin_footer_text->init();
+                $admin_footer_text = new Admin_Footer_Text();
+                $admin_footer_text->init();
+
+               $onboarding = new Onboarding_Wizard();
+               $onboarding->init_hooks();
 
 		$this->init_ajax();
 

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -53,13 +53,14 @@ class Enqueue_Admin {
 		$page              = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
 		$enabled_pages     = apply_filters(
 			'edac_filter_admin_scripts_slugs',
-			[
-				'accessibility_checker',
-				'accessibility_checker_settings',
-				'accessibility_checker_issues',
-				'accessibility_checker_ignored',
-			]
-		);
+                        [
+                                'accessibility_checker',
+                                'accessibility_checker_settings',
+                                'accessibility_checker_issues',
+                                'accessibility_checker_ignored',
+                                'accessibility_checker_onboarding',
+                        ]
+                );
 
 		if (
 			(

--- a/admin/class-onboarding-wizard.php
+++ b/admin/class-onboarding-wizard.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class for the onboarding wizard page.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Admin;
+
+/**
+ * Handles the onboarding wizard admin page.
+ */
+class Onboarding_Wizard {
+
+        /**
+         * Register hooks.
+         *
+         * @return void
+         */
+        public function init_hooks() {
+                add_action( 'admin_menu', [ $this, 'add_menu' ] );
+        }
+
+        /**
+         * Add submenu page for onboarding wizard.
+         *
+         * @return void
+         */
+        public function add_menu() {
+                add_submenu_page(
+                        'accessibility_checker',
+                        __( 'Onboarding Wizard', 'accessibility-checker' ),
+                        __( 'Onboarding Wizard', 'accessibility-checker' ),
+                        'read',
+                        'accessibility_checker_onboarding',
+                        [ $this, 'render_page' ]
+                );
+        }
+
+        /**
+         * Render the onboarding wizard page.
+         *
+         * @return void
+         */
+        public function render_page() {
+                include_once plugin_dir_path( __DIR__ ) . 'partials/onboarding-wizard.php';
+        }
+}

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -15,8 +15,9 @@ use EDAC\Admin\Accessibility_Statement;
 function edac_activation() {
 	// set options.
 	update_option( 'edac_activation_date', gmdate( 'Y-m-d H:i:s' ) );
-	update_option( 'edac_post_types', [ 'post', 'page' ] );
-	update_option( 'edac_simplified_summary_position', 'after' );
+       update_option( 'edac_post_types', [ 'post', 'page' ] );
+       update_option( 'edac_simplified_summary_position', 'after' );
+       update_option( 'edac_redirect_onboarding', true );
 
 	// Sanitize the input.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required.

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -38,14 +38,23 @@ function edac_add_options_page() {
 		return;
 	}
 
-	add_menu_page(
-		__( 'Welcome to Accessibility Checker', 'accessibility-checker' ),
-		__( 'Accessibility Checker', 'accessibility-checker' ),
-		'read',
-		'accessibility_checker',
-		'edac_display_welcome_page',
-		'dashicons-universal-access-alt'
-	);
+        add_menu_page(
+                __( 'Welcome to Accessibility Checker', 'accessibility-checker' ),
+                __( 'Accessibility Checker', 'accessibility-checker' ),
+                'read',
+                'accessibility_checker',
+                'edac_display_welcome_page',
+                'dashicons-universal-access-alt'
+        );
+
+       add_submenu_page(
+               'accessibility_checker',
+               __( 'Onboarding Wizard', 'accessibility-checker' ),
+               __( 'Onboarding Wizard', 'accessibility-checker' ),
+               'read',
+               'accessibility_checker_onboarding',
+               'edac_display_onboarding_wizard'
+       );
 
 	if ( ! edac_user_can_ignore() ) {
 		return;
@@ -85,7 +94,14 @@ function edac_display_welcome_page() {
  * Render the options page for plugin
  */
 function edac_display_options_page() {
-	include_once plugin_dir_path( __DIR__ ) . 'partials/settings-page.php';
+        include_once plugin_dir_path( __DIR__ ) . 'partials/settings-page.php';
+}
+
+/**
+ * Render the onboarding wizard page.
+ */
+function edac_display_onboarding_wizard() {
+       include_once plugin_dir_path( __DIR__ ) . 'partials/onboarding-wizard.php';
 }
 
 /**

--- a/partials/onboarding-wizard.php
+++ b/partials/onboarding-wizard.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Onboarding wizard page.
+ *
+ * @package Accessibility_Checker
+ */
+
+?>
+<div class="wrap edac-onboarding">
+        <h1><?php esc_html_e( 'Accessibility Checker Onboarding', 'accessibility-checker' ); ?></h1>
+        <p><?php esc_html_e( 'Welcome! This short guide will help you configure the plugin.', 'accessibility-checker' ); ?></p>
+        <ol class="edac-onboarding-steps">
+                <li>
+                        <?php
+                        printf(
+                                wp_kses(
+                                        /* translators: %s: settings page URL */
+                                        __( 'Visit the <a href="%s">Settings Page</a> to choose which post types should be scanned.', 'accessibility-checker' ),
+                                        [ 'a' => [ 'href' => [] ] ]
+                                ),
+                                esc_url( admin_url( 'admin.php?page=accessibility_checker_settings' ) )
+                        );
+                        ?>
+                </li>
+                <li><?php esc_html_e( 'After saving your settings, start a scan from the Welcome page.', 'accessibility-checker' ); ?></li>
+                <li>
+                        <?php
+                        printf(
+                                wp_kses(
+                                        /* translators: %s: documentation URL */
+                                        __( 'Need help? Review our <a href="%s" target="_blank" rel="noopener noreferrer">documentation</a>.', 'accessibility-checker' ),
+                                        [ 'a' => [ 'href' => [], 'target' => [], 'rel' => [] ] ]
+                                ),
+                                esc_url( 'https://equalizedigital.com/accessibility-checker/documentation/' )
+                        );
+                        ?>
+                </li>
+        </ol>
+</div>


### PR DESCRIPTION
## Summary
- add onboarding wizard class and page
- register onboarding page in admin menu
- redirect new installs to onboarding page
- load scripts for onboarding page
- schedule redirect on activation

## Testing
- `npm run test:jest`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_688c5ddd33d08328a949a499d8ef1a64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an onboarding wizard page in the WordPress admin to guide users through initial plugin setup.
  * Users are automatically redirected to the onboarding wizard upon first activation of the plugin.
  * Added a new submenu item, "Onboarding Wizard," under the Accessibility Checker menu for easy access.
* **Enhancements**
  * Updated admin scripts to support the new onboarding wizard page.
* **Documentation**
  * The onboarding wizard page includes step-by-step instructions and links to further documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->