### PR TITLE
Hide rescan button when user not logged in

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -396,7 +396,7 @@ class AccessibilityCheckerHighlight {
                                 <button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="Close">×</button>
                                 <div class="edac-highlight-panel-controls-title">Accessibility Checker</div>
                                 <div class="edac-highlight-panel-controls-summary">Loading...</div>
-                                <div class="edac-highlight-panel-controls-buttons">
+                                <div class="edac-highlight-panel-controls-buttons ${ ! isLoggedInUser ? ' single_button' : '' }">
                                         <div>
                                                 <button id="edac-highlight-previous" disabled="true"><span aria-hidden="true">« </span>Previous</button>
                                                 <button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -373,11 +373,13 @@ class AccessibilityCheckerHighlight {
 	 */
 	addHighlightPanel() {
 		const widgetPosition = edacFrontendHighlighterApp?.widgetPosition || 'right';
-		const clearButtonMarkup = edacFrontendHighlighterApp && ( edacFrontendHighlighterApp.loggedIn === true || edacFrontendHighlighterApp.loggedIn === 'true' )
+
+		const isLoggedInUser = edacFrontendHighlighterApp && edacFrontendHighlighterApp?.loggedIn;
+		const clearButtonMarkup = isLoggedInUser
 			? `<button id="edac-highlight-clear-issues" class="edac-highlight-clear-issues">${ __( 'Clear Issues', 'accessibility-checker' ) }</button>`
 			: '';
 
-		const rescanButton = edacFrontendHighlighterApp && ( edacFrontendHighlighterApp.loggedIn === true || edacFrontendHighlighterApp.loggedIn === 'true' )
+		const rescanButton = isLoggedInUser
 			? `<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>`
 			: '';
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -367,7 +367,7 @@ class AccessibilityCheckerHighlight {
 	addHighlightPanel() {
 		const widgetPosition = edacFrontendHighlighterApp?.widgetPosition || 'right';
 
-		const rescanButton = edacFrontendHighlighterApp?.loggedIn
+		const rescanButton = edacFrontendHighlighterApp && ( edacFrontendHighlighterApp.loggedIn === true || edacFrontendHighlighterApp.loggedIn === 'true' )
 			? `<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>`
 			: '';
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -373,7 +373,7 @@ class AccessibilityCheckerHighlight {
 	 */
 	addHighlightPanel() {
 		const widgetPosition = edacFrontendHighlighterApp?.widgetPosition || 'right';
-		const clearButtonMarkup = edacFrontendHighlighterApp.loggedIn
+		const clearButtonMarkup = edacFrontendHighlighterApp && ( edacFrontendHighlighterApp.loggedIn === true || edacFrontendHighlighterApp.loggedIn === 'true' )
 			? `<button id="edac-highlight-clear-issues" class="edac-highlight-clear-issues">${ __( 'Clear Issues', 'accessibility-checker' ) }</button>`
 			: '';
 
@@ -400,7 +400,7 @@ class AccessibilityCheckerHighlight {
                                                 <button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
                                         </div>
                                         <div>
-                                                <button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
+                                                ${ rescanButton }
                                                 ${ clearButtonMarkup }
                                                 <button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
                                         </div>

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -365,9 +365,9 @@ class AccessibilityCheckerHighlight {
 	 * This function adds a new div element to the DOM, which contains the accessibility checker panel.
 	 */
 	addHighlightPanel() {
-		const widgetPosition = edacFrontendHighlighterApp.widgetPosition || 'right';
+		const widgetPosition = edacFrontendHighlighterApp?.widgetPosition || 'right';
 
-		const rescanButton = edacFrontendHighlighterApp.loggedIn
+		const rescanButton = edacFrontendHighlighterApp?.loggedIn
 			? `<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>`
 			: '';
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -367,6 +367,10 @@ class AccessibilityCheckerHighlight {
 	addHighlightPanel() {
 		const widgetPosition = edacFrontendHighlighterApp.widgetPosition || 'right';
 
+		const rescanButton = edacFrontendHighlighterApp.loggedIn
+			? `<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>`
+			: '';
+
 		const newElement = `
 			<div id="edac-highlight-panel" class="edac-highlight-panel edac-highlight-panel--${ widgetPosition }">
 				<button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="Accessibility Checker Tools"></button>
@@ -386,7 +390,7 @@ class AccessibilityCheckerHighlight {
 						<button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />
 					</div>
 					<div>
-						<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>
+						${ rescanButton }
 						<button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }">${ __( 'Disable Styles', 'accessibility-checker' ) }</button>
 					</div>
 				</div>

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -358,6 +358,11 @@ body {
 
 			&-buttons {
 
+				&.single_button {
+					display: grid !important;
+					grid-template-columns: repeat(2, 1fr) !important;
+				}
+
 				button {
 					all: unset;
 					text-decoration: none !important;


### PR DESCRIPTION
## Summary
- Only render the Rescan This Page button in the frontend highlighter when the visitor is logged in

## Testing
- `npm run lint:js`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68912a108ff483289286c04dbefda366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Rescan This Page" button in the accessibility checker panel now appears only for logged-in users.
  * The "Clear Issues" button visibility has been refined to show only for logged-in users.
* **Style**
  * Updated button layout in the accessibility checker panel for users who are not logged in, improving visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->