### PR TITLE
feat: generalize scheduled cleanup system

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -97,6 +97,7 @@ if ( class_exists( 'EDAC\Inc\Plugin' ) ) {
 require_once plugin_dir_path( __FILE__ ) . 'includes/deprecated/deprecated.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/activation.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/deactivation.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/upgrade.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/helper-functions.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/options-page.php';
 

--- a/admin/class-orphaned-issues-cleanup.php
+++ b/admin/class-orphaned-issues-cleanup.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+		exit; // Exit if accessed directly.
 }
 
 /**
@@ -18,64 +18,29 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Orphaned_Issues_Cleanup {
 
-	/**
-	 * Cron event name.
-	 *
-	 * @var string
-	 */
-	const EVENT = 'edac_cleanup_orphaned_issues';
+		/**
+		 * Max number of posts to cleanup per run.
+		 *
+		 * @var int
+		 */
+		const BATCH_LIMIT = 50;
 
-	/**
-	 * Max number of posts to cleanup per run.
-	 *
-	 * @var int
-	 */
-	const BATCH_LIMIT = 50;
-
-	/**
-	 * Batch size for cleanup (overrides BATCH_LIMIT if set).
-	 *
-	 * @var int|null
-	 */
+		/**
+		 * Batch size for cleanup (overrides BATCH_LIMIT if set).
+		 *
+		 * @var int|null
+		 */
 	private ?int $batch_size = null;
 
-	/**
-	 * Register hooks.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @return void
-	 */
+		/**
+		 * Register hooks.
+		 *
+		 * @since 1.29.0
+		 *
+		 * @return void
+		 */
 	public function init_hooks() {
-		self::schedule_event();
-		add_action( self::EVENT, [ $this, 'run_cleanup' ] );
-	}
-
-	/**
-	 * Schedule the cleanup event.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @return void
-	 */
-	public static function schedule_event() {
-		if ( ! wp_next_scheduled( self::EVENT ) ) {
-			wp_schedule_event( time(), 'daily', self::EVENT );
-		}
-	}
-
-	/**
-	 * Unschedule the cleanup event.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @return void
-	 */
-	public static function unschedule_event() {
-		$timestamp = wp_next_scheduled( self::EVENT );
-		if ( $timestamp ) {
-			wp_unschedule_event( $timestamp, self::EVENT );
-		}
+			add_action( Scheduled_Tasks::EVENT, [ $this, 'run_cleanup' ] );
 	}
 
 	/**

--- a/admin/class-scheduled-tasks.php
+++ b/admin/class-scheduled-tasks.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Handle scheduled tasks for Accessibility Checker.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+		exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Scheduled_Tasks
+ *
+ * Provides a generic system for scheduling recurring cleanup or processing tasks.
+ */
+class Scheduled_Tasks {
+
+		/**
+		 * Cron event name used to trigger scheduled tasks.
+		 *
+		 * @var string
+		 */
+		const EVENT = 'edac_run_scheduled_tasks';
+
+		/**
+		 * Register hooks.
+		 *
+		 * @return void
+		 */
+	public function init_hooks(): void {
+			self::schedule_event();
+	}
+
+		/**
+		 * Schedule the recurring event if it is not already scheduled.
+		 *
+		 * @return void
+		 */
+	public static function schedule_event(): void {
+		if ( ! wp_next_scheduled( self::EVENT ) ) {
+				wp_schedule_event( time(), 'daily', self::EVENT );
+		}
+	}
+
+		/**
+		 * Unschedule the recurring event.
+		 *
+		 * @return void
+		 */
+	public static function unschedule_event(): void {
+			$timestamp = wp_next_scheduled( self::EVENT );
+		if ( $timestamp ) {
+				wp_unschedule_event( $timestamp, self::EVENT );
+		}
+	}
+}

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -17,6 +17,7 @@ function edac_activation() {
 	update_option( 'edac_activation_date', gmdate( 'Y-m-d H:i:s' ) );
 	update_option( 'edac_post_types', [ 'post', 'page' ] );
 	update_option( 'edac_simplified_summary_position', 'after' );
+	update_option( 'edac_version', EDAC_VERSION );
 
 	// Sanitize the input.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required.

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -10,6 +10,7 @@ namespace EDAC\Inc;
 use EDAC\Admin\Admin;
 use EDAC\Admin\Meta_Boxes;
 use EDAC\Admin\Orphaned_Issues_Cleanup;
+use EDAC\Admin\Scheduled_Tasks;
 use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
@@ -37,6 +38,9 @@ class Plugin {
 		// Initialize the admin toolbar.
 		$admin_toolbar = new Admin_Toolbar();
 		$admin_toolbar->init();
+
+		$scheduled_tasks = new Scheduled_Tasks();
+		$scheduled_tasks->init_hooks();
 
 		$cleanup = new Orphaned_Issues_Cleanup();
 		$cleanup->init_hooks();

--- a/includes/deactivation.php
+++ b/includes/deactivation.php
@@ -5,7 +5,7 @@
  * @package Accessibility_Checker
  */
 
-use EDAC\Admin\Orphaned_Issues_Cleanup;
+use EDAC\Admin\Scheduled_Tasks;
 
 /**
  * Deactivation
@@ -15,6 +15,6 @@ use EDAC\Admin\Orphaned_Issues_Cleanup;
 function edac_deactivation() {
 	delete_option( 'edac_activation_date' );
 
-	// Unschedule cleanup of orphaned issues.
-	Orphaned_Issues_Cleanup::unschedule_event();
+		// Unschedule scheduled tasks.
+		Scheduled_Tasks::unschedule_event();
 }

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Upgrade routines for Accessibility Checker.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Run upgrade routines when plugin version changes.
+ *
+ * @return void
+ */
+function edac_upgrade() {
+	$installed_version = get_option( 'edac_version', '0' );
+
+	if ( version_compare( $installed_version, EDAC_VERSION, '<' ) ) {
+		// Unschedule legacy orphaned issues cleanup event.
+		$timestamp = wp_next_scheduled( 'edac_cleanup_orphaned_issues' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'edac_cleanup_orphaned_issues' );
+		}
+
+		update_option( 'edac_version', EDAC_VERSION );
+	}
+}
+add_action( 'plugins_loaded', 'edac_upgrade' );


### PR DESCRIPTION
## Summary
- create Scheduled_Tasks class to provide a generic daily cron hook
- run orphaned issue cleanup via the shared scheduler
- unschedule the shared cleanup event on plugin deactivation
- add an upgrade routine to migrate old cron events and record plugin version

## Testing
- `composer lint`
- `composer check-cs`
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php; WordPress test suite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68962580aad08328906052cee918b394

Fixes: https://linear.app/equalize-digital/issue/PRO-229/make-the-cleanup-orphaned-issues-system-more-generic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new upgrade routine that automatically manages plugin version updates and cleans up legacy scheduled tasks.
  * Added centralized management for scheduled tasks, improving reliability of recurring plugin operations.

* **Improvements**
  * Enhanced plugin activation to store the current plugin version.
  * Streamlined deactivation and cleanup processes for scheduled events.

* **Maintenance**
  * Refactored internal scheduling logic for better maintainability and future flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->