### PR TITLE
Sanitize page parameter before admin enqueues

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -50,7 +50,7 @@ class Enqueue_Admin {
 		global $pagenow;
 		$post_types        = get_option( 'edac_post_types' );
 		$current_post_type = get_post_type();
-		$page              = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
+		$page              = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
 		$enabled_pages     = apply_filters(
 			'edac_filter_admin_scripts_slugs',
 			[
@@ -147,7 +147,7 @@ class Enqueue_Admin {
 	 */
 	public static function maybe_enqueue_email_opt_in_script() {
 
-		$page = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
+		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
 		if ( 'accessibility_checker' !== $page ) {
 			return;
 		}

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -50,7 +50,7 @@ class Enqueue_Admin {
 		global $pagenow;
 		$post_types        = get_option( 'edac_post_types' );
 		$current_post_type = get_post_type();
-		$page              = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
+		$page              = self::get_current_page_slug();
 		$enabled_pages     = apply_filters(
 			'edac_filter_admin_scripts_slugs',
 			[
@@ -147,7 +147,7 @@ class Enqueue_Admin {
 	 */
 	public static function maybe_enqueue_email_opt_in_script() {
 
-		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
+		$page = self::get_current_page_slug();
 		if ( 'accessibility_checker' !== $page ) {
 			return;
 		}
@@ -159,5 +159,15 @@ class Enqueue_Admin {
 
 		$email_opt_in = new Email_Opt_In();
 		$email_opt_in->enqueue_scripts();
+	}
+
+	/**
+	 * Gets the current admin page slug.
+	 *
+	 * @since 1.31.0
+	 * @return string|null The current page slug or null if not set.
+	 */
+	private static function get_current_page_slug(): ?string {
+		return isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
 	}
 }


### PR DESCRIPTION
## Summary
- unslash `$_GET['page']` before sanitizing in admin enqueue checks
- unslash `$_GET['page']` before sanitizing for welcome page opt-in

## Testing
- `composer lint`
- `composer check-cs`
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_689a227d433c83289f257d3eef6c15da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened admin request handling to better sanitize page parameters, reducing risk from malformed inputs.
* **Bug Fixes**
  * Improved reliability when navigating admin screens by more consistently processing special characters in query parameters.
* **Chores**
  * Internal sanitization flow aligned with WordPress best practices; no changes to behavior, settings, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->