### PR TITLE
Unslash edac nonce before sanitizing

### DIFF
--- a/includes/classes/class-lazyload-filter.php
+++ b/includes/classes/class-lazyload-filter.php
@@ -31,7 +31,7 @@ class Lazyload_Filter {
 	public function perfmatters( $lazyload ) {
 		if (
 			! isset( $_GET['edac_nonce'] ) 
-			|| ! wp_verify_nonce( sanitize_text_field( $_GET['edac_nonce'] ), 'edac_highlight' ) 
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['edac_nonce'] ) ), 'edac_highlight' )
 		) {
 			return $lazyload;
 		}


### PR DESCRIPTION
## Summary
- unslash `$_GET['edac_nonce']` prior to sanitizing before nonce verification

## Testing
- `composer lint`
- `composer check-cs`
- `composer test` *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_689a225ab2b88328a83f39bf20fd1b41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved nonce verification by making input sanitization more robust, reducing false negatives caused by escaped request values. This enhances reliability of lazyload behavior across different server configurations and prevents intermittent issues where lazyload might not respond as expected. No UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->