### PR TITLE
refactor: remove unused input sanitization and redirect logic from ac…

### DIFF
--- a/includes/activation.php
+++ b/includes/activation.php
@@ -18,16 +18,5 @@ function edac_activation() {
 	update_option( 'edac_post_types', [ 'post', 'page' ] );
 	update_option( 'edac_simplified_summary_position', 'after' );
 
-	// Sanitize the input.
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required.
-	$action = isset( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
-	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is not required.
-	$checked = isset( $_POST['checked'] ) ? array_map( 'sanitize_text_field', $_POST['checked'] ) : [];
-
-	// Redirect: Don't do redirects when multiple plugins are bulk activated.
-	if ( 'activate-selected' === $action && count( $checked ) > 1 ) {
-		return;
-	}
-
 	Accessibility_Statement::add_page();
 }


### PR DESCRIPTION
This pull request simplifies the plugin activation logic by removing unnecessary input sanitization and redirect handling code from the `edac_activation` function. The main change is the cleanup of code related to bulk plugin activation, making the function more straightforward.

Activation logic simplification:

* Removed input sanitization for `action` and `checked` parameters, as well as related comments and `phpcs` ignore directives, from the `edac_activation` function in `includes/activation.php`.
* Eliminated the conditional redirect logic that prevented redirects during bulk plugin activation, further streamlining the activation process.

Original redirect function was removed some time ago.
<img width="1090" height="606" alt="Screenshot 2025-08-11 at 9 06 34 PM" src="https://github.com/user-attachments/assets/586b3237-5c73-4194-8baf-3bfbf21af2d4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the Accessibility Statement page is consistently created on plugin activation, including during bulk activations. Previously, the page might not be generated in some scenarios.
  * Improves reliability of initial setup without altering existing settings.
  * Existing defaults remain unchanged (e.g., activation date and content placement preferences).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->