### PR TITLE
Be more explicit with who can save and clear issues for a given post

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.30.0
+ * Version:           1.30.1
  * Requires PHP:      7.4
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
@@ -36,7 +36,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.30.0' );
+	define( 'EDAC_VERSION', '1.30.1' );
 }
 
 // Current database version.
@@ -122,7 +122,7 @@ function edac_register_rules() {
 
 	// Use the new class-based rules system.
 	$default_rules = \EqualizeDigital\AccessibilityChecker\Rules\RuleRegistry::load_rules();
-	
+
 	/**
 	 * Filter the default rules.
 	 *

--- a/admin/class-welcome-page.php
+++ b/admin/class-welcome-page.php
@@ -40,9 +40,11 @@ class Welcome_Page {
 						</div>
 
 						<p class="edac-cols-right">
-							<button class="button" id="edac_clear_cached_stats">
-								<?php esc_html_e( 'Update Counts', 'accessibility-checker' ); ?>
-							</button>
+							<?php if ( current_user_can( 'publish_posts' ) ) : ?>
+								<button class="button" id="edac_clear_cached_stats">
+									<?php esc_html_e( 'Update Counts', 'accessibility-checker' ); ?>
+								</button>
+							<?php endif; ?>
 
 							<a class="edac-ml-1 button" href="<?php echo esc_url( admin_url( 'admin.php?page=accessibility_checker_full_site_scan' ) ); ?>">
 								<?php esc_html_e( 'Start New Scan', 'accessibility-checker' ); ?>

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -101,6 +101,7 @@ class Enqueue_Frontend {
 					'nonce'            => wp_create_nonce( 'ajax-nonce' ),
 					'restNonce'        => wp_create_nonce( 'wp_rest' ),
 					'userCanFix'       => current_user_can( apply_filters( 'edac_filter_settings_capability', 'manage_options' ) ),
+					'userCanEdit'      => current_user_can( 'edit_post', $post_id ),
 					'edacUrl'          => esc_url_raw( get_site_url() ),
 					'ajaxurl'          => admin_url( 'admin-ajax.php' ),
 					'loggedIn'         => is_user_logged_in(),

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -138,7 +138,7 @@ class REST_Api {
 						'methods'             => 'GET',
 						'callback'            => [ $this, 'get_scans_stats_by_post_type' ],
 						'permission_callback' => function () {
-							return current_user_can( 'read' ); // able to access the admin dashboard.
+							return current_user_can( 'edit_posts' );
 						},
 					]
 				);
@@ -155,7 +155,7 @@ class REST_Api {
 						'methods'             => 'GET',
 						'callback'            => [ $this, 'get_scans_stats_by_post_types' ],
 						'permission_callback' => function () {
-							return current_user_can( 'read' ); // able to access the admin dashboard.
+							return current_user_can( 'edit_posts' );
 						},
 					]
 				);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -81,7 +81,8 @@ class REST_Api {
 							'id' => [
 								'required'          => true,
 								'validate_callback' => function ( $param ) {
-									return is_numeric( $param ); },
+									return is_numeric( $param );
+								},
 								'sanitize_callback' => 'absint',
 							],
 						],
@@ -174,7 +175,8 @@ class REST_Api {
 							'id' => [
 								'required'          => true,
 								'validate_callback' => function ( $param ) {
-									return is_numeric( $param ); },
+									return is_numeric( $param );
+								},
 								'sanitize_callback' => 'absint',
 							],
 						],

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -104,7 +104,7 @@ class REST_Api {
 						'methods'             => 'GET',
 						'callback'            => [ $this, 'get_scans_stats' ],
 						'permission_callback' => function () {
-							return current_user_can( 'read' ); // able to access the admin dashboard.
+							return current_user_can( 'edit_posts' ); // able to access the admin dashboard.
 						},
 					]
 				);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -210,14 +210,15 @@ class REST_Api {
 	 *
 	 * This is a permission callback to replace several places where we check if the user can edit a post.
 	 *
-	 * @param int $request The request object passed from the REST call. This should contain the 'id' of the post to check permissions for.
+	 * @since 1.31.0
 	 *
-	 * @return bool
+	 * @param \WP_REST_Request $request The request object passed from the REST call. This should contain the 'id' of the post to check permissions for.
+	 *
+	 * @return bool|\WP_Error
 	 */
 	public function user_can_edit_passed_post_id( $request ) {
-		// Check if the user has permission to edit posts.
 		if ( ! isset( $request['id'] ) ) {
-			return new \WP_REST_Response( [ 'message' => 'A required parameter is missing.' ], 400 );
+			return new \WP_Error( 'rest_post_invalid_id', __( 'A required parameter is missing.', 'accessibility-checker' ), [ 'status' => 400 ] );
 		}
 		$post_id = (int) $request['id'];
 		return current_user_can( 'edit_post', $post_id ); // able to edit the post.
@@ -226,7 +227,7 @@ class REST_Api {
 	/**
 	 * REST handler to clear issues results for a given post ID.
 	 *
-	 * @param WP_REST_Request $request  The request passed from the REST call.
+	 * @param \WP_REST_Request $request  The request passed from the REST call.
 	 *
 	 * @return \WP_REST_Response
 	 */

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -104,7 +104,7 @@ class REST_Api {
 						'methods'             => 'GET',
 						'callback'            => [ $this, 'get_scans_stats' ],
 						'permission_callback' => function () {
-							return current_user_can( 'edit_posts' ); // able to access the admin dashboard.
+							return current_user_can( 'edit_posts' );
 						},
 					]
 				);
@@ -121,7 +121,7 @@ class REST_Api {
 						'methods'             => 'POST',
 						'callback'            => [ $this, 'clear_cached_scans_stats' ],
 						'permission_callback' => function () {
-							return current_user_can( 'read' ); // able to access the admin dashboard.
+							return current_user_can( 'edit_posts' );
 						},
 					]
 				);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -121,7 +121,7 @@ class REST_Api {
 						'methods'             => 'POST',
 						'callback'            => [ $this, 'clear_cached_scans_stats' ],
 						'permission_callback' => function () {
-							return current_user_can( 'edit_posts' );
+							return current_user_can( 'publish_posts' );
 						},
 					]
 				);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -212,7 +212,7 @@ class REST_Api {
 	 *
 	 * This is a permission callback to replace several places where we check if the user can edit a post.
 	 *
-	 * @since 1.31.0
+	 * @since 1.30.1
 	 *
 	 * @param \WP_REST_Request $request The request object passed from the REST call. This should contain the 'id' of the post to check permissions for.
 	 *

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -204,6 +204,24 @@ class REST_Api {
 	}
 
 	/**
+	 * Check if the user can edit a post.
+	 *
+	 * This is a permission callback to replace several places where we check if the user can edit a post.
+	 *
+	 * @param int $request The request object passed from the REST call. This should contain the 'id' of the post to check permissions for.
+	 *
+	 * @return bool
+	 */
+	public function user_can_edit_passed_post_id( $request ) {
+		// Check if the user has permission to edit posts.
+		if ( ! isset( $request['id'] ) ) {
+			return new \WP_REST_Response( [ 'message' => 'A required parameter is missing.' ], 400 );
+		}
+		$post_id = (int) $request['id'];
+		return current_user_can( 'edit_post', $post_id ); // able to edit the post.
+	}
+
+	/**
 	 * REST handler to clear issues results for a given post ID.
 	 *
 	 * @param WP_REST_Request $request  The request passed from the REST call.

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -84,8 +84,8 @@ class REST_Api {
 								},
 							],
 						],
-						'permission_callback' => function () {
-							return current_user_can( 'edit_posts' );
+						'permission_callback' => function ( $request ) {
+							return $this->user_can_edit_passed_post_id( $request );
 						},
 					]
 				);
@@ -176,8 +176,8 @@ class REST_Api {
 								},
 							],
 						],
-						'permission_callback' => function () {
-							return current_user_can( 'edit_posts' );
+						'permission_callback' => function ( $request ) {
+							return $this->user_can_edit_passed_post_id( $request );
 						},
 					]
 				);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -79,9 +79,10 @@ class REST_Api {
 						'callback'            => [ $this, 'set_post_scan_results' ],
 						'args'                => [
 							'id' => [
+								'required'          => true,
 								'validate_callback' => function ( $param ) {
-									return is_numeric( $param );
-								},
+									return is_numeric( $param ); },
+								'sanitize_callback' => 'absint',
 							],
 						],
 						'permission_callback' => function ( $request ) {
@@ -171,9 +172,10 @@ class REST_Api {
 						'callback'            => [ $this, 'clear_issues_for_post' ],
 						'args'                => [
 							'id' => [
+								'required'          => true,
 								'validate_callback' => function ( $param ) {
-									return is_numeric( $param );
-								},
+									return is_numeric( $param ); },
+								'sanitize_callback' => 'absint',
 							],
 						],
 						'permission_callback' => function ( $request ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-checker",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.",
   "author": "Equalize Digital",
   "license": "GPL-2.0+",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, WP accessibility
 Requires at least: 6.6
 Tested up to: 6.8
-Stable tag: 1.30.0
+Stable tag: 1.30.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -210,6 +210,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 10. Accessibility Checker automated fix settings.
 
 == Changelog ==
+
+= 1.30.1 =
+* Improved: The rescan and clear buttons in the frontend highlighter are now only shown when they can be used.
+* Improved: Issue saving and clearing now has more robust capability checking.
 
 = 1.30.0 =
 * Added: Ability to clear issues on a post or page from the frontend highlighter.

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -394,12 +394,12 @@ class AccessibilityCheckerHighlight {
 	addHighlightPanel() {
 		const widgetPosition = edacFrontendHighlighterApp?.widgetPosition || 'right';
 
-		const isLoggedInUser = edacFrontendHighlighterApp && edacFrontendHighlighterApp?.loggedIn;
-		const clearButtonMarkup = isLoggedInUser
+		const userCanEdit = edacFrontendHighlighterApp && edacFrontendHighlighterApp?.userCanEdit && edacFrontendHighlighterApp?.loggedIn;
+		const clearButtonMarkup = userCanEdit
 			? `<button id="edac-highlight-clear-issues" class="edac-highlight-clear-issues">${ __( 'Clear Issues', 'accessibility-checker' ) }</button>`
 			: '';
 
-		const rescanButton = isLoggedInUser
+		const rescanButton = userCanEdit
 			? `<button id="edac-highlight-rescan" class="edac-highlight-rescan">${ __( 'Rescan This Page', 'accessibility-checker' ) }</button>`
 			: '';
 
@@ -416,7 +416,7 @@ class AccessibilityCheckerHighlight {
                                 <button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="Close">×</button>
                                 <div class="edac-highlight-panel-controls-title">Accessibility Checker</div>
                                 <div class="edac-highlight-panel-controls-summary">Loading...</div>
-                                <div class="edac-highlight-panel-controls-buttons ${ ! isLoggedInUser ? ' single_button' : '' }">
+                                <div class="edac-highlight-panel-controls-buttons ${ ! userCanEdit ? ' single_button' : '' }">
                                         <div>
                                                 <button id="edac-highlight-previous" disabled="true"><span aria-hidden="true">« </span>Previous</button>
                                                 <button id="edac-highlight-next" disabled="true">Next<span aria-hidden="true"> »</span></button><br />

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * REST API endpoints behavior tests.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Test class for REST API endpoints.
+ *
+ * @group rest
+ */
+class RestApiEndpointsTest extends WP_UnitTestCase {
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Limited user ID.
+	 *
+	 * @var int
+	 */
+	protected static $limited_id;
+
+	/**
+	 * Post ID used for tests.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * REST server instance for dispatching requests.
+	 *
+	 * @var WP_REST_Server|null
+	 */
+	private $server;
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		// Initialize REST routes for each test.
+		do_action( 'init' );
+		do_action( 'rest_api_init' );
+		$this->server = rest_get_server();
+	}
+
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		// Reset current user between tests.
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Create shared fixtures for this test class.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		// Ensure posts are scannable by plugin.
+		update_option( 'edac_post_types', [ 'post' ] );
+
+		// Ensure plugin DB table exists for tests (normally created via admin_init).
+		( new \EDAC\Admin\Update_Database() )->edac_update_database();
+
+		self::$admin_id   = $factory->user->create( [ 'role' => 'administrator' ] );
+		self::$limited_id = $factory->user->create( [ 'role' => 'subscriber' ] );
+		// Give limited user edit_posts but not edit_others_posts so they cannot edit this post.
+		$user = new WP_User( self::$limited_id );
+		$user->add_cap( 'edit_posts' );
+
+		self::$post_id = $factory->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_author'  => self::$admin_id,
+				'post_title'   => 'EDAC PHPUnit Post',
+				'post_content' => '<main><h1>Title</h1><p>Img without alt <img src="/wp-includes/images/media/default.png"></p></main>',
+			]
+		);
+	}
+
+	/**
+	 * Verify permissions for saving post scan results.
+	 *
+	 * @return void
+	 */
+	public function test_rest_post_scan_results_permissions() {
+		$this->assertNotNull( $this->server );
+
+		// Minimal violations payload similar to scanner output.
+		$violations = [
+			[
+				'ruleId'   => 'image-alt',
+				'html'     => '<img src="/wp-includes/images/media/default.png">',
+				'impact'   => 'error',
+				'landmark' => null,
+			],
+		];
+
+		// Admin can POST results for the post.
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/accessibility-checker/v1/post-scan-results/' . self::$post_id );
+		$request->set_param( 'id', self::$post_id );
+		$request->set_param( 'violations', $violations );
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'Admin should be allowed to save scan results.' );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+
+		// Limited user cannot POST results for the admin-owned post.
+		wp_set_current_user( self::$limited_id );
+		$request2 = new WP_REST_Request( 'POST', '/accessibility-checker/v1/post-scan-results/' . self::$post_id );
+		$request2->set_param( 'id', self::$post_id );
+		$request2->set_param( 'violations', $violations );
+		$response2 = $this->server->dispatch( $request2 );
+		$this->assertSame( 403, $response2->get_status(), 'Limited user must not be allowed to save scan results for another user\'s post.' );
+	}
+
+	/**
+	 * Verify permissions for clearing issues for a post.
+	 *
+	 * @return void
+	 */
+	public function test_rest_clear_issues_permissions() {
+		$this->assertNotNull( $this->server );
+
+		// Admin can clear issues.
+		wp_set_current_user( self::$admin_id );
+		$r1 = new WP_REST_Request( 'POST', '/accessibility-checker/v1/clear-issues/' . self::$post_id );
+		$r1->set_param( 'id', self::$post_id );
+		$r1->set_body( wp_json_encode( [ 'flush' => true ] ) );
+		$r1->set_header( 'Content-Type', 'application/json' );
+		$resp1 = $this->server->dispatch( $r1 );
+		$this->assertSame( 200, $resp1->get_status(), 'Admin should be allowed to clear issues.' );
+		$body1 = $resp1->get_data();
+		$this->assertIsArray( $body1 );
+		$this->assertArrayHasKey( 'success', $body1 );
+		$this->assertTrue( $body1['success'] );
+
+		// Limited user cannot clear issues for a post they cannot edit.
+		wp_set_current_user( self::$limited_id );
+		$r2 = new WP_REST_Request( 'POST', '/accessibility-checker/v1/clear-issues/' . self::$post_id );
+		$r2->set_param( 'id', self::$post_id );
+		$r2->set_body( wp_json_encode( [ 'flush' => true ] ) );
+		$r2->set_header( 'Content-Type', 'application/json' );
+		$resp2 = $this->server->dispatch( $r2 );
+		$this->assertSame( 403, $resp2->get_status(), 'Limited user must not be allowed to clear issues.' );
+	}
+}

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -173,7 +173,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 				'post_type'   => 'post',
 				'post_status' => 'draft',
 				'post_author' => self::$limited_id,
-			] 
+			]
 		);
 
 		// Save scan results.
@@ -186,7 +186,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 					'ruleId' => 'image-alt',
 					'html'   => '<img>',
 				],
-			] 
+			]
 		);
 		$resp1 = $this->server->dispatch( $req1 );
 		$this->assertSame( 200, $resp1->get_status() );

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -120,6 +120,10 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status(), 'Admin should be allowed to save scan results.' );
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertSame( self::$post_id, $data['id'] );
 
 		// Limited user cannot POST results for the admin-owned post.
 		wp_set_current_user( self::$limited_id );
@@ -150,6 +154,10 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertIsArray( $body1 );
 		$this->assertArrayHasKey( 'success', $body1 );
 		$this->assertTrue( $body1['success'] );
+		$this->assertArrayHasKey( 'id', $body1 );
+		$this->assertSame( self::$post_id, $body1['id'] );
+		$this->assertArrayHasKey( 'flushed', $body1 );
+		$this->assertTrue( $body1['flushed'] );
 
 		// Limited user cannot clear issues for a post they cannot edit.
 		wp_set_current_user( self::$limited_id );
@@ -190,6 +198,10 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		);
 		$resp1 = $this->server->dispatch( $req1 );
 		$this->assertSame( 200, $resp1->get_status() );
+		$data1 = $resp1->get_data();
+		$this->assertIsArray( $data1 );
+		$this->assertArrayHasKey( 'success', $data1 );
+		$this->assertTrue( $data1['success'] );
 
 		// Clear issues.
 		$req2 = new WP_REST_Request( 'POST', '/accessibility-checker/v1/clear-issues/' . $own_post_id );
@@ -198,5 +210,9 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$req2->set_header( 'Content-Type', 'application/json' );
 		$resp2 = $this->server->dispatch( $req2 );
 		$this->assertSame( 200, $resp2->get_status() );
+		$data2 = $resp2->get_data();
+		$this->assertIsArray( $data2 );
+		$this->assertArrayHasKey( 'success', $data2 );
+		$this->assertTrue( $data2['success'] );
 	}
 }


### PR DESCRIPTION
This pull request enhances permission handling for REST API endpoints and UI elements in the Accessibility Checker plugin, ensuring that actions like saving scan results, clearing issues, and updating stats are only available to users with the appropriate capabilities for specific posts. It also adds comprehensive PHPUnit tests to verify these permission checks.

**Permission and Capability Improvements:**

* Refined REST API permission callbacks in `class-rest-api.php` to check if the current user can edit the specific post (`edit_post`, with post ID), replacing broad capability checks like `edit_posts` and `read`. Introduced a new helper method `user_can_edit_passed_post_id` for this purpose. [[1]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8R82-R90) [[2]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8R176-R184) [[3]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8R210-R232)
* Updated REST API endpoint permissions for stats and cache clearing to require more appropriate capabilities (`edit_posts` or `publish_posts` instead of `read`). [[1]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8L105-R107) [[2]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8L122-R124) [[3]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8L139-R141) [[4]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8L156-R158)

**Frontend and Admin UI Adjustments:**

* Modified the frontend highlighter app (`index.js`) to show "Clear Issues" and "Rescan This Page" buttons only to users who can edit the current post, improving security and user experience. [[1]](diffhunk://#diff-bece1bbb785a9261a7e6aca0d5cb83eda772f26999f3c83a31e4e57f728c75acL397-R402) [[2]](diffhunk://#diff-bece1bbb785a9261a7e6aca0d5cb83eda772f26999f3c83a31e4e57f728c75acL419-R419)
* Added a capability check (`publish_posts`) for displaying the "Update Counts" button on the admin welcome page, restricting access to users who can publish posts.
* Passed a new `userCanEdit` property to the frontend via the enqueue logic, reflecting whether the current user can edit the viewed post.

**Testing Enhancements:**

* Added a new PHPUnit test class `RestApiEndpointsTest.php` to verify REST API endpoint permissions, including scenarios for admin and limited users, and checking that users can only manage their own posts.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Action buttons in the welcome screen and frontend highlighter now only appear when the current user has the appropriate edit/publish permissions.
  - REST API actions now require stricter edit/publish capabilities for targeted posts and stats/clear operations.

- Refactor
  - Permission checks centralized for consistent access control across endpoints.

- Tests
  - Added end-to-end REST API permission tests for admins, limited users, and own-post scenarios.

- Chores
  - Plugin and package version bumped to 1.30.1; changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->