### PR TITLE
updated: video selector to exclude script tags and add test case for YouTube API

### DIFF
--- a/src/pageScanner/rules/video-present.js
+++ b/src/pageScanner/rules/video-present.js
@@ -6,7 +6,7 @@
 
 export default {
 	id: 'video_present',
-	selector: 'video, iframe, object, source, [src], [role]',
+	selector: 'video, iframe, object, source, [src]:not(script), [role]',
 	excludeHidden: false,
 	tags: [
 		'wcag2a',

--- a/tests/jest/rules/videoElementPresent.test.js
+++ b/tests/jest/rules/videoElementPresent.test.js
@@ -135,6 +135,11 @@ describe( 'video_present rule', () => {
 			html: '<audio controls><source src="sound.mp3" type="audio/mpeg"></audio>',
 			shouldPass: true,
 		},
+		{
+			name: 'does not detect YouTube API script tag',
+			html: '<script type="text/javascript" src="https://www.youtube.com/iframe_api?ver=1.2.6" id="youtube-scripts-js"></script>',
+			shouldPass: true,
+		},
 	];
 
 	testCases.forEach( ( testCase ) => {


### PR DESCRIPTION
This pull request updates the `video_present` accessibility rule to avoid incorrectly flagging `<script>` tags with a `src` attribute as video-related elements. It also adds a test to ensure that YouTube API script tags are not detected by this rule.

**Rule selector update:**

* Updated the `selector` in `video_present` rule to exclude `[src]` attributes on `<script>` tags, preventing false positives for scripts.

**Test coverage:**

* Added a test case to confirm that `<script>` tags with a `src` attribute, such as the YouTube API script, are not detected by the `video_present` rule.