### PR TITLE
Update copilot instructions to clarify lock file commit policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,8 @@ This is a WordPress plugin called "Accessibility Checker" developed by Equalize 
 
 ## Development Workflow
 
+Never commit lock files (`composer.lock`, `package-lock.json`), even if they change when you install, unless you are adding new packages or updating packages. Always run `composer install` and `npm install` to get the latest dependencies.
+
 Code should always be linted by phpcs and eslint before committing. Tests should be added for new functionality. Tests should also be added for any bug fixes. Use the following commands to run tests and linting:
 
 ```bash


### PR DESCRIPTION
Never commit lock files (`composer.lock`, `package-lock.json`), even if they change when you install, unless you are adding new packages or updating packages.