### PR TITLE
Add privacy policy statement link to newsletter forms

### DIFF
--- a/admin/opt-in/class-email-opt-in.php
+++ b/admin/opt-in/class-email-opt-in.php
@@ -146,6 +146,16 @@ class Email_Opt_In {
 					</div>
 				</div>
 				<div class="_button-wrapper _full_width edac-mt-3 edac-mb-3">
+					<small>
+						<?php
+						printf(
+						/* translators: 1: Equalize Digital. */
+							esc_html__( 'By subscribing, you consent to receive emails in accordance with our %1$sPrivacy Policy%2$s.', 'accessibility-checker' ),
+							'<a href="' . esc_url( edac_link_wrapper( 'https://equalizedigital.com/privacy-policy/', 'email_newsletter', 'privacy', false ) ) . '" target="_blank">',
+							'</a>'
+						);
+						?>
+					</small>
 					<button id="_form_1_submit" class="_submit button button-primary" type="submit">
 						Subscribe
 					</button>

--- a/src/emailOptIn/sass/email-opt-in.scss
+++ b/src/emailOptIn/sass/email-opt-in.scss
@@ -4,6 +4,23 @@
 	input {
 		width: 100%;
 	}
+
+	._button-wrapper {
+		display: flex;
+		flex-direction: row-reverse;
+		justify-content: start;
+		gap: 1rem;
+		align-items: center;
+		margin-top: 0;
+
+		.edac-welcome-aside & {
+			flex-direction: column;
+
+			button {
+				width: 100%;
+			}
+		}
+	}
 }
 
 


### PR DESCRIPTION
This change includes a link to the privacy policy in the newsletter subscription form, ensuring users are informed about email consent.

[PRO-275]

Modal:
<img width="665" height="469" alt="Screenshot from 2025-09-04 15-33-59" src="https://github.com/user-attachments/assets/d23a9cbf-8405-4b2a-80d9-898432a33b88" />

Sidebar:
<img width="212" height="520" alt="Screenshot from 2025-09-04 15-30-35" src="https://github.com/user-attachments/assets/ecce38f1-416f-446c-afc4-c078a61cbd7b" />

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
