### PR TITLE
updated: sanitize and unslash review action before updating option for review notice

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -336,9 +336,10 @@ class Admin_Notices {
 
 		}
 
-		$results = update_option( 'edac_review_notice', sanitize_text_field( $_REQUEST['review_action'] ) );
+		$review_action = sanitize_text_field( wp_unslash( $_REQUEST['review_action'] ) );
+		$results       = update_option( 'edac_review_notice', $review_action );
 
-		if ( 'pause' === $_REQUEST['review_action'] ) {
+		if ( 'pause' === $review_action ) {
 			set_transient( 'edac_review_notice_reminder', true, 14 * DAY_IN_SECONDS );
 		}
 


### PR DESCRIPTION
This pull request makes a minor improvement to the sanitization and handling of AJAX requests in the `edac_review_notice_ajax` function. The change ensures that the `review_action` parameter is properly sanitized and unslashed before use, which improves security and reliability.

* Improved sanitization: The `review_action` value from `$_REQUEST` is now passed through both `wp_unslash` and `sanitize_text_field` before being used, ensuring safer input handling.
* Code clarity: The code now uses the sanitized `$review_action` variable throughout the function, replacing direct references to `$_REQUEST['review_action']`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improves reliability of the admin review prompt so pause/dismiss choices are consistently saved and respected.
* **Chores**
  * Hardens input handling for the review prompt action in the AJAX flow by sanitizing request data, improving stability and preventing malformed inputs from affecting preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->