### PR TITLE
added: 'heading-order' to standardRuleIdsArray

### DIFF
--- a/src/pageScanner/config/rules.js
+++ b/src/pageScanner/config/rules.js
@@ -160,6 +160,7 @@ export const standardRuleIdsArray = [
 	'html-lang-valid',
 	'html-has-lang',
 	'form-field-multiple-labels',
+	'heading-order',
 ];
 
 // Define custom rule IDs from the rules array.


### PR DESCRIPTION
This pull request adds a new accessibility rule to the standard ruleset in the page scanner configuration. The main change is:

Accessibility ruleset update:

* Added the `heading-order` rule to the `standardRuleIdsArray` in `src/pageScanner/config/rules.js`, ensuring heading levels are checked for proper order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced accessibility scanning by adding a check for heading order. The scanner now flags pages where headings do not follow a logical hierarchy (e.g., skipping levels).
  - Users may notice additional accessibility issues related to document structure, enabling more comprehensive audits and clearer guidance on fixing heading hierarchy problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->