### PR TITLE
Make commands bootstrap later at `init` and add support for shorthand names on commands 

### DIFF
--- a/includes/classes/WPCLI/BootstrapCLI.php
+++ b/includes/classes/WPCLI/BootstrapCLI.php
@@ -94,6 +94,14 @@ class BootstrapCLI {
 					$command,
 					$command::get_args()
 				);
+				// For ease of typing on cli there's a shortname too in some commands.
+				if ( method_exists( $command, 'get_shortname' ) ) {
+					$this->wp_cli::add_command(
+						$command::get_shortname(),
+						$command,
+						$command::get_args()
+					);
+				}
 			} catch ( Exception $e ) {
 				$this->wp_cli::warning(
 					sprintf(

--- a/includes/classes/WPCLI/Command/CleanupOrphanedIssues.php
+++ b/includes/classes/WPCLI/Command/CleanupOrphanedIssues.php
@@ -54,7 +54,7 @@ class CleanupOrphanedIssues implements CLICommandInterface {
 	 * @return string
 	 */
 	public static function get_shortname(): string {
-			return 'edac cleanup-orphaned-issues';
+		return 'edac cleanup-orphaned-issues';
 	}
 
 	/**

--- a/includes/classes/WPCLI/Command/CleanupOrphanedIssues.php
+++ b/includes/classes/WPCLI/Command/CleanupOrphanedIssues.php
@@ -47,6 +47,17 @@ class CleanupOrphanedIssues implements CLICommandInterface {
 	}
 
 	/**
+	 * Get the short name of the command.
+	 *
+	 * @since 1.32.0
+	 *
+	 * @return string
+	 */
+	public static function get_shortname(): string {
+			return 'edac cleanup-orphaned-issues';
+	}
+
+	/**
 	 * Get the arguments for the command.
 	 *
 	 * @since 1.29.0

--- a/includes/classes/WPCLI/Command/CleanupOrphanedIssues.php
+++ b/includes/classes/WPCLI/Command/CleanupOrphanedIssues.php
@@ -32,7 +32,7 @@ class CleanupOrphanedIssues implements CLICommandInterface {
 	 * @param mixed|WP_CLI $wp_cli The WP-CLI instance.
 	 */
 	public function __construct( $wp_cli = null ) {
-			$this->wp_cli = $wp_cli ?? new WP_CLI();
+		$this->wp_cli = $wp_cli ?? new WP_CLI();
 	}
 
 	/**
@@ -43,7 +43,7 @@ class CleanupOrphanedIssues implements CLICommandInterface {
 	 * @return string
 	 */
 	public static function get_name(): string {
-			return 'accessibility-checker cleanup-orphaned-issues';
+		return 'accessibility-checker cleanup-orphaned-issues';
 	}
 
 	/**
@@ -65,24 +65,24 @@ class CleanupOrphanedIssues implements CLICommandInterface {
 	 * @return array
 	 */
 	public static function get_args(): array {
-			return [
-				'synopsis' => [
-					[
-						'type'        => 'assoc',
-						'name'        => 'batch',
-						'description' => __( 'Number of orphaned posts to process in one batch.', 'accessibility-checker' ),
-						'optional'    => true,
-						'default'     => null,
-					],
-					[
-						'type'        => 'assoc',
-						'name'        => 'sleep',
-						'description' => __( 'Seconds to sleep between deletions (default: 0).', 'accessibility-checker' ),
-						'optional'    => true,
-						'default'     => 0,
-					],
+		return [
+			'synopsis' => [
+				[
+					'type'        => 'assoc',
+					'name'        => 'batch',
+					'description' => __( 'Number of orphaned posts to process in one batch.', 'accessibility-checker' ),
+					'optional'    => true,
+					'default'     => null,
 				],
-			];
+				[
+					'type'        => 'assoc',
+					'name'        => 'sleep',
+					'description' => __( 'Seconds to sleep between deletions (default: 0).', 'accessibility-checker' ),
+					'optional'    => true,
+					'default'     => 0,
+				],
+			],
+		];
 	}
 
 	/**

--- a/includes/classes/WPCLI/Command/DeleteStats.php
+++ b/includes/classes/WPCLI/Command/DeleteStats.php
@@ -48,6 +48,17 @@ class DeleteStats implements CLICommandInterface {
 	}
 
 	/**
+	 * Get the short name of the command.
+	 *
+	 * @since 1.32.0
+	 *
+	 * @return string
+	 */
+	public static function get_shortname(): string {
+		return 'edac delete-stats';
+	}
+
+	/**
 	 * Get the arguments for the command
 	 *
 	 * @return array

--- a/includes/classes/WPCLI/Command/GetSiteStats.php
+++ b/includes/classes/WPCLI/Command/GetSiteStats.php
@@ -52,6 +52,17 @@ class GetSiteStats implements CLICommandInterface {
 	}
 
 	/**
+	 * Get the short name of the command.
+	 *
+	 * @since 1.32.0
+	 *
+	 * @return string
+	 */
+	public static function get_shortname(): string {
+		return 'edac get-site-stats';
+	}
+
+	/**
 	 * Get the arguments for the command
 	 *
 	 * @since 1.15.0

--- a/includes/classes/WPCLI/Command/GetStats.php
+++ b/includes/classes/WPCLI/Command/GetStats.php
@@ -70,6 +70,17 @@ class GetStats implements CLICommandInterface {
 	}
 
 	/**
+	 * Get the short name of the command.
+	 *
+	 * @since 1.32.0
+	 *
+	 * @return string
+	 */
+	public static function get_shortname(): string {
+		return 'edac get-stats';
+	}
+
+	/**
 	 * Get the arguments for the command
 	 *
 	 * @since 1.15.0

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -45,8 +45,13 @@ class Plugin {
 
 		// When WP CLI is enabled, load the CLI commands.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			$cli = new BootstrapCLI();
-			$cli->register();
+			add_action(
+				'init',
+				function () {
+					$cli = new BootstrapCLI();
+					$cli->register();
+				}
+			);
 		}
 	}
 


### PR DESCRIPTION
This adds some support for inserting commands in other plugins by making the registration of them happen at a more appropriate time. Also adds support for a shortname on each command. For example `edac delete-stats` instead of `accessibility-checker delete-stats`

## Summary by CodeRabbit

* New Features
  * WP-CLI commands now include short aliases (e.g., “edac cleanup-orphaned-issues”, “edac delete-stats”, “edac get-site-stats”, “edac get-stats”) for quicker usage.
  * CLI now supports automatic registration of shortname aliases alongside primary commands.

* Refactor
  * Improved CLI initialization by deferring registration to WordPress init, enhancing compatibility with other plugins and environments.
  * Streamlined command registration flow to ensure aliases and primary commands are consistently available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added short aliases for WP‑CLI commands, enabling quicker command usage (e.g., shorter “edac …” forms).

* **Refactor**
  * Adjusted CLI bootstrap to load during WordPress initialization, improving reliability of command availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->