### PR TITLE
Fix average issue density when only ignored issues remain

### DIFF
--- a/admin/class-scans-stats.php
+++ b/admin/class-scans-stats.php
@@ -290,26 +290,33 @@ class Scans_Stats {
 			}
 		}
 
-		// Average issue density percentage is the sum of all post densities divided by the number of posts scanned.
-		$data['avg_issue_density_percentage'] =
-			$wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
-				$wpdb->prepare(
-					'SELECT AVG(meta_value)
-					FROM ' . $wpdb->postmeta . '
-					JOIN (
-						SELECT DISTINCT postid
-						FROM ' . $wpdb->prefix . 'accessibility_checker
-					) AS distinct_posts ON ' . $wpdb->postmeta . '.post_id = distinct_posts.postid
-					WHERE meta_key = %s',
-					[ '_edac_issue_density' ]
-				)
-			);
+                // Average issue density percentage should ignore posts whose issues have all been ignored.
+                $data['avg_issue_density_percentage'] =
+                        $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
+                                $wpdb->prepare(
+                                        'SELECT AVG(pm.meta_value)
+                                        FROM ' . $wpdb->postmeta . ' AS pm
+                                        INNER JOIN (
+                                                SELECT DISTINCT postid
+                                                FROM %i
+                                                WHERE siteid = %d
+                                                        AND COALESCE(ignre, 0) = 0
+                                                        AND COALESCE(ignre_global, 0) = 0
+                                        ) AS active_posts ON pm.post_id = active_posts.postid
+                                        WHERE pm.meta_key = %s',
+                                        [
+                                                $wpdb->prefix . 'accessibility_checker',
+                                                $siteid,
+                                                '_edac_issue_density',
+                                        ]
+                                )
+                        );
 
-		if ( null === $data['avg_issue_density_percentage'] ) {
-			$data['avg_issue_density_percentage'] = 'N/A';
-		} else {
-			$data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 2 );
-		}
+                if ( null === $data['avg_issue_density_percentage'] ) {
+                        $data['avg_issue_density_percentage'] = $data['posts_scanned'] > 0 ? 0 : 'N/A';
+                } else {
+                        $data['avg_issue_density_percentage'] = round( $data['avg_issue_density_percentage'], 2 );
+                }
 
 		$data['fullscan_running']      = false;
 		$data['fullscan_state']        = '';

--- a/tests/phpunit/Admin/ScansStatsTest.php
+++ b/tests/phpunit/Admin/ScansStatsTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Tests for the Scans_Stats class.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Scans_Stats;
+
+/**
+ * Test class for Scans_Stats summary calculations.
+ */
+class ScansStatsTest extends WP_UnitTestCase {
+
+        /**
+         * Name of the accessibility checker table.
+         *
+         * @var string
+         */
+        protected $table_name;
+
+        /**
+         * Set up the database table required for the tests.
+         */
+        public function setUp(): void {
+                parent::setUp();
+
+                global $wpdb;
+
+                $this->table_name = $wpdb->prefix . 'accessibility_checker';
+
+                require_once dirname( __DIR__, 3 ) . '/admin/class-update-database.php';
+
+                ( new \EDAC\Admin\Update_Database() )->edac_update_database();
+
+                update_option( 'edac_post_types', [ 'post' ] );
+        }
+
+        /**
+         * Clean up the custom table after each test.
+         */
+        public function tearDown(): void {
+                global $wpdb;
+
+                $wpdb->query( "DROP TABLE IF EXISTS $this->table_name" ); // phpcs:ignore WordPress.DB -- table name is safe and not caching in tests.
+
+                delete_option( 'edac_post_types' );
+
+                parent::tearDown();
+        }
+
+        /**
+         * Ensures the average issue density ignores posts where all issues are ignored.
+         */
+        public function test_average_issue_density_excludes_ignored_posts() {
+                global $wpdb;
+
+                $site_id = get_current_blog_id();
+
+                $ignored_post = self::factory()->post->create( [ 'post_type' => 'post', 'post_status' => 'publish' ] );
+                $active_post  = self::factory()->post->create( [ 'post_type' => 'post', 'post_status' => 'publish' ] );
+
+                update_post_meta( $ignored_post, '_edac_issue_density', 75 );
+                update_post_meta( $active_post, '_edac_issue_density', 50 );
+
+                $this->insert_issue_row(
+                        $ignored_post,
+                        $site_id,
+                        [
+                                'ignre' => 1,
+                        ]
+                );
+
+                $this->insert_issue_row( $active_post, $site_id );
+
+                $stats  = new Scans_Stats( 0 );
+                $result = $stats->summary( true );
+
+                $this->assertSame( 50.0, $result['avg_issue_density_percentage'] );
+
+                // Mark the remaining issue as ignored and confirm the average density drops to zero.
+                $wpdb->update(
+                        $this->table_name,
+                        [
+                                'ignre'        => 1,
+                                'ignre_global' => 0,
+                        ],
+                        [
+                                'postid' => $active_post,
+                        ]
+                );
+
+                $result = $stats->summary( true );
+
+                $this->assertSame( 0.0, $result['avg_issue_density_percentage'] );
+        }
+
+        /**
+         * Helper to insert an issue row into the accessibility checker table.
+         *
+         * @param int   $post_id  Post ID the issue is associated with.
+         * @param int   $site_id  Current site ID.
+         * @param array $overrides Optional overrides for the default row data.
+         */
+        private function insert_issue_row( int $post_id, int $site_id, array $overrides = [] ): void {
+                global $wpdb;
+
+                $defaults = [
+                        'postid'            => $post_id,
+                        'siteid'            => (string) $site_id,
+                        'type'              => 'post',
+                        'landmark'          => null,
+                        'landmark_selector' => null,
+                        'selector'          => null,
+                        'ancestry'          => null,
+                        'xpath'             => null,
+                        'rule'              => 'test_rule',
+                        'ruletype'          => 'error',
+                        'object'            => '{}',
+                        'recordcheck'       => 1,
+                        'user'              => 1,
+                        'ignre'             => 0,
+                        'ignre_global'      => 0,
+                        'ignre_user'        => null,
+                        'ignre_date'        => null,
+                        'ignre_comment'     => null,
+                ];
+
+                $data = array_merge( $defaults, $overrides );
+
+                $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- direct insert is acceptable within tests.
+                        $this->table_name,
+                        $data
+                );
+        }
+}
+


### PR DESCRIPTION
## Summary
- ensure the average issue density query only includes posts with non-ignored issues and respects the current site ID
- return an average of 0 when scans exist but all issues have been ignored, instead of showing N/A
- add PHPUnit coverage confirming ignored issues are excluded from the average density calculation

## Testing
- composer lint
- ./vendor/bin/phpunit tests/phpunit/Admin/ScansStatsTest.php *(fails: missing /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fc2f68b08328b89b43151d257ec0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Average issue density in scan stats now excludes ignored content for more accurate reporting.
  * Clarified display when no applicable data: shows 0% if scans exist but all issues are ignored; shows N/A if nothing has been scanned.
  * Values are consistently rounded to two decimals.

* **Tests**
  * Added automated tests to verify average issue density calculations and behavior with ignored content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->