### PR TITLE
updated: prefixes and text domain in PHPCS ruleset for accessibility checker

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -30,13 +30,13 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
-			<property name="prefixes" type="array" value="my-plugin"/>
+			<property name="prefixes" type="array" value="edac"/>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="my-plugin"/>
+			<property name="text_domain" type="array" value="accessibility-checker"/>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">


### PR DESCRIPTION
This pull request updates the coding standards configuration to match the plugin's actual naming and text domain conventions.

Configuration updates:

* Changed the global prefix in `.phpcs.xml.dist` from `my-plugin` to `edac` to ensure code uses the correct project-specific prefix.
* Updated the internationalization text domain in `.phpcs.xml.dist` from `my-plugin` to `accessibility-checker` for accurate localization checks.