### PR TITLE
Updated:  prevent initial scan on unsaved posts; fallback for classic editor

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -140,6 +140,7 @@ class Enqueue_Admin {
 						'scanUrl'      => $scan_url,
 						'maxAltLength' => max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) ),
 						'version'      => EDAC_VERSION,
+						'postStatus'   => get_post_status( $post_id ),
 						'restNonce'    => wp_create_nonce( 'wp_rest' ),
 					]
 				);

--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -161,13 +161,10 @@ export const init = () => {
 	}
 
 	const editor = wp?.data?.select?.( 'core/editor' );
+	const postStatus = editor?.getEditedPostAttribute( 'status' ) ?? window?.edac_editor_app?.postStatus;
 
-	// In the block editor, don't run the initial scan on auto-drafts.
-	if ( editor ) {
-		const postStatus = editor.getEditedPostAttribute( 'status' );
-		if ( ! postStatus || postStatus === 'auto-draft' ) {
-			return;
-		}
+	if ( ! postStatus || postStatus === 'auto-draft' ) {
+		return;
 	}
 
 	// eslint-disable-next-line camelcase


### PR DESCRIPTION
This pull request updates the logic for initializing the scan in `src/editorApp/checkPage.js` to ensure the scan only runs when the post has been saved. The main change is to prevent scans from running on auto-draft posts, improving both accuracy and resource usage.

Scan initialization improvements:

* Updated the `init` function to check the post status using `wp.data.select('core/editor').getEditedPostAttribute('status')`, and only run the scan if the post is not an auto-draft.
* Added a fallback for the classic editor, assuming the post is saved if on `post.php`, to maintain compatibility.

Fixes: https://linear.app/equalize-digital/issue/PRO-221/bug-scanner-attempts-to-scan-unsaved-new-posts-and-gets-404-error
Fixes: #1151

Gutenberg:
![2025-12-01 18 37 00](https://github.com/user-attachments/assets/9c327daf-d0aa-4d5e-9226-2f9bc6647f97)

Classic:
![2025-12-01 18 37 34](https://github.com/user-attachments/assets/6ad12d07-9191-456c-909e-f68677abe803)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Iframe injection is skipped for posts in the auto-draft state; initial scan is deferred until the post is saved or confirmed non-draft.
  * Ensures consistent iframe behavior when editor state is unavailable by using a fallback source for post status, avoiding unexpected injections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->