### PR TITLE
Update: help ID for new window warning fix settings

### DIFF
--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -77,7 +77,7 @@ class AddNewWindowWarningFix implements FixInterface {
 			),
 			'fix_slug'    => $this->get_slug(),
 			'group_name'  => $this->get_nicename(),
-			'help_id'     => 8493,
+			'help_id'     => 9946,
 		];
 
 		return $fields;


### PR DESCRIPTION
This pull request makes a minor update to the `AddNewWindowWarningFix.php` class, specifically changing the help documentation reference for the fix.

* Updated the `help_id` in the `get_fields_array` method from `8493` to `9946` to point to the correct help documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the help documentation link for the Add New Window Warning fix to ensure users can access the appropriate contextual help resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->