### PR TITLE
When bulk ignoring issues setup to update the counts

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -764,18 +764,16 @@ class Ajax {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 			$wpdb->query( $wpdb->prepare( 'UPDATE %i SET ignre = %d, ignre_user = %d, ignre_date = %s, ignre_comment = %s, ignre_global = %d WHERE siteid = %d and object = %s', $table_name, $ignre, $ignre_user, $ignre_date, $ignre_comment, $ignore_global, $siteid, $object ) );
 		} else {
-			// Track the ids in an option. They should be unique in the option so we might want a little helper.
-			$last_ignored_ids = get_option( 'edac_last_ignored_ids', [] );
-			$last_ignored_ids = is_array( $last_ignored_ids ) ? $last_ignored_ids : [];
-			$ignored_ids      = array_unique( array_merge( $last_ignored_ids, $ids ) );
-			update_option( 'edac_last_ignored_ids', $ignored_ids );
-
 			// For small batches of IDs, we can just loop through.
 			foreach ( $ids as $id ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 				$wpdb->query( $wpdb->prepare( 'UPDATE %i SET ignre = %d, ignre_user = %d, ignre_date = %s, ignre_comment = %s, ignre_global = %d WHERE siteid = %d and id = %d', $table_name, $ignre, $ignre_user, $ignre_date, $ignre_comment, $ignore_global, $siteid, $id ) );
+				// update the summary after ignoring.
+				$summary_generator = new Summary_Generator( $id );
+				$summary_generator->generate_summary();
 			}
 		}
+
 
 		$data = [
 			'ids'    => $ids,

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -751,9 +751,25 @@ class Ajax {
 			if ( ! $object ) {
 				wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
 			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
+			$affected_post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT postid FROM %i WHERE siteid = %d and object = %s', $table_name, $siteid, $object ) );
+			if ( $affected_post_ids ) {
+				$last_ignored_ids = get_option( 'edac_last_ignored_ids', [] );
+				$last_ignored_ids = is_array( $last_ignored_ids ) ? $last_ignored_ids : [];
+				$ignored_ids      = array_unique( array_merge( $last_ignored_ids, $affected_post_ids ) );
+				update_option( 'edac_last_ignored_ids', $ignored_ids );
+			}
+
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 			$wpdb->query( $wpdb->prepare( 'UPDATE %i SET ignre = %d, ignre_user = %d, ignre_date = %s, ignre_comment = %s, ignre_global = %d WHERE siteid = %d and object = %s', $table_name, $ignre, $ignre_user, $ignre_date, $ignre_comment, $ignore_global, $siteid, $object ) );
 		} else {
+			// Track the ids in an option. They should be unique in the option so we might want a little helper.
+			$last_ignored_ids = get_option( 'edac_last_ignored_ids', [] );
+			$last_ignored_ids = is_array( $last_ignored_ids ) ? $last_ignored_ids : [];
+			$ignored_ids      = array_unique( array_merge( $last_ignored_ids, $ids ) );
+			update_option( 'edac_last_ignored_ids', $ignored_ids );
+
 			// For small batches of IDs, we can just loop through.
 			foreach ( $ids as $id ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.

--- a/admin/class-summary-update-scheduler.php
+++ b/admin/class-summary-update-scheduler.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Scheduled summary update for posts with ignored issues.
+ *
+ * NOTE: This entire class should ideally be hooked into a refactored and
+ * generalized cleanup routine when that is merged in.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Admin;
+
+use EDAC\Inc\Summary_Generator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Summary_Update_Scheduler
+ *
+ * Handles scheduled updates of post summaries for posts that have recently
+ * had issues ignored or unignored.
+ *
+ * @since 1.34.0
+ */
+class Summary_Update_Scheduler {
+
+	/**
+	 * Cron event name.
+	 *
+	 * @var string
+	 */
+	const EVENT = 'edac_update_post_summaries';
+
+	/**
+	 * Option name for storing post IDs.
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'edac_last_ignored_ids';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		self::schedule_event();
+		add_action( self::EVENT, [ $this, 'run_summary_updates' ] );
+	}
+
+	/**
+	 * Schedule the summary update event.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @return void
+	 */
+	public static function schedule_event() {
+		if ( ! wp_next_scheduled( self::EVENT ) ) {
+			wp_schedule_event( time(), 'hourly', self::EVENT );
+		}
+	}
+
+	/**
+	 * Unschedule the summary update event.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @return void
+	 */
+	public static function unschedule_event() {
+		$timestamp = wp_next_scheduled( self::EVENT );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::EVENT );
+		}
+	}
+
+	/**
+	 * Get post IDs from the option.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @return int[] Array of post IDs.
+	 */
+	protected function get_post_ids(): array {
+		$post_ids = get_option( self::OPTION_NAME, [] );
+
+		if ( ! is_array( $post_ids ) ) {
+			return [];
+		}
+
+		// Ensure all values are integers.
+		return array_map( 'intval', $post_ids );
+	}
+
+	/**
+	 * Clear the post IDs option.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @return void
+	 */
+	protected function clear_post_ids() {
+		delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * Update summary for a single post.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @param int $post_id The post ID.
+	 * @return bool Whether the update was successful.
+	 */
+	protected function update_post_summary( int $post_id ): bool {
+		// Verify the post exists.
+		if ( ! get_post( $post_id ) ) {
+			return false;
+		}
+
+		try {
+			$summary_generator = new Summary_Generator( $post_id );
+			$summary_generator->generate_summary();
+			return true;
+		} catch ( \Exception $e ) {
+			// Log the error if WP_DEBUG is enabled.
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Only logs in debug mode.
+				error_log( 'EDAC Summary Update Error for Post ' . $post_id . ': ' . $e->getMessage() );
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * Run summary updates for all pending posts.
+	 *
+	 * @since 1.34.0
+	 *
+	 * @return array {
+	 *     Summary of the update operation.
+	 *
+	 *     @type int[] $processed  Array of successfully processed post IDs.
+	 *     @type int[] $failed     Array of post IDs that failed to process.
+	 *     @type int   $total      Total number of posts attempted.
+	 * }
+	 */
+	public function run_summary_updates(): array {
+		$post_ids = $this->get_post_ids();
+
+		if ( empty( $post_ids ) ) {
+			return [
+				'processed' => [],
+				'failed'    => [],
+				'total'     => 0,
+			];
+		}
+
+		$processed = [];
+		$failed    = [];
+
+		// Track start time to prevent timeouts.
+		$start_time       = time();
+		$max_execution    = (int) ini_get( 'max_execution_time' );
+		$safety_threshold = 0.3; // Stop at 30% of max execution time.
+		$time_limit       = $max_execution > 0 ? ( $max_execution * $safety_threshold ) : 50;
+		$elapsed          = 0;
+
+		// Split the array into chunks of 20 to avoid timeouts on large updates.
+		$post_id_chunks = array_chunk( $post_ids, 20 );
+
+		// Process each chunk separately.
+		foreach ( $post_id_chunks as $chunk ) {
+			// Check if we're approaching max execution time before processing next chunk.
+			$elapsed = time() - $start_time;
+			if ( $elapsed >= $time_limit ) {
+				// Time limit reached, save remaining posts back to the option for next run.
+				$remaining = array_merge( $chunk, ...array_slice( $post_id_chunks, array_search( $chunk, $post_id_chunks, true ) + 1 ) );
+				$remaining = array_merge( $remaining, $failed ); // Include failed posts for retry.
+				update_option( self::OPTION_NAME, array_unique( $remaining ) );
+				break;
+			}
+
+			foreach ( $chunk as $post_id ) {
+				if ( $this->update_post_summary( $post_id ) ) {
+					$processed[] = $post_id;
+				} else {
+					$failed[] = $post_id;
+				}
+			}
+		}
+
+		// Only clear the option if all posts were processed successfully.
+		if ( empty( $failed ) && $elapsed < $time_limit ) {
+			$this->clear_post_ids();
+		}
+
+		return [
+			'processed' => $processed,
+			'failed'    => $failed,
+			'total'     => count( $post_ids ),
+		];
+	}
+}

--- a/admin/class-summary-update-scheduler.php
+++ b/admin/class-summary-update-scheduler.php
@@ -117,9 +117,9 @@ class Summary_Update_Scheduler {
 	 * @return bool Whether the update was successful.
 	 */
 	protected function update_post_summary( int $post_id ): bool {
-		// Verify the post exists.
+		// If the post no longer exists then mark it as successfully processed so it is removed from the list.
 		if ( ! get_post( $post_id ) ) {
-			return false;
+			return true;
 		}
 
 		try {

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -10,6 +10,7 @@ namespace EDAC\Inc;
 use EDAC\Admin\Admin;
 use EDAC\Admin\Meta_Boxes;
 use EDAC\Admin\Orphaned_Issues_Cleanup;
+use EDAC\Admin\Summary_Update_Scheduler;
 use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
@@ -40,6 +41,9 @@ class Plugin {
 
 		$cleanup = new Orphaned_Issues_Cleanup();
 		$cleanup->init_hooks();
+
+		$summary_scheduler = new Summary_Update_Scheduler();
+		$summary_scheduler->init_hooks();
 
 		$this->register_fixes_manager();
 

--- a/includes/deactivation.php
+++ b/includes/deactivation.php
@@ -6,6 +6,7 @@
  */
 
 use EDAC\Admin\Orphaned_Issues_Cleanup;
+use EDAC\Admin\Summary_Update_Scheduler;
 
 /**
  * Deactivation
@@ -17,4 +18,7 @@ function edac_deactivation() {
 
 	// Unschedule cleanup of orphaned issues.
 	Orphaned_Issues_Cleanup::unschedule_event();
+
+	// Unschedule summary updates.
+	Summary_Update_Scheduler::unschedule_event();
 }


### PR DESCRIPTION
When someone ignores an issue the summary data doesn't update if the ignore is done outside of the single post page. This can happen when bulk ignoring or doing global ignores.

This PR adds some code in the ignore callback that will regenerate the summary right away for small batches or store the IDs for later if the batch is too large to process right away.

It also adds a summary generator routine (run on cron once an hour) that will look over those issue ids and generate summaries for them. It has a timer built in to try ensure it doesn't run for too long.

## Testing:

### Before PR

If you bulk ignore issues from fast track then view the admin colums of one of the posts you will see they did not update.

### After PR

### Small batch
If you bulk ignore small batch (less than 20) of issues and view admin colums of one of the posts you will see admin columns are updated right away.

### Large batch 
If you bulk ignore issue in a large batch (more than 20) and view admin columns of one of the posts you will see the numbers don't immedately change. But if you run the cron `edac_update_post_summaries` the numbers should be updated.

Note: if the batch of ignores are really large, or the max execution time on the server is low) you might have to run the cron more than once.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post summaries now automatically regenerate when issues are ignored or unignored.
  * Background scheduling system efficiently manages summary updates, processing items in batches with automatic timeout handling to prevent conflicts.
  * Plugin integration ensures proper initialization and cleanup of the scheduling system on activation and deactivation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->