### PR TITLE
Update some tests to account for WP6.9 changes to wp_json_encode flags.

### DIFF
--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -116,9 +116,9 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 
 		$localized_data = $wp_scripts->get_data( 'edac-editor-app', 'data' );
 		$this->assertStringContainsString( 'edac_pageScanner', $localized_data );
-		// In wp 6.9 there were changes to the flags passed to wp_json_encode() that made slashes no longer get escaped by default.
-		// we should check for both possibilities here to ensure compatibility across versions.
-		// see: https://github.com/WordPress/wordpress-develop/pull/9557 for more details.
+		// In WP 6.9 there were changes to the flags passed to wp_json_encode() that made slashes no longer get escaped by default.
+		// We should check for both possibilities here to ensure compatibility across versions.
+		// See: https://github.com/WordPress/wordpress-develop/pull/9557 for more details.
 		if ( version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) ) {
 			$this->assertStringContainsString( esc_url_raw( get_permalink( $post->ID ) ), $localized_data );
 		} else {
@@ -148,9 +148,9 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 
 		$localized_data = $wp_scripts->get_data( 'edac-editor-app', 'data' );
 		$this->assertStringContainsString( 'edac_pageScanner', $localized_data );
-		// In wp 6.9 there were changes to the flags passed to wp_json_encode() that made slashes no longer get escaped by default.
-		// we should check for both possibilities here to ensure compatibility across versions.
-		// see: https://github.com/WordPress/wordpress-develop/pull/9557 for more details.
+		// In WP 6.9 there were changes to the flags passed to wp_json_encode() that made slashes no longer get escaped by default.
+		// We should check for both possibilities here to ensure compatibility across versions.
+		// See: https://github.com/WordPress/wordpress-develop/pull/9557 for more details.
 		if ( version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) ) {
 			$this->assertStringContainsString( esc_url_raw( get_permalink( $post->ID ) ), $localized_data );
 		} else {


### PR DESCRIPTION
Specifically the addition of JSON_UNESCAPED_SLASHES as a flag.

See: https://github.com/WordPress/wordpress-develop/pull/9557

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to handle WordPress 6.9+ behavior with version-aware assertions ensuring correct checks across WP versions.
  * Added explanatory comments to clarify intent and a minor formatting tweak for readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->