### PR TITLE
Add: "an image" to invalid alt text checks and corresponding tests

### DIFF
--- a/src/pageScanner/checks/img-alt-invalid-check.js
+++ b/src/pageScanner/checks/img-alt-invalid-check.js
@@ -31,6 +31,7 @@ export default {
 			'graphic of',
 			'bullet',
 			'image of',
+			'an image',
 		];
 		for ( const keyword of startsWithKeywords ) {
 			if ( altTrimmed.startsWith( keyword ) ) {
@@ -62,7 +63,7 @@ export default {
 
 		// Check for exact matches with problematic keywords
 		const keywords = [
-			'graphic of', 'bullet', 'image of', 'image', 'graphic', 'photo',
+			'graphic of', 'bullet', 'image of', 'an image', 'image', 'graphic', 'photo',
 			'photograph', 'drawing', 'painting', 'artwork', 'logo',
 			'button', 'arrow', 'more', 'spacer', 'blank', 'chart', 'table',
 			'diagram', 'graph', '*',

--- a/tests/jest/rules/imgAltInvalid.test.js
+++ b/tests/jest/rules/imgAltInvalid.test.js
@@ -40,6 +40,16 @@ describe( 'Image Alt Invalid Validation', () => {
 			shouldPass: false,
 		},
 		{
+			name: 'should fail for alt text that starts with "an image"',
+			html: '<img src="test.jpg" alt="an image of a sunset">',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for alt text that is exactly "an image"',
+			html: '<img src="test.jpg" alt="an image">',
+			shouldPass: false,
+		},
+		{
 			name: 'should fail for alt text that ends with "image"',
 			html: '<img src="test.jpg" alt="cat image">',
 			shouldPass: false,


### PR DESCRIPTION
This pull request updates the image alt text validation logic to more strictly catch problematic alt attributes that use the phrase "an image". The changes ensure that alt text starting with or exactly matching "an image" is considered invalid, and adds corresponding test coverage.

**Accessibility validation improvements:**

* Updated the list of invalid alt text keywords in `img-alt-invalid-check.js` to include "an image" in both the "starts with" and "exact match" checks. [[1]](diffhunk://#diff-fbfd2f9e6eff4952d617f82b414b8698897baafeec90e95cc2a0851abc8a7e6eR34) [[2]](diffhunk://#diff-fbfd2f9e6eff4952d617f82b414b8698897baafeec90e95cc2a0851abc8a7e6eL65-R66)

**Test coverage:**

* Added two new test cases in `imgAltInvalid.test.js` to verify that alt text starting with or exactly matching "an image" is correctly flagged as invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced image alt text validation to detect additional invalid patterns, including alt text starting with or exactly matching "an image"

* **Tests**
  * Added test coverage for expanded alt text validation scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->