### PR TITLE
Add: exclusion for role="menuitem" with aria-expanded in link validation

### DIFF
--- a/src/pageScanner/checks/link-has-valid-href-or-role.js
+++ b/src/pageScanner/checks/link-has-valid-href-or-role.js
@@ -15,26 +15,18 @@ export default {
 		const href = node.getAttribute( 'href' );
 		const role = node.getAttribute( 'role' ) || '';
 
+		// Parse roles once for efficiency (DRY principle)
+		const roles = role.toLowerCase().split( /\s+/ );
+
 		// Allow roles of button or tab
-		if (
-			role
-				.toLowerCase()
-				.split( /\s+/ )
-				.some( ( r ) => [ 'button', 'tab' ].includes( r ) )
-		) {
+		if ( roles.some( ( r ) => [ 'button', 'tab' ].includes( r ) ) ) {
 			return true;
 		}
 
 		// Allow role="menuitem" with aria-expanded (for expandable menu items)
 		// See: https://wordpress.org/support/topic/improper-use-of-link-5/
 		const hasAriaExpanded = node.hasAttribute( 'aria-expanded' );
-		if (
-			role
-				.toLowerCase()
-				.split( /\s+/ )
-				.includes( 'menuitem' ) &&
-			hasAriaExpanded
-		) {
+		if ( roles.includes( 'menuitem' ) && hasAriaExpanded ) {
 			return true;
 		}
 

--- a/tests/jest/rules/linkImproper.test.js
+++ b/tests/jest/rules/linkImproper.test.js
@@ -131,6 +131,11 @@ describe( 'Link Improper Rule', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'Passes with multiple roles including menuitem and aria-expanded',
+			html: '<a href="#" role="foo menuitem bar" aria-expanded="false">Multiple roles with menuitem</a>',
+			shouldPass: true,
+		},
+		{
 			name: 'Fails with role="menuitem" but no aria-expanded',
 			html: '<a href="#" role="menuitem">Menu without aria-expanded</a>',
 			shouldPass: false,


### PR DESCRIPTION
This pull request updates the link validation logic to better support accessibility patterns, specifically for menu items that use `role="menuitem"` and the `aria-expanded` attribute. It also adds new tests to ensure this behavior is correctly enforced.

**Accessibility logic improvements:**

* Updated the link validation rule in `link-has-valid-href-or-role.js` to allow anchor elements with `role="menuitem"` and an `aria-expanded` attribute to pass validation, supporting common expandable menu patterns.

**Test coverage:**

* Added new test cases in `linkImproper.test.js` to verify that links with `role="menuitem"` and `aria-expanded` pass validation, and that links with `role="menuitem"` but without `aria-expanded` fail validation.

Fixes: #79
Fixes: PRO-469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link accessibility validation to treat links with `menuitem` roles as valid when accompanied by `aria-expanded`, and retained existing href validation rules.

* **Tests**
  * Added test coverage for links combining `menuitem` roles with `aria-expanded` and `aria-haspopup` to ensure correct accessibility handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->