### PR TITLE
Fix: Update namespace references for Activation_Redirect class in admin files

### DIFF
--- a/admin/class-activation-redirect.php
+++ b/admin/class-activation-redirect.php
@@ -5,7 +5,7 @@
  * @package Accessibility_Checker\Admin
  */
 
-namespace EDAC\Admin;
+namespace EqualizeDigital\AccessibilityChecker\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -13,6 +13,7 @@ use EDAC\Admin\Purge_Post_Data;
 use EDAC\Admin\Post_Save;
 use EqualizeDigital\AccessibilityChecker\Admin\Upgrade_Promotion;
 use EqualizeDigital\AccessibilityChecker\Admin\Admin_Footer_Text;
+use EqualizeDigital\AccessibilityChecker\Admin\Activation_Redirect;
 
 /**
  * Admin handling class.

--- a/tests/phpunit/Admin/ActivationRedirectTest.php
+++ b/tests/phpunit/Admin/ActivationRedirectTest.php
@@ -6,12 +6,12 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use EDAC\Admin\Activation_Redirect;
+use EqualizeDigital\AccessibilityChecker\Admin\Activation_Redirect;
 
 /**
  * Class Activation_Redirect_Test
  *
- * @covers \EDAC\Admin\Activation_Redirect
+ * @covers \EqualizeDigital\AccessibilityChecker\Admin\Activation_Redirect
  */
 class ActivationRedirectTest extends WP_UnitTestCase {
 


### PR DESCRIPTION
This pull request updates the namespace for the `Activation_Redirect` class and its references throughout the codebase to ensure consistency with the new project structure. The main changes involve updating import statements and class references in both the admin and test files.

**Namespace and reference updates:**

* Changed the namespace in `class-activation-redirect.php` from `EDAC\Admin` to `EqualizeDigital\AccessibilityChecker\Admin` to align with the new naming convention.
* Updated the import and usage of `Activation_Redirect` in `class-admin.php` to use the new namespace.
* Updated the import and `@covers` annotation for `Activation_Redirect` in `ActivationRedirectTest.php` to reflect the new namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code organization and namespace structure to improve consistency across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->