### PR TITLE
Add a license page and connector activating a free license to myDot

### DIFF
--- a/admin/AdminPage/LicensePage.php
+++ b/admin/AdminPage/LicensePage.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * License Page and Notices for Accessibility Checker
+ *
+ * Handles the rendering and functionality of the license settings page
+ * in the WordPress admin, including form submission, error notices, and
+ * license status management.
+ *
+ * @package Accessibility_Checker
+ * @since 1.34.0
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage;
+
+use EqualizeDigital\AccessibilityChecker\MyDot\Connector;
+
+/**
+ * Class LicensePage
+ *
+ * Manages license page display and functionality within the admin settings area.
+ *
+ * @since 1.xx.x
+ */
+class LicensePage implements PageInterface {
+
+	/**
+	 * The capability required to access the settings page.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @var string
+	 */
+	private string $settings_capability;
+
+	/**
+	 * Constructor
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @param string $settings_capability The capability required to view/edit license settings.
+	 */
+	public function __construct( $settings_capability ) {
+		$this->settings_capability = $settings_capability;
+	}
+
+	/**
+	 * Register hooks to add the license page to the settings tabs
+	 * and handle license-related notices.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	public function add_page() {
+		// Add license tab to settings page.
+		add_filter(
+			'edac_filter_settings_tab_items',
+			[ $this, 'add_license_tab' ]
+		);
+
+		// Render license tab content when active.
+		add_action(
+			'edac_settings_tab_content',
+			[ $this, 'maybe_render_tab_content' ]
+		);
+
+		// Register admin notice display with higher priority than default.
+		add_action(
+			'in_admin_header',
+			[ $this, 'register_admin_notices' ],
+			1001
+		);
+	}
+
+	/**
+	 * Add license tab to settings tabs array.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @param array $tabs Array of registered settings tabs.
+	 *
+	 * @return array Modified tabs array with license tab added.
+	 */
+	public function add_license_tab( $tabs ) {
+		$tabs[] = [
+			'slug'       => 'license',
+			'label'      => esc_html__( 'License', 'accessibility-checker' ),
+			'order'      => 99, // License is always last tab.
+			'capability' => $this->settings_capability,
+		];
+		return $tabs;
+	}
+
+	/**
+	 * Conditionally render the license tab content if the current tab is 'license'.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @param string $settings_tab The current active settings tab.
+	 *
+	 * @return void
+	 */
+	public function maybe_render_tab_content( $settings_tab ) {
+		if ( 'license' === $settings_tab ) {
+			$this->render_page();
+		}
+	}
+
+	/**
+	 * Register the admin notices function to display license-related messages.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	public function register_admin_notices() {
+		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+	}
+
+	/**
+	 * Render the license settings page content.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	public function render_page() {
+		$license = get_option( 'edac_license_key' );
+		$status  = get_option( 'edac_license_status' );
+		?>
+		<h2><?php esc_html_e( 'License Settings', 'accessibility-checker' ); ?></h2>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<?php settings_fields( 'edac_license' ); ?>
+			<table class="form-table">
+				<tbody>
+				<tr valign="top">
+					<th scope="row" valign="top">
+						<?php esc_html_e( 'License Key', 'accessibility-checker' ); ?>
+					</th>
+					<td>
+						<input
+							id="edac_license_key"
+							name="edac_license_key"
+							type="text"
+							class="regular-text"
+							value="<?php echo esc_attr( $license ); ?>"
+						/>
+						<label class="description" for="edac_license_key">
+							<?php if ( false !== $status && 'valid' === $status ) : ?>
+								<span style="color:green;"> <?php esc_html_e( 'active', 'accessibility-checker' ); ?></span>
+							<?php elseif ( false !== $status && 'expired' === $status ) : ?>
+								<span style="color:red;"> <?php esc_html_e( 'expired', 'accessibility-checker' ); ?></span>
+							<?php else : ?>
+								<?php esc_html_e( 'Enter your license key', 'accessibility-checker' ); ?>
+							<?php endif; ?>
+						</label>
+					</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row" valign="top"></th>
+					<td>
+						<input type="hidden" name="action" value="edac_license" />
+						<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
+						<?php if ( false !== $status && 'valid' === $status ) : ?>
+							<input
+								type="submit"
+								class="button-primary"
+								name="edac_license_deactivate"
+								value="<?php esc_attr_e( 'Deactivate License', 'accessibility-checker' ); ?>"
+							>
+						<?php else : ?>
+							<input
+								type="submit"
+								class="button-primary"
+								name="edac_license_activate"
+								value="<?php esc_attr_e( 'Activate License', 'accessibility-checker' ); ?>"
+							/>
+						<?php endif; ?>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+		</form>
+		<?php
+	}
+
+	/**
+	 * Display admin notices when the license added is invalid or expired.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	public function admin_notices() {
+		$error       = get_option( 'edac_license_error' );
+		$license_url = get_bloginfo( 'url' ) . '/wp-admin/admin.php?page=accessibility_checker_settings&tab=license';
+		$message     = null;
+
+		if ( $error ) {
+			$message = $this->get_error_message( $error, $license_url );
+		}
+
+		if ( isset( $message ) ) {
+			printf(
+				'<div class="notice notice-error"><p>%s</p></div>',
+				wp_kses_post( $message )
+			);
+		}
+	}
+
+	/**
+	 * Get appropriate error message based on the license error code.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @param string $error_code The license error code.
+	 * @param string $license_url URL to the license settings page.
+	 *
+	 * @return string The formatted error message.
+	 */
+	private function get_error_message( $error_code, $license_url ) {
+		switch ( $error_code ) {
+			case 'expired':
+				return sprintf(
+				/* translators: %1$s: item name, %2$s: item name */
+					__( 'Your %1$s license has expired. <a href="https://my.equalizedigital.com/?utm_source=wpadmin" target="_blank">Please renew your license</a> to continue accessing additional features and services for %2$s.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME,
+					Connector::PRODUCT_NAME
+				);
+
+			case 'disabled':
+			case 'revoked':
+				return sprintf(
+				/* translators: %s: item name */
+					__( 'Your %s license key has been disabled. Please contact our support team if you believe this is an error or would like to continue accessing additional features.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME
+				);
+
+			case 'missing':
+				return sprintf(
+				/* translators: %1$s: item name, %2$s: license url, %3$s: item name */
+					__( 'The license key for %1$s appears to be invalid. Please <a href="%2$s">check your license key</a> to access additional accessibility features and services for %3$s.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME,
+					$license_url,
+					Connector::PRODUCT_NAME
+				);
+
+			case 'invalid':
+			case 'site_inactive':
+				return sprintf(
+				/* translators: %s: item name */
+					__( 'This license key for %s is not active for this site. Please activate it to access additional features on this website.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME
+				);
+
+			case 'item_name_mismatch':
+				return sprintf(
+				/* translators: %s: the plugins item name */
+					__( 'This license key does not appear to be valid for %s. Please verify you\'ve entered the correct license key.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME
+				);
+
+			case 'no_activations_left':
+				return sprintf(
+				/* translators: %s: the plugins item name */
+					__( 'Your %s license key has reached its site activation limit. You can upgrade your license or deactivate it on another site to use the additional features here.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME
+				);
+
+			default:
+				return sprintf(
+				/* translators: %s: the plugins item name */
+					__( 'There was an issue validating your %s license key. Please try again or contact our support team if the problem persists.', 'accessibility-checker' ),
+					Connector::PRODUCT_NAME
+				);
+		}
+	}
+}

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -65,6 +65,10 @@ class Connector {
 
 		// Admin-post handler for license activate/deactivate.
 		add_action( 'admin_post_edac_license', [ $this, 'handle_license_post' ] );
+
+		// Schedule periodic license checks.
+		add_action( 'admin_init', [ $this, 'check_license_cron' ] );
+		add_action( 'edacp_check_license_hook', [ $this, 'periodic_check_license' ] );
 	}
 
 	/**
@@ -165,7 +169,7 @@ class Connector {
 			self::API_ENDPOINT,
 			[
 				'timeout'   => 15,  // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout -- accommodation for slow hosting environments.
-				'sslverify' => false,
+				'sslverify' => self::verify_ssl(),
 				'body'      => $api_params,
 			]
 		);
@@ -212,7 +216,7 @@ class Connector {
 			self::API_ENDPOINT,
 			[
 				'timeout'   => 15, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout -- accommodation for slow hosting environments.
-				'sslverify' => false,
+				'sslverify' => self::verify_ssl(),
 				'body'      => $api_params,
 			]
 		);
@@ -228,5 +232,75 @@ class Connector {
 			delete_option( 'edac_license_status' );
 			delete_option( 'edac_license_error' );
 		}
+	}
+
+	/**
+	 * License check
+	 *
+	 * @return void
+	 */
+	public function periodic_check_license() {
+
+		if ( ! get_option( 'edac_license_key' ) ) {
+			return;
+		}
+
+		$license = trim( get_option( 'edac_license_key' ) );
+
+		$api_params = [
+			'edd_action'   => 'check_license',
+			'license'      => $license,
+			'item_id'      => self::PRODUCT_ID,
+			'item_name'    => rawurlencode( self::PRODUCT_NAME ),
+			'url'          => home_url(),
+			'environment'  => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
+			'edac_version' => defined( 'EDAC_VERSION' ) ? EDAC_VERSION : '0.0.0',
+			'wp_version'   => get_bloginfo( 'version' ),
+			'php_version'  => phpversion(),
+		];
+
+		// Call the custom API.
+		$response = wp_remote_post(
+			EDACP_STORE_URL,
+			[
+				'timeout'   => 15, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout -- 15 seconds is needed for now.
+				'sslverify' => self::verify_ssl(),
+				'body'      => $api_params,
+			]
+		);
+		if ( is_wp_error( $response ) ) {
+			// this is a silent failure, we should log this or flag it somehow.
+			return;
+		}
+
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( 'valid' !== $license_data->license ) {
+			update_option( 'edacp_license_status', $license_data->license );
+		}
+	}
+
+	/**
+	 * License check cron schedule
+	 *
+	 * @return void
+	 */
+	public function check_license_cron() {
+		if ( ! wp_next_scheduled( 'edacp_check_license_hook' ) ) {
+			wp_schedule_event( time(), 'daily', 'edacp_check_license_hook' );
+		}
+	}
+
+	/**
+	 * Determines whether to verify SSL for licensing requests.
+	 *
+	 * Can be disabled by returning `false` to the `edacp_verify_ssl_for_licensing` filter.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return bool Whether to verify SSL. Defaults to `true`.
+	 */
+	public static function verify_ssl() {
+		return (bool) apply_filters( 'edac_verify_ssl_for_licensing', true );
 	}
 }

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * MyDot Connector Class
+ *
+ * Provides connection and product information for MyDot license management integration.
+ *
+ * @package Accessibility_Checker
+ * @since 1.xx.x
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\MyDot;
+
+/**
+ * Class Connector
+ *
+ * Handles MyDot product and license integration constants and utilities.
+ *
+ * @since 1.xx.x
+ */
+class Connector {
+
+	/**
+	 * The product name used in MyDot licensing system.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @var string
+	 */
+	const PRODUCT_NAME = 'Accessibility Checker Free';
+
+	/**
+	 * The MyDot API endpoint for license validation.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @var string
+	 */
+	const API_ENDPOINT = 'http://my.equalizedigital.local';
+
+	/**
+	 * The product ID used in MyDot licensing system.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @var int
+	 */
+	const PRODUCT_ID = 1666;
+
+	/**
+	 * Sets up the license page and handlers if EDACP is not active.
+	 *
+	 * @since 1.xx.x
+	 */
+	public function init() {
+		// set up the license page file if EDACP is not active.
+		if ( defined( 'EDACP_VERSION' ) ) {
+			return;
+		}
+
+		$license = new \EqualizeDigital\AccessibilityChecker\Admin\AdminPage\LicensePage( 'administrator' );
+		$license->add_page();
+
+		// Ensure the license options group is registered so options.php allows saves.
+		add_action( 'admin_init', [ $this, 'register_license_settings' ] );
+
+		// Admin-post handler for license activate/deactivate.
+		add_action( 'admin_post_edac_license', [ $this, 'handle_license_post' ] );
+	}
+
+	/**
+	 * Register license settings so the edac_license group is allowed by options.php.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	public function register_license_settings() {
+		register_setting(
+			'edac_license',
+			'edac_license_key',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			]
+		);
+
+		register_setting(
+			'edac_license',
+			'edac_license_status',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			]
+		);
+
+		register_setting(
+			'edac_license',
+			'edac_license_error',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			]
+		);
+	}
+
+	/**
+	 * Handle license activate/deactivate from admin-post.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	public function handle_license_post() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage this license.', 'accessibility-checker' ) );
+		}
+
+		check_admin_referer( 'edac_license_nonce', 'edac_license_nonce' );
+
+		// Normalize license key from the form.
+		if ( isset( $_POST['edac_license_key'] ) ) {
+			$license = sanitize_text_field( wp_unslash( $_POST['edac_license_key'] ) );
+			update_option( 'edac_license_key', $license );
+		}
+
+		if ( isset( $_POST['edac_license_activate'] ) ) {
+			$this->activate_license();
+		} elseif ( isset( $_POST['edac_license_deactivate'] ) ) {
+			$this->deactivate_license();
+		}
+
+		$redirect = wp_get_referer();
+		if ( ! $redirect ) {
+			$redirect = admin_url();
+		}
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Activate the license via API and store status/error.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	private function activate_license() {
+		$license = trim( get_option( 'edac_license_key' ) );
+		if ( empty( $license ) ) {
+			update_option( 'edac_license_error', 'missing' );
+			return;
+		}
+
+		$api_params = [
+			'edd_action'  => 'activate_license',
+			'license'     => $license,
+			'item_name'   => rawurlencode( self::PRODUCT_NAME ),
+			'url'         => home_url(),
+			'environment' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
+			'wp_version'  => get_bloginfo( 'version' ),
+			'php_version' => phpversion(),
+		];
+
+		$response = wp_remote_post(
+			self::API_ENDPOINT,
+			[
+				'timeout'   => 15,  // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout -- accommodation for slow hosting environments.
+				'sslverify' => false,
+				'body'      => $api_params,
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$message = is_wp_error( $response ) ? $response->get_error_message() : esc_html__( 'An error occurred, please try again.', 'accessibility-checker' );
+			update_option( 'edac_license_error', $message );
+			return;
+		}
+
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( isset( $license_data->error ) ) {
+			update_option( 'edac_license_error', $license_data->error );
+			update_option( 'edac_license_status', $license_data->license ?? '' );
+			return;
+		}
+
+		delete_option( 'edac_license_error' );
+		update_option( 'edac_license_status', $license_data->license ?? '' );
+	}
+
+	/**
+	 * Deactivate the license via API and clear stored values on success.
+	 *
+	 * @since 1.xx.x
+	 *
+	 * @return void
+	 */
+	private function deactivate_license() {
+		$license = trim( get_option( 'edac_license_key' ) );
+		if ( empty( $license ) ) {
+			return;
+		}
+
+		$api_params = [
+			'edd_action' => 'deactivate_license',
+			'license'    => $license,
+			'item_name'  => rawurlencode( self::PRODUCT_NAME ),
+			'url'        => home_url(),
+		];
+
+		$response = wp_remote_post(
+			self::API_ENDPOINT,
+			[
+				'timeout'   => 15, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout -- accommodation for slow hosting environments.
+				'sslverify' => false,
+				'body'      => $api_params,
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return;
+		}
+
+		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( isset( $license_data->license ) && 'deactivated' === $license_data->license ) {
+			delete_option( 'edac_license_key' );
+			delete_option( 'edac_license_status' );
+			delete_option( 'edac_license_error' );
+		}
+	}
+}

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -10,6 +10,7 @@ namespace EDAC\Inc;
 use EDAC\Admin\Admin;
 use EDAC\Admin\Meta_Boxes;
 use EDAC\Admin\Orphaned_Issues_Cleanup;
+use EqualizeDigital\AccessibilityChecker\MyDot\Connector;
 use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
@@ -42,6 +43,9 @@ class Plugin {
 		$cleanup->init_hooks();
 
 		$this->register_fixes_manager();
+
+		$connector = new Connector();
+		$connector->init();
 
 		// When WP CLI is enabled, load the CLI commands.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
This adds a page to enter a license key in the free plugin, enabling connection to our myDot site for additional services not offered in the plugin.

It contains no update logic, and no code is sent from the service for execution. This verifies that a license key exists in our service, nothing in the plugin is gated behind it, and users are not required to fill it in unless they want to make use of the services from the myDot site.

Easily accessible terms will be added before this is released that show what is sent and why.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new License settings tab in the admin area with activation and deactivation capabilities.
  * Displays current license status with detailed error messages and automatic periodic license validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->