### PR TITLE
Fix selected scan speed option value being reflected

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -413,7 +413,7 @@ function edac_full_site_scan_speed_cb() {
 			<?php foreach ( $speed_values as $value => $label ) : ?>
 				<option
 					value="<?php echo esc_attr( $value ); ?>"
-					<?php selected( $full_site_scan_speed, (int) $value, false ); ?>
+					<?php selected( $full_site_scan_speed, (int) $value ); ?>
 				>
 					<?php echo esc_html( $label ); ?>
 				</option>


### PR DESCRIPTION
A UI bug was blocking the output of the 'selected' attribute on the scan speed select box when the pro plugin was enabled. This PR changes the line to remove the 3rd parameter passed to `selected()` letting it echo.

Fixes: #1313 

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the selected scan speed option was not displaying correctly in the dropdown menu.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->