### PR TITLE
Add PHPUnit coverage for UTC datetime helper

### DIFF
--- a/tests/phpunit/helper-functions/FormatDatetimeFromUtcTest.php
+++ b/tests/phpunit/helper-functions/FormatDatetimeFromUtcTest.php
@@ -83,10 +83,10 @@ class FormatDatetimeFromUtcTest extends WP_UnitTestCase {
 	 */
 	public function provider_valid_datetime_values(): array {
 		return [
-			'New York (DST)'        => [ 'America/New_York', '2024-07-01 12:00:00', '2024-07-01 08:00' ],
-			'New York (Standard)'   => [ 'America/New_York', '2024-01-01 12:00:00', '2024-01-01 07:00' ],
-			'London (DST)'          => [ 'Europe/London', '2024-07-01 12:00:00', '2024-07-01 13:00' ],
-			'London (Standard)'     => [ 'Europe/London', '2024-01-01 12:00:00', '2024-01-01 12:00' ],
+			'New York (DST)'      => [ 'America/New_York', '2024-07-01 12:00:00', '2024-07-01 08:00' ],
+			'New York (Standard)' => [ 'America/New_York', '2024-01-01 12:00:00', '2024-01-01 07:00' ],
+			'London (DST)'        => [ 'Europe/London', '2024-07-01 12:00:00', '2024-07-01 13:00' ],
+			'London (Standard)'   => [ 'Europe/London', '2024-01-01 12:00:00', '2024-01-01 12:00' ],
 		];
 	}
 


### PR DESCRIPTION
### Motivation
- Ensure the `edac_format_datetime_from_utc` helper has unit coverage to validate timezone conversion behavior.
- Guard against regressions when formatting UTC datetimes for display in the WordPress timezone.
- Verify handling of invalid and sentinel datetime values so the function returns a stable empty result when appropriate.

### Description
- Add `tests/phpunit/helper-functions/FormatDatetimeFromUtcTest.php` with `@covers ::edac_format_datetime_from_utc` to provide focused unit tests.
- Implement `setUp` and `tearDown` to save and restore the `date_format`, `time_format`, and `timezone_string` options.
- Add `test_edac_format_datetime_from_utc_formats_output` which asserts `edac_format_datetime_from_utc('2024-07-01 12:00:00')` yields `2024-07-01 08:00` for the `America/New_York` timezone.
- Add `provider_invalid_datetime_values` and `test_edac_format_datetime_from_utc_invalid_values` to assert empty-string output for invalid inputs such as `''`, `'0000-00-00 00:00:00'`, and malformed dates.

### Testing
- No automated tests were executed as part of this change (PHPUnit not run).
- The change only adds the test file `tests/phpunit/helper-functions/FormatDatetimeFromUtcTest.php` for subsequent CI or local test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654537a3988328aa0b8e025b625728)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for UTC-to-local date/time formatting, verifying correct output across multiple date/time formats and timezones, and ensuring robust handling of various invalid inputs to improve reliability and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->