### PR TITLE
Fix date in readme and changelog to use correct date and format

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Accessibility Checker ***
 
-2025-15-22 - version 1.36.0
+2025-12-15 - version 1.36.0
 * Fix - passed tests percentage logic now accounts times no posts are scanned
 * Fix - don't prevent scan speed saving when pro plugin is enabled.
 * Add - new trigger for invalid alt text - "an image".

--- a/readme.txt
+++ b/readme.txt
@@ -211,7 +211,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-2025-15-22 - version 1.36.0
+2025-12-15 - version 1.36.0
 * Fix - passed tests percentage logic now accounts times no posts are scanned
 * Fix - don't prevent scan speed saving when pro plugin is enabled.
 * Add - new trigger for invalid alt text - "an image".


### PR DESCRIPTION
The date in the readme and the changelog were formatted in the wrong order and had the wrong number. This PR solves that.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected release date for version 1.36.0
  * Documented enhanced link validation supporting additional ARIA attributes
  * Documented welcome screen display on plugin activation for improved onboarding

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->