### PR TITLE
Add PHPUnit coverage for table name validation helper

### DIFF
--- a/tests/phpunit/helper-functions/GetValidTableNameTest.php
+++ b/tests/phpunit/helper-functions/GetValidTableNameTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class GetValidTableNameTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Test cases for edac_get_valid_table_name() function.
+ */
+class GetValidTableNameTest extends WP_UnitTestCase {
+
+	/**
+	 * Tests edac_get_valid_table_name with invalid and valid table names.
+	 */
+	public function test_edac_get_valid_table_name() {
+		global $wpdb;
+
+		$this->assertNull( edac_get_valid_table_name( 'wp_posts; DROP TABLE wp_users' ) );
+
+		$missing_table = $wpdb->prefix . 'edac_missing_table';
+		$this->assertNull( edac_get_valid_table_name( $missing_table ) );
+
+		$valid_table = $wpdb->posts;
+		$this->assertSame( $valid_table, edac_get_valid_table_name( $valid_table ) );
+	}
+}


### PR DESCRIPTION
### Motivation
- Add unit tests for `edac_get_valid_table_name` to verify input validation and database existence checks.
- Ensure malicious inputs (e.g. SQL injection-like strings) are rejected and return `null`.
- Confirm that non-existent tables return `null` while known valid tables are accepted.
- Improve PHPUnit coverage for helper functions in `includes/helper-functions.php`.

### Description
- Add `tests/phpunit/helper-functions/GetValidTableNameTest.php` which defines `GetValidTableNameTest` extending `WP_UnitTestCase`.
- The test asserts `null` for a malicious input string, `null` for a missing table constructed from `$wpdb->prefix . 'edac_missing_table'`, and equality for a valid table using `$wpdb->posts`.
- The test uses `global $wpdb` and `assertNull`/`assertSame` assertions to validate the helper's behavior.
- No production code was modified; only the new test file was added.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965562d27648328a7840f4547c7507b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for table name validation functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->