### PR TITLE
Add @since tag to UTC datetime PHPUnit test

### DIFF
--- a/tests/phpunit/helper-functions/GetCurrentUtcDatetimeTest.php
+++ b/tests/phpunit/helper-functions/GetCurrentUtcDatetimeTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Class GetCurrentUtcDatetimeTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Tests for edac_get_current_utc_datetime().
+ *
+ * @since 1.35.0
+ */
+class GetCurrentUtcDatetimeTest extends WP_UnitTestCase {
+
+	/**
+	 * Tests the edac_get_current_utc_datetime function.
+	 */
+	public function test_edac_get_current_utc_datetime() {
+		$datetime = edac_get_current_utc_datetime();
+
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+			$datetime
+		);
+
+		$timestamp = strtotime( $datetime . ' UTC' );
+		$this->assertNotFalse( $timestamp );
+		$this->assertLessThanOrEqual( 5, abs( time() - $timestamp ) );
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure the PHPUnit test for the UTC datetime helper is documented with a version tag for release tracking.
- Make it clear when the `edac_get_current_utc_datetime` test was introduced for maintainers and changelogs.

### Description
- Added an `@since 1.35.0` tag to the docblock of the test in `tests/phpunit/helper-functions/GetCurrentUtcDatetimeTest.php`.
- The test file exercises `edac_get_current_utc_datetime()` and asserts the returned string matches the MySQL datetime format and parses to a valid timestamp.
- The test also asserts the parsed timestamp is within 5 seconds of `time()` to ensure recency.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69668ebc9908832886a63e70ce3c36f0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test suite for UTC datetime retrieval functionality to ensure correct format and timing accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->