### PR TITLE
Refactor GitHub token usage across some CI files to have fallback

### DIFF
--- a/.github/workflows/code-coverage-and-coveralls.yml
+++ b/.github/workflows/code-coverage-and-coveralls.yml
@@ -28,9 +28,9 @@ jobs:
       with:
         php-version: '7.4'
         coverage: xdebug
-        github-token: ${{ secrets.PUBLIC_REPO_ACCESS }}
+        github-token: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
       env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS }}
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -32,9 +32,9 @@ jobs:
           php-version: '7.4'
           coverage: none
           tools: cs2pr
-          github-token: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          github-token: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
-          github-token: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          github-token: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
 
       # The lint stage doesn't run the unit tests or use code style, so no need for PHPUnit, WPCS or phpcompatibility.
       - name: 'Composer: adjust dependencies - remove PHPUnit'
@@ -70,7 +70,7 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
           tools: cs2pr
-          github-token: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          github-token: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
 
       - name: Lint against parse errors
         id: lint_with_cs2pr

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     env:
-      COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.PUBLIC_REPO_ACCESS }}"}}'
+      COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}"}}'
 
     strategy:
       fail-fast: false
@@ -63,12 +63,12 @@ jobs:
           php-version: ${{ matrix.php_version }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
-          github-token: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          github-token: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
 
       - name: Configure Composer to use PAT
-        run: composer config --global --auth github-oauth.github.com ${{ secrets.PUBLIC_REPO_ACCESS }}
+        run: composer config --global --auth github-oauth.github.com ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -84,9 +84,9 @@ jobs:
           composer-options: "yoast/wp-test-utils --with-dependencies"
           # Bust the cache at least once a month - output format: YYYY-MM-DD.
           custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-3)) days" "+%F")
-          github-token: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          github-token: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS || secrets.GITHUB_TOKEN }}
       # Some images won't have svn available. Install it if that's the case.
       - name: Install SVN
         run: |


### PR DESCRIPTION
For PRs that come from forks the runner own GITHUB_TOKEN gets used since the private repo secret PUBLIC_REPO_ACCESS is not available.

[PRO-545]

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to implement fallback authentication mechanisms, improving resilience and reliability of automated testing and deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->