### PR TITLE
Strip inline "Exit if accessed directly" comments from ABSPATH guards

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -8,7 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Admin\AdminPage;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-activation-redirect.php
+++ b/admin/class-activation-redirect.php
@@ -8,7 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-admin-footer-text.php
+++ b/admin/class-admin-footer-text.php
@@ -8,7 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -10,7 +10,7 @@ namespace EDAC\Admin;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -16,7 +16,7 @@ use EqualizeDigital\AccessibilityChecker\Admin\Admin_Footer_Text;
 use EqualizeDigital\AccessibilityChecker\Admin\Activation_Redirect;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -13,7 +13,7 @@ use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -11,7 +11,7 @@ use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-meta-boxes.php
+++ b/admin/class-meta-boxes.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-orphaned-issues-cleanup.php
+++ b/admin/class-orphaned-issues-cleanup.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-plugin-row-meta.php
+++ b/admin/class-plugin-row-meta.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -9,7 +9,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-upgrade-promotion.php
+++ b/admin/class-upgrade-promotion.php
@@ -8,7 +8,7 @@
 namespace EqualizeDigital\AccessibilityChecker\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/class-widgets.php
+++ b/admin/class-widgets.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/opt-in/class-email-opt-in.php
+++ b/admin/opt-in/class-email-opt-in.php
@@ -8,7 +8,7 @@
 namespace EDAC\Admin\OptIn;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/site-health/class-checks.php
+++ b/admin/site-health/class-checks.php
@@ -12,7 +12,7 @@ use EDAC\Admin\Scans_Stats;
 use EDAC\Admin\Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/admin/site-health/class-information.php
+++ b/admin/site-health/class-information.php
@@ -9,7 +9,7 @@
 namespace EDAC\Admin\SiteHealth;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -8,7 +8,7 @@
 use EDAC\Admin\Accessibility_Statement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
+++ b/includes/classes/Fixes/Fix/AddFileSizeAndTypeToLinkedFilesFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
+++ b/includes/classes/Fixes/Fix/AddLabelToUnlabelledFormFieldsFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
+++ b/includes/classes/Fixes/Fix/AddMissingOrEmptyPageTitleFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
+++ b/includes/classes/Fixes/Fix/BlockPDFUploadsFix.php
@@ -12,7 +12,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
+++ b/includes/classes/Fixes/Fix/CommentSearchLabelFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/FocusOutlineFix.php
+++ b/includes/classes/Fixes/Fix/FocusOutlineFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
+++ b/includes/classes/Fixes/Fix/HTMLLangAndDirFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/LinkUnderline.php
+++ b/includes/classes/Fixes/Fix/LinkUnderline.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/MetaViewportScalableFix.php
+++ b/includes/classes/Fixes/Fix/MetaViewportScalableFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
+++ b/includes/classes/Fixes/Fix/PreventLinksOpeningNewWindowFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -11,7 +11,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
+++ b/includes/classes/Fixes/Fix/RemoveTitleIfPrefferedAccessibleNameFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/SkipLinkFix.php
+++ b/includes/classes/Fixes/Fix/SkipLinkFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/Fix/TabindexFix.php
+++ b/includes/classes/Fixes/Fix/TabindexFix.php
@@ -10,7 +10,7 @@ namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -25,7 +25,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ReadMoreAddTitleFix;
 use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/class-accessibility-statement.php
+++ b/includes/classes/class-accessibility-statement.php
@@ -8,7 +8,7 @@
 namespace EDAC\Inc;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/class-admin-toolbar.php
+++ b/includes/classes/class-admin-toolbar.php
@@ -8,7 +8,7 @@
 namespace EDAC\Inc;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/class-lazyload-filter.php
+++ b/includes/classes/class-lazyload-filter.php
@@ -8,7 +8,7 @@
 namespace EDAC\Inc;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/class-plugin.php
+++ b/includes/classes/class-plugin.php
@@ -14,7 +14,7 @@ use EqualizeDigital\AccessibilityChecker\WPCLI\BootstrapCLI;
 use EqualizeDigital\AccessibilityChecker\Fixes\FixesManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -13,7 +13,7 @@ use EDAC\Admin\Settings;
 use EDAC\Admin\Purge_Post_Data;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/classes/class-simplified-summary.php
+++ b/includes/classes/class-simplified-summary.php
@@ -8,7 +8,7 @@
 namespace EDAC\Inc;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/deactivation.php
+++ b/includes/deactivation.php
@@ -8,7 +8,7 @@
 use EDAC\Admin\Orphaned_Issues_Cleanup;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/deprecated/deprecated.php
+++ b/includes/deprecated/deprecated.php
@@ -11,7 +11,7 @@ use EDAC\Admin\Purge_Post_Data;
 use EDAC\Admin\Post_Save;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 // Deprecated constants.

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -8,7 +8,7 @@
 use EDAC\Admin\Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -12,7 +12,7 @@ use EDAC\Inc\Accessibility_Statement;
 use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/includes/wcag.php
+++ b/includes/wcag.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 return [

--- a/partials/admin-page/fixes-page.php
+++ b/partials/admin-page/fixes-page.php
@@ -8,7 +8,7 @@
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddNewWindowWarningFix;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 ?>

--- a/partials/custom-meta-box.php
+++ b/partials/custom-meta-box.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 // get the post type of the current editor page.

--- a/partials/pro-callout.php
+++ b/partials/pro-callout.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 ?>

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 /**

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -8,7 +8,7 @@
 use EDAC\Admin\Welcome_Page;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 ?>


### PR DESCRIPTION
### Motivation
- Remove redundant inline comments from ABSPATH guard exits to keep guard statements concise and consistent across the codebase.
- Apply a uniform style for top-of-file WordPress safety checks in `admin/`, `includes/`, and `partials/` areas to reduce noise in diffs and reviews.

### Description
- Replaced occurrences of `exit; // Exit if accessed directly.` with a plain `exit;` in ~50 PHP files under `admin/`, `includes/`, and `partials/` (including many `includes/classes/Fixes/Fix/*` files). 
- Affected files include admin pages, REST/API classes, activation/deactivation hooks, helper functions, partial templates, and multiple fix classes used by the plugin. 
- Ensured the project-level `package-lock.json` changes were not included in this PR by reverting those changes before finalizing the update. 

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698605095f048328b32928ac7005a303)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed inline comments from direct-access protection statements across 46+ files throughout the codebase. No functional or behavioral changes; security protections remain identical. This standardizes code formatting by simplifying exit statements while preserving their protective functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->