### PR TITLE
Prefix globals in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -11,8 +11,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 // check if the delte data option is checked. If not, don't delete data.
-$delete_data = get_option( 'edac_delete_data' );
-if ( true === (bool) $delete_data ) {
+$edac_delete_data = get_option( 'edac_delete_data' );
+if ( true === (bool) $edac_delete_data ) {
 
 	// drop database.
 	global $wpdb;
@@ -21,7 +21,7 @@ if ( true === (bool) $delete_data ) {
 	$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $wpdb->prefix . 'accessibility_checker' ) );
 
 	// delete options.
-	$options     = [
+	$edac_options     = [
 		'edac_db_version',
 		'edac_activation_date',
 		'edac_simplified_summary_position',
@@ -39,7 +39,7 @@ if ( true === (bool) $delete_data ) {
 		'edac_black_friday_2024_notice_dismiss',
 		'edac_black_friday_2025_notice_dismiss',
 	];
-	$fix_options = [
+	$edac_fix_options = [
 		'edac_add_label_to_unlabeled_form_fields',
 		'edac_add_label_to_unlabelled_form_fields',
 		'edac_fix_add_file_size_and_type_to_linked_files',
@@ -68,10 +68,10 @@ if ( true === (bool) $delete_data ) {
 		'edac_fix_new_window_warning',
 	];
 
-	$options_to_clear = array_merge( $options, $fix_options );
+	$edac_options_to_clear = array_merge( $edac_options, $edac_fix_options );
 
-	foreach ( $options_to_clear as $option ) {
-		delete_option( $option );
-		delete_site_option( $option );
+	foreach ( $edac_options_to_clear as $edac_option ) {
+		delete_option( $edac_option );
+		delete_site_option( $edac_option );
 	}
 }


### PR DESCRIPTION
### Motivation
- Prefix uninstall-script global variables with the plugin prefix to satisfy WordPress naming conventions and remove static analysis warnings.

### Description
- Renamed globals in `uninstall.php`: ` $delete_data` → ` $edac_delete_data`, ` $options` → ` $edac_options`, ` $fix_options` → ` $edac_fix_options`, ` $options_to_clear` → ` $edac_options_to_clear`, and loop variable ` $option` → ` $edac_option`, and updated uses including the `array_merge` call.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986455a86988328ad89cb31490a2f8d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and variable naming consistency improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->