### PR TITLE
Prefix virtual page flag variable

### DIFF
--- a/partials/custom-meta-box.php
+++ b/partials/custom-meta-box.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // get the post type of the current editor page.
-$is_virtual_page = edac_is_virtual_page( get_the_ID() );
+$edac_is_virtual_page = edac_is_virtual_page( get_the_ID() );
 
 ?>
 <div id="edac-tabs">
@@ -38,7 +38,7 @@ $is_virtual_page = edac_is_virtual_page( get_the_ID() );
 					<?php esc_html_e( 'Details', 'accessibility-checker' ); ?>
 				</button>
 			</li>
-			<li class="edac-tab" <?php echo $is_virtual_page ? 'style="display: none;"' : ''; ?>>
+			<li class="edac-tab" <?php echo $edac_is_virtual_page ? 'style="display: none;"' : ''; ?>>
 				<button
 					role="tab"
 					aria-selected="false"


### PR DESCRIPTION
### Motivation
- Prefix the global virtual page flag to comply with WordPress naming conventions and remove the PHPCS warning `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound` for `$is_virtual_page`.

### Description
- Rename `$is_virtual_page` to `$edac_is_virtual_page` in `partials/custom-meta-box.php` and update its single usage so the Readability tab is conditionally hidden for virtual pages, with no functional change.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986461ef5408328b7c646ed7681b377)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated conditional logic for Details tab visibility on virtual pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->