### PR TITLE
Prefix settings page tab variables

### DIFF
--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -14,9 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.4.0
  *
- * @param array $settings_tab_items The settings tab items as an array of arrays. Needs a 'slug', 'label', and 'order'.
+ * @param array $edac_settings_tab_items The settings tab items as an array of arrays. Needs a 'slug', 'label', and 'order'.
  */
-$settings_tab_items = apply_filters(
+$edac_settings_tab_items = apply_filters(
 	'edac_filter_settings_tab_items',
 	[
 		[
@@ -28,9 +28,9 @@ $settings_tab_items = apply_filters(
 );
 
 // sort settings tab items.
-if ( is_array( $settings_tab_items ) ) {
+if ( is_array( $edac_settings_tab_items ) ) {
 	usort(
-		$settings_tab_items,
+		$edac_settings_tab_items,
 		function ( $a, $b ) {
 			if ( $a['order'] < $b['order'] ) {
 				return -1;
@@ -44,17 +44,17 @@ if ( is_array( $settings_tab_items ) ) {
 }
 
 // Null represents the default tab (empty slug) in the navigation logic.
-$default_tab = null;
+$edac_default_tab = null;
 
 // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce verification not required for tab display.
 if ( isset( $_GET['tab'] ) ) {
-	$settings_tab = sanitize_key( wp_unslash( $_GET['tab'] ) );
+	$edac_settings_tab = sanitize_key( wp_unslash( $_GET['tab'] ) );
 } else {
-	$settings_tab = $default_tab;
+	$edac_settings_tab = $edac_default_tab;
 }
 // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-$settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items, 'slug' ), true ) !== false ) ? $settings_tab : $default_tab;
+$edac_settings_tab = ( array_search( $edac_settings_tab, array_column( $edac_settings_tab_items, 'slug' ), true ) !== false ) ? $edac_settings_tab : $edac_default_tab;
 ?>
 
 <div class="wrap edac-settings <?php echo EDAC_KEY_VALID ? '' : 'pro-callout-wrapper'; ?>">
@@ -62,22 +62,22 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
 	<?php
-	if ( $settings_tab_items ) {
+	if ( $edac_settings_tab_items ) {
 		echo '<nav class="nav-tab-wrapper" aria-label="Settings Tabs">';
-		foreach ( $settings_tab_items as $settings_tab_item ) {
-			$slug      = $settings_tab_item['slug'] ? $settings_tab_item['slug'] : null;
-			$query_var = $slug ? '&tab=' . $slug : '';
-			$label     = $settings_tab_item['label'];
+		foreach ( $edac_settings_tab_items as $edac_settings_tab_item ) {
+			$edac_slug      = $edac_settings_tab_item['slug'] ? $edac_settings_tab_item['slug'] : null;
+			$edac_query_var = $edac_slug ? '&tab=' . $edac_slug : '';
+			$edac_label     = $edac_settings_tab_item['label'];
 			?>
 			<a
 			<?php
-			if ( $settings_tab === $slug ) :
+			if ( $edac_settings_tab === $edac_slug ) :
 				?>
-				aria-current="true" <?php endif; ?>href="?page=accessibility_checker_settings<?php echo esc_html( $query_var ); ?>" class="nav-tab
+				aria-current="true" <?php endif; ?>href="?page=accessibility_checker_settings<?php echo esc_html( $edac_query_var ); ?>" class="nav-tab
 				<?php
-				if ( $settings_tab === $slug ) :
+				if ( $edac_settings_tab === $edac_slug ) :
 					?>
-				nav-tab-active<?php endif; ?>"><?php echo esc_html( $label ); ?></a>
+				nav-tab-active<?php endif; ?>"><?php echo esc_html( $edac_label ); ?></a>
 			<?php
 		}
 		echo '</nav>';
@@ -86,7 +86,7 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 
 	<div class="tab-content">
 
-		<?php if ( null === $settings_tab ) { ?>
+		<?php if ( null === $edac_settings_tab ) { ?>
 			<div class="edac-settings-general
 			<?php
 			if ( EDAC_KEY_VALID === false ) {
@@ -117,7 +117,7 @@ $settings_tab = ( array_search( $settings_tab, array_column( $settings_tab_items
 		 *
 		 * @param string $settings_tab The current settings tab.
 		 */
-		do_action( 'edac_settings_tab_content', $settings_tab );
+		do_action( 'edac_settings_tab_content', $edac_settings_tab );
 		?>
 	</div>
 


### PR DESCRIPTION
### Motivation
- Address WordPress naming-convention warnings and avoid unprefixed globals by namespacing settings tab variables used in the settings page navigation and content.

### Description
- Rename settings tab variables in `partials/settings-page.php` from `settings_tab_items`, `default_tab`, `settings_tab`, `settings_tab_item`, `slug`, `query_var`, and `label` to `edac_settings_tab_items`, `edac_default_tab`, `edac_settings_tab`, `edac_settings_tab_item`, `edac_slug`, `edac_query_var`, and `edac_label` respectively, and update the docblock and `do_action` call to use the prefixed names.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698646596c1483288977e6e911c48906)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->