### PR TITLE
Prefix local variables in welcome page template

### DIFF
--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -22,18 +22,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<h1 class="edac-welcome-title">
 					<?php
 					if ( defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID === true ) {
-						$welcome_title = __( 'Accessibility Checker Pro', 'accessibility-checker' );
-						$version       = EDACP_VERSION;
+						$edac_welcome_title = __( 'Accessibility Checker Pro', 'accessibility-checker' );
+						$edac_version       = EDACP_VERSION;
 					} else {
-						$welcome_title = __( 'Accessibility Checker', 'accessibility-checker' );
-						$version       = EDAC_VERSION;
+						$edac_welcome_title = __( 'Accessibility Checker', 'accessibility-checker' );
+						$edac_version       = EDAC_VERSION;
 					}
 
 					printf(
 						'%1$s <span class="edac-welcome-header-version">%2$s %3$s</span>',
-						esc_html( $welcome_title ),
+						esc_html( $edac_welcome_title ),
 						esc_html__( 'version', 'accessibility-checker' ),
-						esc_html( $version )
+						esc_html( $edac_version )
 					);
 					?>
 				</h1>
@@ -235,8 +235,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	?>
 
 		<?php
-		$meetup_html = edac_get_upcoming_meetups_html( 'wordpress-accessibility-meetup-group', 2 );
-		if ( ! empty( $meetup_html ) ) :
+		$edac_meetup_html = edac_get_upcoming_meetups_html( 'wordpress-accessibility-meetup-group', 2 );
+		if ( ! empty( $edac_meetup_html ) ) :
 			?>
 			<div class="edac-panel">
 				<h2 class="edac-summary-header">
@@ -244,7 +244,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</h2>
 				<?php
 				//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- content is being escaped as it is being produced, late escaping would be more complicated and unreadable
-				echo $meetup_html;
+				echo $edac_meetup_html;
 				?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
### Motivation
- Address PHPCS warnings about non-prefixed globals by namespacing local variables used in the welcome page template to avoid accidental global collisions and comply with WordPress naming conventions.

### Description
- Rename the local variables `$welcome_title`, `$version`, and `$meetup_html` to ` $edac_welcome_title`, ` $edac_version`, and ` $edac_meetup_html` respectively, and update their usages in `partials/welcome-page.php` so output behavior remains unchanged.

### Testing
- No automated tests were run for this change; the file was inspected and committed after verifying the substitutions preserved the original output logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698647089b6c83289584bfef2cea353f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal variable naming conventions across the welcome page for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->