### PR TITLE
Fix prepared queries in summary counts

### DIFF
--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -164,17 +164,16 @@ class Summary_Generator {
 	private function count_warnings() {
 		global $wpdb;
 
-		$warnings_parameters = [ get_current_blog_id(), $this->post_id, 'warning', 0 ];
-		$warnings_where      = 'WHERE siteid = %d and postid = %d and ruletype = %s and ignre = %d';
+		$warnings_parameters = [ $wpdb->prefix . 'accessibility_checker', get_current_blog_id(), $this->post_id, 'warning', 0 ];
+		$warnings_query      = 'SELECT count(*) FROM %i WHERE siteid = %d and postid = %d and ruletype = %s and ignre = %d';
 		if ( defined( 'ANWW_VERSION' ) ) {
 			array_push( $warnings_parameters, 'link_blank' );
-			$warnings_where .= ' and rule != %s';
+			$warnings_query .= ' and rule != %s';
 		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
 		$warnings_count = $wpdb->get_var(
 			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-				'SELECT count(*) FROM ' . $wpdb->prefix . 'accessibility_checker ' . $warnings_where,
+				$warnings_query,
 				$warnings_parameters
 			)
 		);
@@ -193,18 +192,17 @@ class Summary_Generator {
 	private function count_ignored() {
 		global $wpdb;
 
-		$ignored_parameters = [ get_current_blog_id(), $this->post_id, 1 ];
-		$ignored_where      = 'WHERE siteid = %d and postid = %d and ignre = %d';
+		$ignored_parameters = [ $wpdb->prefix . 'accessibility_checker', get_current_blog_id(), $this->post_id, 1 ];
+		$ignored_query      = 'SELECT count(*) FROM %i WHERE siteid = %d and postid = %d and ignre = %d';
 		if ( defined( 'ANWW_VERSION' ) ) {
 			array_push( $ignored_parameters, 'link_blank' );
-			$ignored_where .= ' and rule != %s';
+			$ignored_query .= ' and rule != %s';
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
 		$ignored_count = $wpdb->get_var(
 			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared , WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-				"SELECT count(*) FROM {$wpdb->prefix}accessibility_checker $ignored_where",
+				$ignored_query,
 				$ignored_parameters
 			)
 		);


### PR DESCRIPTION
### Motivation
- Prevent unsafe concatenation in prepared SQL for warning/ignored counts and ensure the table identifier and placeholders are bound correctly.

### Description
- Updated `includes/classes/class-summary-generator.php` to build full prepared query strings (using `%i` for the table) and include the table name in the parameters for `count_warnings()` and `count_ignored()` instead of concatenating `WHERE` fragments.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698648dac5948328bbbf7e915b95f80a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal query handling for enhanced consistency and reliability of warning and ignored item counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->