### PR TITLE
Use full plugin name for sidebar title accessibility checker

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -71,7 +71,7 @@ function AccessibilityCheckerSidebar() {
 	return (
 		<PluginSidebar
 			name="accessibility-checker-sidebar"
-			title={ __( 'Accessibility', 'accessibility-checker' ) }
+			title={ __( 'Accessibility Checker', 'accessibility-checker' ) }
 			icon="universal-access"
 		>
 			<SidebarContent />


### PR DESCRIPTION
This pull request makes a small change to the sidebar title to improve clarity for users.

* Changed the sidebar title from "Accessibility" to "Accessibility Checker" in the `AccessibilityCheckerSidebar` component in `src/sidebar/index.js`.