### PR TITLE
Remove: wcag details from rule list and rely on issue modal

### DIFF
--- a/src/sidebar/components/RuleAccordion.js
+++ b/src/sidebar/components/RuleAccordion.js
@@ -2,7 +2,6 @@
  * Rule Accordion Component
  */
 
-import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';


### PR DESCRIPTION
This pull request makes a focused change to the `RuleAccordion` component in the sidebar. It removes the display of WCAG details, rule summaries, and the "How to Fix" link from the expanded rule view, leaving only the list of issues visible when a rule is expanded.

Content display changes:

* Removed the rendering of WCAG information, rule summary/summary_plural, and the "How to Fix" help link from the expanded content of the `RuleAccordion` component, so now only the list of issues is shown when expanded. [[1]](diffhunk://#diff-ade34f40876428769ca352d229d99c035bd363081b369257c88ac158ebc89512L134-L158) [[2]](diffhunk://#diff-ade34f40876428769ca352d229d99c035bd363081b369257c88ac158ebc89512L170)

Other code cleanup:

* Removed the unused import of the `__` translation function from `@wordpress/i18n` in `RuleAccordion.js`.