### PR TITLE
Set: readability analysis accordion to closed by default

### DIFF
--- a/src/sidebar/components/Panels/ReadabilityAnalysis.js
+++ b/src/sidebar/components/Panels/ReadabilityAnalysis.js
@@ -180,6 +180,7 @@ const ReadabilityAnalysis = () => {
 				hasContent && postGrade > 0 ? ` (${ postGradeReadable })` : '',
 			) }
 			className="edac-panel-body edac-readability-analysis-panel edac-readability-analysis"
+			initialOpen={ false }
 		>
 			{ notice && (
 				<Notice


### PR DESCRIPTION
This pull request introduces a minor improvement to the `ReadabilityAnalysis` panel component. The panel will now be initially closed when rendered, providing a cleaner user interface by default.

- UI Behavior Update:
  * The `ReadabilityAnalysis` panel now sets the `initialOpen` prop to `false`, so the panel is collapsed by default when displayed.