### PR TITLE
Update: modify labels and messages in Dismissed Issues panel for clarity

### DIFF
--- a/src/sidebar/components/IssuesPanel.js
+++ b/src/sidebar/components/IssuesPanel.js
@@ -89,7 +89,7 @@ const IssuesPanel = ( {
 					title: (
 						<>
 							{ tab.label }
-							<span className="edac-analysis__count">{ count }</span>
+							<span className="edac-analysis__count">({ count })</span>
 						</>
 					),
 					className: 'edac-analysis__tab',

--- a/src/sidebar/components/Panels/DismissedIssues.js
+++ b/src/sidebar/components/Panels/DismissedIssues.js
@@ -24,19 +24,19 @@ const DismissedIssues = () => {
 	const tabs = [
 		{
 			name: 'dismissed-problems',
-			label: __( 'Dismissed Problems', 'accessibility-checker' ),
+			label: __( 'Problems', 'accessibility-checker' ),
 			items: allErrors,
 		},
 		{
 			name: 'dismissed-warnings',
-			label: __( 'Dismissed Warnings', 'accessibility-checker' ),
+			label: __( 'Needs Review', 'accessibility-checker' ),
 			items: allWarnings,
 		},
 	];
 
 	const emptyMessages = {
 		'dismissed-problems': __( 'No dismissed problems.', 'accessibility-checker' ),
-		'dismissed-warnings': __( 'No dismissed warnings.', 'accessibility-checker' ),
+		'dismissed-warnings': __( 'No dismissed items to review.', 'accessibility-checker' ),
 	};
 
 	// Build title with info icon


### PR DESCRIPTION
This pull request makes small updates to the sidebar issue panels to improve clarity and consistency in labeling and display.

* UI labeling improvements:
  * Changed the tab label for dismissed errors from "Dismissed Problems" to "Problems", and for dismissed warnings from "Dismissed Warnings" to "Needs Review" in `DismissedIssues.js`. Also updated the empty message for dismissed warnings to "No dismissed items to review."
  * Modified the issue count display in `IssuesPanel.js` to show the count in parentheses for better readability.