### PR TITLE
Remove duplicate meta viewport frontend fix import

### DIFF
--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -42,13 +42,6 @@ if ( edacFrontendFixes?.underline?.enabled ) {
 	} );
 }
 
-if ( edacFrontendFixes?.meta_viewport_scalable?.enabled ) {
-	// lazy import the module
-	import( /* webpackChunkName: "meta-viewport-scalable" */ './Fixes/metaViewportScalableFix' ).then( ( metaViewportScalableFix ) => {
-		metaViewportScalableFix.default();
-	} );
-}
-
 if ( edacFrontendFixes?.prevent_links_opening_new_windows?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "prevent-links-opening-in-new-window" */ './Fixes/preventLinksOpeningNewWindowFix' ).then( ( preventLinksOpeningNewWindowFix ) => {


### PR DESCRIPTION
### Motivation
- Prevent the `meta_viewport_scalable` frontend fix from being initialized twice by removing a duplicated lazy-import block in the frontend entrypoint.

### Description
- Removed the duplicate lazy-import/conditional for `edacFrontendFixes?.meta_viewport_scalable?.enabled` in `src/frontendFixes/index.js` so the `metaViewportScalableFix` module is only imported and executed once.

### Testing
- Ran the Jest test suite with `npm run test:jest -- --runInBand` and all tests passed (`31` suites, `551` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e971d8c0c83289a2b53529e7e70f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed redundant lazy-loaded initialization code with no impact to application behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->