### PR TITLE
Fix ReadMoreAddTitleFix for PHP 7.4 compatibility

### DIFF
--- a/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
+++ b/includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php
@@ -145,7 +145,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 		global $id;
 
 		// If the $text already contains the title, we won't add it again.
-		if ( str_contains( strtolower( $text ), strtolower( get_the_title( $id ) ) ) ) {
+		if ( false !== stripos( $text, get_the_title( $id ) ) ) {
 			return $link;
 		}
 
@@ -170,7 +170,7 @@ class ReadMoreAddTitleFix implements FixInterface {
 
 			// If the last part of the excerpt contains the post title, we won't add it again.
 			$exceprt_fragment = strtolower( substr( $excerpt, ( -100 - strlen( $post_title ) ) ) );
-			if ( str_contains( $exceprt_fragment, strtolower( $post_title ) ) ) {
+			if ( false !== stripos( $exceprt_fragment, $post_title ) ) {
 				return $excerpt;
 			}
 


### PR DESCRIPTION
Summary:\n- replace PHP 8-only str_contains calls with stripos in ReadMoreAddTitleFix\n- preserve existing case-insensitive behavior for duplicate-title checks\n\nTesting:\n- php -l includes/classes/Fixes/Fix/ReadMoreAddTitleFix.php\n\nRisk:\n- Low: targeted string-check implementation change in one class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced read-more link functionality to properly detect titles regardless of text case, ensuring consistent behavior across all posts and excerpts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->