### PR TITLE
Fix UTM parameter keys for generated links

### DIFF
--- a/admin/AdminPage/FixesSettingType/Checkbox.php
+++ b/admin/AdminPage/FixesSettingType/Checkbox.php
@@ -51,8 +51,8 @@ trait Checkbox {
 			if ( isset( $args['help_id'] ) && ! empty( $args['help_id'] ) && $args['label'] ) :
 				$link = \edac_generate_link_type(
 					[
-						'utm-campaign' => 'fix-description',
-						'utm-content'  => $args['name'],
+						'utm_campaign' => 'fix-description',
+						'utm_content'  => $args['name'],
 					],
 					'help',
 					[

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -41,8 +41,8 @@ trait Text {
 			if ( isset( $args['help_id'] ) && ! empty( $args['help_id'] ) && $args['label'] ) :
 				$link  = \edac_generate_link_type(
 					[
-						'utm-campaign' => 'fix-description',
-						'utm-content'  => $args['name'],
+						'utm_campaign' => 'fix-description',
+						'utm_content'  => $args['name'],
 					],
 					'help',
 					[

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -86,7 +86,7 @@ class Enqueue_Admin {
 					'nonce'      => wp_create_nonce( 'ajax-nonce' ),
 					'edacApiUrl' => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
 					'restNonce'  => wp_create_nonce( 'wp_rest' ),
-					'proUrl'     => esc_url_raw( edac_generate_link_type( [ 'utm-content' => '__name__' ] ) ),
+					'proUrl'     => esc_url_raw( edac_generate_link_type( [ 'utm_content' => '__name__' ] ) ),
 				]
 			);
 

--- a/admin/class-widgets.php
+++ b/admin/class-widgets.php
@@ -63,8 +63,8 @@ class Widgets {
 			) {
 				$pro_modal_link = edac_generate_link_type(
 					[
-						'utm-campaign' => 'dashboard-widget',
-						'utm-content'  => 'upgrade-to-edacp',
+						'utm_campaign' => 'dashboard-widget',
+						'utm_content'  => 'upgrade-to-edacp',
 					],
 				);
 				$pro_modal_html = '
@@ -235,8 +235,8 @@ class Widgets {
 
 				$non_scannable_post_type_pro_link = edac_generate_link_type(
 					[
-						'utm-campaign' => 'dashboard-widget',
-						'utm-content'  => 'upgrade-to-edacp',
+						'utm_campaign' => 'dashboard-widget',
+						'utm_content'  => 'upgrade-to-edacp',
 					],
 					'pro',
 					[

--- a/partials/pro-callout.php
+++ b/partials/pro-callout.php
@@ -39,8 +39,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			echo esc_url(
 				edac_generate_link_type(
 					[
-						'utm-campaign' => 'pro-callout',
-						'utm-content'  => 'get-pro',
+						'utm_campaign' => 'pro-callout',
+						'utm_content'  => 'get-pro',
 					]
 				)
 			);
@@ -62,5 +62,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</a>
 	<?php endif; ?>
 </div>
-
 

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -64,6 +64,21 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that proUrl tracking uses the expected utm_content key format.
+	 *
+	 * @return void
+	 */
+	public function testLocalizedProUrlUsesUtmContentKey() {
+		global $wp_scripts;
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$localized_data = $wp_scripts->get_data( 'edac', 'data' );
+		$this->assertStringContainsString( 'utm_content=__name__', $localized_data );
+		$this->assertStringNotContainsString( 'utm-content=__name__', $localized_data );
+	}
+
+	/**
 	 * Test that the base script and editor script is enqueued in the editor for an existing page.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary
- replace hyphenated UTM keys (`utm-campaign`, `utm-content`) with underscore keys expected by `edac_generate_link_type`
- update admin/fixes/pro-callout link generators so campaign/content values are no longer dropped
- add regression test in `EnqueueAdminTest` asserting `proUrl` contains `utm_content=__name__`

## Testing
- php -l admin/class-enqueue-admin.php
- php -l admin/class-widgets.php
- php -l partials/pro-callout.php
- php -l admin/AdminPage/FixesSettingType/Checkbox.php
- php -l admin/AdminPage/FixesSettingType/Text.php
- php -l tests/phpunit/Admin/EnqueueAdminTest.php
- `npm run test:php` (blocked in this environment: Docker socket permission denied)

## Risk
- low: key rename only in query-arg arrays plus one regression test
- possible impact limited to UTM query string values on outbound marketing/help links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed analytics parameter formatting in tracking links used throughout the admin interface to ensure consistent tracking behavior across help references, promotional callouts, and dashboard elements.

* **Tests**
  * Added test coverage to validate correct analytics parameter format in localized admin data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->