### PR TITLE
Fix over-broad admin script enqueue condition

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -69,7 +69,7 @@ class Enqueue_Admin {
 					in_array( $current_post_type, $post_types, true ) ||
 					in_array( $page, $enabled_pages, true )
 				)
-			) ||
+			) &&
 			'site-editor.php' !== $pagenow
 		) {
 

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -52,15 +52,39 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the base script is enqueued in the admin on non-editor pages.
+	 * Test that the base script is enqueued on an Accessibility Checker admin page.
 	 *
 	 * @return void
 	 */
-	public function testEnqueueBaseScriptInAdminNonEditorPage() {
+	public function testEnqueueBaseScriptOnAccessibilityCheckerAdminPage() {
+		global $pagenow;
+		$pagenow      = 'admin.php';
+		$_GET['page'] = 'accessibility_checker'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- test setup.
+
 		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
 
 		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
 		$this->assertFalse( wp_script_is( 'edac-editor-app', 'enqueued' ) );
+
+		unset( $_GET['page'] );
+	}
+
+	/**
+	 * Test that scripts are not enqueued on unrelated admin pages.
+	 *
+	 * @return void
+	 */
+	public function testDoesNotEnqueueScriptsOnUnrelatedAdminPage() {
+		global $pagenow;
+		$pagenow      = 'tools.php';
+		$_GET['page'] = 'tools';
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$this->assertFalse( wp_script_is( 'edac', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'edac-editor-app', 'enqueued' ) );
+
+		unset( $_GET['page'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- tighten `Enqueue_Admin::maybe_enqueue_admin_and_editor_app_scripts()` guard so scripts only load when post type/page checks pass and current screen is not `site-editor.php`
- update the existing admin enqueue test to target an Accessibility Checker page explicitly
- add a regression test asserting scripts do not enqueue on unrelated admin pages (`tools.php`)

## Testing
- `php -l admin/class-enqueue-admin.php`
- `php -l tests/phpunit/Admin/EnqueueAdminTest.php`
- `./vendor/bin/phpunit tests/phpunit/Admin/EnqueueAdminTest.php` *(fails in this environment: `./vendor/bin/phpunit` missing because dependencies cannot be installed)*

## Risk
- Low: change is limited to one boolean operator in enqueue gating logic plus test coverage.
- Potential behavioral change is intentional: EDAC scripts will stop loading on unrelated admin screens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the logic for loading admin and editor app scripts to ensure they only load on appropriate pages, preventing unnecessary script loading on unrelated admin pages and improving overall performance.

* **Tests**
  * Enhanced test coverage to validate correct script behavior on specific admin pages and unrelated pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->