### PR TITLE
Problems are errors + contrast_errors from the summary data

### DIFF
--- a/src/sidebar/components/Panels/AccessibilityStatus.js
+++ b/src/sidebar/components/Panels/AccessibilityStatus.js
@@ -71,7 +71,7 @@ const AccessibilityStatus = () => {
 	const readability = data?.readability || {};
 
 	const coveragePercent = summary.passed_tests || 0;
-	const problems = summary.errors || 0;
+	const problems = ( summary.errors || 0 ) + ( summary.contrast_errors || 0 );
 	const needsReview = summary.warnings || 0;
 
 	const postGrade = readability.post_grade || 0;


### PR DESCRIPTION
This pull request makes a targeted adjustment to how accessibility problems are counted in the `AccessibilityStatus` component. Now, both general errors and contrast errors are included in the total number of problems, providing a more accurate representation of accessibility issues.

- Accessibility calculation update:
  * In `AccessibilityStatus.js`, the `problems` variable now sums both `summary.errors` and `summary.contrast_errors` to reflect all detected accessibility problems.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
