### PR TITLE
Problems count in quick access panel should be errors + contrast erroors

### DIFF
--- a/src/sidebar/components/QuickAccessPanel.js
+++ b/src/sidebar/components/QuickAccessPanel.js
@@ -39,7 +39,7 @@ const QuickAccessPanel = () => {
 	}
 
 	// Calculate error and warning counts from data
-	const errorCount = data?.summary?.errors || 0;
+	const errorCount = ( data?.summary?.errors || 0 ) + ( data?.summary?.contrast_errors || 0 );
 	const warningCount = data?.summary?.warnings || 0;
 
 	// Determine which content to display


### PR DESCRIPTION
This pull request updates the error count calculation in the `QuickAccessPanel` component to include both general errors and contrast errors. This ensures that the error count more accurately reflects all relevant issues.

- UI bug fix:
  * Updated the calculation of `errorCount` in `QuickAccessPanel` to sum both `errors` and `contrast_errors` from the summary data, instead of only counting `errors`.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
