### PR TITLE
Handle malformed activation date in edac_generate_link_type

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -631,9 +631,9 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 	} catch ( Exception $e ) {
 		$activation_date = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
 	}
-		$interval       = $date_now->diff( $activation_date );
-		$days_active    = $interval->days;
-		$query_defaults = [
+	$interval       = $date_now->diff( $activation_date );
+	$days_active    = $interval->days;
+	$query_defaults = [
 		'utm_source'       => 'accessibility-checker',
 		'utm_medium'       => 'software',
 		'utm_campaign'     => 'wordpress-general',

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -631,9 +631,9 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 	} catch ( Exception $e ) {
 		$activation_date = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
 	}
-	$interval        = $date_now->diff( $activation_date );
-	$days_active     = $interval->days;
-	$query_defaults  = [
+		$interval       = $date_now->diff( $activation_date );
+		$days_active    = $interval->days;
+		$query_defaults = [
 		'utm_source'       => 'accessibility-checker',
 		'utm_medium'       => 'software',
 		'utm_campaign'     => 'wordpress-general',

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -620,8 +620,13 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 		$args = [];
 	}
 
-	$date_now        = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
-	$activation_date = new DateTime( get_option( 'edac_activation_date', gmdate( 'Y-m-d H:i:s' ) ) );
+	$date_now = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
+	try {
+		$activation_raw  = get_option( 'edac_activation_date', '' );
+		$activation_date = new DateTime( $activation_raw ? $activation_raw : gmdate( 'Y-m-d H:i:s' ) );
+	} catch ( Exception $e ) {
+		$activation_date = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
+	}
 	$interval        = $date_now->diff( $activation_date );
 	$days_active     = $interval->days;
 	$query_defaults  = [

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -620,10 +620,14 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 		$args = [];
 	}
 
-	$date_now = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
+	$date_now       = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
+	$activation_raw = get_option( 'edac_activation_date', '' );
+	if ( ! is_string( $activation_raw ) || '' === $activation_raw ) {
+		$activation_raw = gmdate( 'Y-m-d H:i:s' );
+	}
+
 	try {
-		$activation_raw  = get_option( 'edac_activation_date', '' );
-		$activation_date = new DateTime( $activation_raw ? $activation_raw : gmdate( 'Y-m-d H:i:s' ) );
+		$activation_date = new DateTime( $activation_raw );
 	} catch ( Exception $e ) {
 		$activation_date = new DateTime( gmdate( 'Y-m-d H:i:s' ) );
 	}

--- a/tests/phpunit/helper-functions/GenerateLinkTypeTest.php
+++ b/tests/phpunit/helper-functions/GenerateLinkTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class GenerateLinkTypeTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Test case for edac_generate_link_type function.
+ */
+class GenerateLinkTypeTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up options after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( 'edac_activation_date' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests that invalid activation dates do not throw errors.
+	 */
+	public function test_generate_link_type_with_invalid_activation_date() {
+		update_option( 'edac_activation_date', 'not-a-date' );
+
+		$link = edac_generate_link_type();
+
+		$query = wp_parse_url( $link, PHP_URL_QUERY );
+		parse_str( $query, $params );
+
+		$this->assertArrayHasKey( 'days_active', $params );
+		$this->assertSame( '0', $params['days_active'] );
+	}
+}

--- a/tests/phpunit/helper-functions/GenerateLinkTypeTest.php
+++ b/tests/phpunit/helper-functions/GenerateLinkTypeTest.php
@@ -32,4 +32,19 @@ class GenerateLinkTypeTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'days_active', $params );
 		$this->assertSame( '0', $params['days_active'] );
 	}
+
+	/**
+	 * Tests that non-string activation date values do not throw errors.
+	 */
+	public function test_generate_link_type_with_non_string_activation_date() {
+		update_option( 'edac_activation_date', [ 'bad' => 'value' ] );
+
+		$link = edac_generate_link_type();
+
+		$query = wp_parse_url( $link, PHP_URL_QUERY );
+		parse_str( $query, $params );
+
+		$this->assertArrayHasKey( 'days_active', $params );
+		$this->assertSame( '0', $params['days_active'] );
+	}
 }


### PR DESCRIPTION
## Summary
- prevent DateTime exceptions in edac_generate_link_type when edac_activation_date contains malformed data
- fall back to current GMT time when the stored option is invalid
- add PHPUnit coverage for invalid activation-date handling

## Testing
- npm run test:php (fails in sandbox: Docker socket permission denied)

## Risk
- low: change is narrowly scoped to activation-date parsing fallback in link generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activation-date handling so invalid, malformed, or non-string values gracefully fall back to the current time; days-active now reliably computes as zero when parsing fails.

* **Tests**
  * Added unit tests covering invalid and non-string activation-date scenarios to ensure consistent, stable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->