### PR TITLE
Guard EDAC_KEY_VALID usage in options page

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -659,7 +659,7 @@ function edac_post_types_cb() {
 			}
 			?>
 		</fieldset>
-		<?php if ( EDAC_KEY_VALID === false ) { ?>
+		<?php if ( defined( 'EDAC_KEY_VALID' ) && false === EDAC_KEY_VALID ) { ?>
 			<p class="edac-description">
 				<?php
 				echo esc_html__( 'To check content other than posts and pages, please ', 'accessibility-checker' );

--- a/tests/phpunit/includes/OptionsPageSourceTest.php
+++ b/tests/phpunit/includes/OptionsPageSourceTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Tests for options-page source safety checks.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Verify options page source keeps EDAC_KEY_VALID usage guarded.
+ */
+class OptionsPageSourceTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that EDAC_KEY_VALID is checked with defined() before usage.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_cb_guards_edac_key_valid_constant() {
+		$source = file_get_contents( EDAC_PLUGIN_DIR . 'includes/options-page.php' );
+
+		$this->assertNotFalse( $source, 'Failed to read includes/options-page.php' );
+		$this->assertStringContainsString(
+			"defined( 'EDAC_KEY_VALID' ) && false === EDAC_KEY_VALID",
+			$source
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- guard the `EDAC_KEY_VALID` check in `edac_post_types_cb()` with `defined()` to avoid undefined-constant errors when the file is loaded outside normal bootstrap
- add `OptionsPageSourceTest` to lock in the constant guard at source level

## Testing
- `php -l includes/options-page.php`
- `php -l tests/phpunit/includes/OptionsPageSourceTest.php`
- `npm run test:php` *(fails in this environment: Docker socket permission denied at `/Users/stevejones/.docker/run/docker.sock`)*

## Risk
- Low. Change is a single conditional guard in settings rendering path; behavior is unchanged when `EDAC_KEY_VALID` is defined.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential PHP notice error that could occur when a specific configuration constant was not defined. The application now properly checks whether the constant exists before attempting to use it, improving stability.

* **Tests**
  * Added test coverage to verify the application properly guards against undefined constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->