### PR TITLE
Handle missing meta viewport fix data

### DIFF
--- a/src/frontendFixes/Fixes/metaViewportScalableFix.js
+++ b/src/frontendFixes/Fixes/metaViewportScalableFix.js
@@ -1,4 +1,4 @@
-const MetaViewportScalable = window.edac_frontend_fixes.meta_viewport_scalable || {
+const MetaViewportScalable = window.edac_frontend_fixes?.meta_viewport_scalable || {
 	enabled: false,
 };
 

--- a/tests/jest/frontendFixes/metaViewportScalableFix.test.js
+++ b/tests/jest/frontendFixes/metaViewportScalableFix.test.js
@@ -1,0 +1,42 @@
+/**
+ * Tests for meta viewport scalable fix.
+ */
+
+describe( 'Meta Viewport Scalable Fix', () => {
+	let MetaViewportScalableFix;
+
+	beforeEach( async () => {
+		document.head.innerHTML = '';
+		document.body.innerHTML = '';
+		jest.resetModules();
+
+		const module = await import( '../../../src/frontendFixes/Fixes/metaViewportScalableFix.js' );
+		MetaViewportScalableFix = module.default;
+	} );
+
+	test( 'does nothing when frontend fixes data is missing', () => {
+		delete window.edac_frontend_fixes;
+
+		expect( () => MetaViewportScalableFix() ).not.toThrow();
+		expect( document.querySelector( 'meta[name="viewport"]' ) ).toBeNull();
+	} );
+
+	test( 'replaces non-scalable viewport tag when enabled', () => {
+		window.edac_frontend_fixes = {
+			meta_viewport_scalable: {
+				enabled: true,
+			},
+		};
+
+		const existingMeta = document.createElement( 'meta' );
+		existingMeta.name = 'viewport';
+		existingMeta.content = 'width=device-width, initial-scale=1, user-scalable=no';
+		document.head.appendChild( existingMeta );
+
+		MetaViewportScalableFix();
+
+		const metas = document.querySelectorAll( 'meta[name="viewport"]' );
+		expect( metas ).toHaveLength( 1 );
+		expect( metas[ 0 ].getAttribute( 'content' ) ).toBe( 'width=device-width, initial-scale=1' );
+	} );
+} );


### PR DESCRIPTION
Summary
- guard the meta viewport fix initializer against undefined `window.edac_frontend_fixes` using optional chaining
- add Jest coverage that exercises the new guard and the non-scalable viewport replacement flow

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for viewport meta tag configuration to prevent runtime errors when initialization data is unavailable.

* **Tests**
  * Added test coverage for viewport meta tag configuration handling in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->