### PR TITLE
Guard plugin action links pro check when EDAC_KEY_VALID is undefined

### DIFF
--- a/admin/class-plugin-action-links.php
+++ b/admin/class-plugin-action-links.php
@@ -55,7 +55,7 @@ class Plugin_Action_Links {
 		array_unshift( $links, $settings_link );
 
 		// Add Pro link if not already pro version.
-		if ( ! defined( 'EDACP_VERSION' ) || ! EDAC_KEY_VALID ) {
+		if ( ! edac_is_pro() ) {
 			$go_pro_text = esc_html__( 'Get Pro', 'accessibility-checker' );
 			
 			$links['go_pro'] = sprintf( 

--- a/tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Plugin Action Links undefined key constant test.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Plugin_Action_Links;
+
+/**
+ * Plugin Action Links undefined key constant test case.
+ */
+class PluginActionLinksUndefinedKeyTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensure pro link is added when EDAC_KEY_VALID is not defined.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_plugin_action_links_adds_pro_link_when_key_constant_missing() {
+		if ( ! defined( 'EDAC_PLUGIN_FILE' ) ) {
+			define( 'EDAC_PLUGIN_FILE', __FILE__ );
+		}
+
+		if ( ! function_exists( 'edac_link_wrapper' ) ) {
+			/**
+			 * Mock the edac_link_wrapper function.
+			 *
+			 * @param string $url      The URL to wrap.
+			 * @param string $source   The source parameter.
+			 * @param string $campaign The campaign parameter.
+			 * @param bool   $unused   Unused parameter for compatibility.
+			 * @return string The wrapped URL.
+			 */
+			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
+			}
+		}
+
+		$plugin_action_links = new Plugin_Action_Links();
+		$input_links         = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result              = $plugin_action_links->add_plugin_action_links( $input_links );
+
+		$this->assertArrayHasKey( 'go_pro', $result, 'Pro link should be present when EDAC_KEY_VALID is undefined' );
+	}
+}

--- a/tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php
@@ -27,14 +27,18 @@ class PluginActionLinksUndefinedKeyTest extends WP_UnitTestCase {
 			/**
 			 * Mock the edac_link_wrapper function.
 			 *
-			 * @param string $url      The URL to wrap.
-			 * @param string $source   The source parameter.
-			 * @param string $campaign The campaign parameter.
-			 * @param bool   $unused   Unused parameter for compatibility.
+			 * @param string $base_url      The URL to wrap.
+			 * @param string $campaign      The campaign parameter.
+			 * @param string $content       The content parameter.
+			 * @param bool   $directly_echo Unused in this mock.
 			 * @return string The wrapped URL.
 			 */
-			function edac_link_wrapper( $url, $source, $campaign, $unused ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				return $url . '?utm_source=' . $source . '&utm_campaign=' . $campaign;
+			function edac_link_wrapper( $base_url, $campaign, $content, $directly_echo ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				$params = [
+					'utm_campaign' => $campaign,
+					'utm_content'  => $content,
+				];
+				return $base_url . '?' . http_build_query( array_filter( $params ) );
 			}
 		}
 

--- a/tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php
+++ b/tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php
@@ -19,6 +19,15 @@ class PluginActionLinksUndefinedKeyTest extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_add_plugin_action_links_adds_pro_link_when_key_constant_missing() {
+		// Precondition: neither EDAC_KEY_VALID nor EDACP_VERSION should be defined so that
+		// edac_is_pro() returns false via the missing-key branch.  PHP constants cannot be
+		// undefined once set, so skip rather than produce a misleading test result.
+		if ( defined( 'EDAC_KEY_VALID' ) || defined( 'EDACP_VERSION' ) ) {
+			$this->markTestSkipped( 'Cannot exercise the undefined-key branch: EDAC_KEY_VALID or EDACP_VERSION is already defined in this process.' );
+		}
+		$this->assertFalse( defined( 'EDAC_KEY_VALID' ), 'Precondition failed: EDAC_KEY_VALID must not be defined.' );
+		$this->assertFalse( defined( 'EDACP_VERSION' ), 'Precondition failed: EDACP_VERSION must not be defined.' );
+
 		if ( ! defined( 'EDAC_PLUGIN_FILE' ) ) {
 			define( 'EDAC_PLUGIN_FILE', __FILE__ );
 		}


### PR DESCRIPTION
## Summary
- replace direct `EDAC_KEY_VALID` usage in plugin action links with `edac_is_pro()` guard
- add a regression test that runs in a separate process and verifies Get Pro link behavior when `EDAC_KEY_VALID` is undefined

## Root Cause
`Plugin_Action_Links::add_plugin_action_links()` referenced `EDAC_KEY_VALID` directly. In free-plugin contexts where the constant is not defined, PHP 8 raises an undefined constant error.

## Test Added
- `tests/phpunit/Admin/PluginActionLinksUndefinedKeyTest.php`
  - `test_add_plugin_action_links_adds_pro_link_when_key_constant_missing`

## Risk Assessment
Low risk. The change narrows to pro-state detection in one UI link condition and reuses existing helper logic (`edac_is_pro()`) already used elsewhere.

## Environment Limitations
- `npm run lint:js:fix` and `npm run lint:js` completed successfully.
- `npm run lint:php:fix` and `npm run lint:php` could not run because `vendor/bin/phpcbf` and `vendor/bin/phpcs` are missing after incomplete Composer install.
- `npm run test:php` is blocked by Docker socket permission in this sandbox (`operation not permitted`).
- Earlier `composer install` failed due DNS resolution for `api.github.com`, preventing full PHP tooling install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test to ensure the “Get Pro” action appears when license-key validation is missing.

* **Refactor**
  * Simplified Pro-status detection to use a dedicated helper, which changes when the “Get Pro” link is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->