### PR TITLE
Fix skip link crash when frontend fixes data is missing

### DIFF
--- a/src/frontendFixes/Fixes/skipLinkFix.js
+++ b/src/frontendFixes/Fixes/skipLinkFix.js
@@ -59,7 +59,8 @@ const SkipLinkFixInit = () => {
 		return;
 	}
 
-	if ( ! window.edac_frontend_fixes.skip_link.targets ) {
+	const skipLinkTargets = window.edac_frontend_fixes?.skip_link?.targets;
+	if ( ! Array.isArray( skipLinkTargets ) || skipLinkTargets.length === 0 ) {
 		return;
 	}
 
@@ -70,7 +71,7 @@ const SkipLinkFixInit = () => {
 	}
 
 	// try to find one the targets on the page.
-	const foundMainTarget = window.edac_frontend_fixes.skip_link.targets.find( ( target ) => document.querySelector( target ) );
+	const foundMainTarget = skipLinkTargets.find( ( target ) => document.querySelector( target ) );
 
 	if ( ! foundMainTarget ) {
 		// eslint-disable-next-line

--- a/tests/jest/frontendFixes/skipLinkFix.test.js
+++ b/tests/jest/frontendFixes/skipLinkFix.test.js
@@ -1,0 +1,34 @@
+/**
+ * Tests for Skip Link Fix
+ */
+
+describe( 'Skip Link Fix', () => {
+	let SkipLinkFix;
+
+	beforeEach( async () => {
+		// Reset DOM
+		document.body.innerHTML = '<template id="skip-link-template"><a class="edac-skip-link--content" href="#main">Skip</a></template>';
+		document.head.innerHTML = '';
+
+		// Clear module cache to get fresh import
+		jest.resetModules();
+
+		// Import the module
+		const module = await import( '../../../src/frontendFixes/Fixes/skipLinkFix.js' );
+		SkipLinkFix = module.default;
+	} );
+
+	afterEach( () => {
+		delete window.edac_frontend_fixes;
+	} );
+
+	test( 'does not throw when frontend fixes data is missing', () => {
+		delete window.edac_frontend_fixes;
+		expect( () => SkipLinkFix() ).not.toThrow();
+	} );
+
+	test( 'does not throw when skip link targets are empty', () => {
+		window.edac_frontend_fixes = { skip_link: { targets: [] } };
+		expect( () => SkipLinkFix() ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
## Summary
- guard skip link init against missing or empty frontend fix targets
- reuse a validated `skipLinkTargets` array instead of dereferencing nested globals directly
- add Jest regression tests for missing and empty frontend fix data

## Root cause
`SkipLinkFixInit` dereferenced `window.edac_frontend_fixes.skip_link.targets` unconditionally. When localized frontend data is absent or incomplete, this throws before the early return path can run.

## Evidence type
- Test evidence: `tests/jest/frontendFixes/skipLinkFix.test.js` passes with two regression cases
- Static certainty: direct nested global dereference without guard in `src/frontendFixes/Fixes/skipLinkFix.js`

## Risk assessment
- Low risk: change is scoped to skip-link initialization guard logic
- No behavior change when valid targets exist
- Adds regression coverage for missing/empty data edge cases

## Environment limitations
- `npm ci --ignore-scripts` failed in this environment (`Exit handler never called!` and npm log directory permission issue)
- Other required gates passed (`lint:js`, `lint:php`, `test:php`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced skip link feature with defensive validation and improved error handling to ensure stability when frontend fixes data is missing or skip link targets are empty.

* **Tests**
  * Added comprehensive test coverage for skip link functionality, validating behavior with missing data and empty targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->