### PR TITLE
Fix loopback helper warning on DNS AAAA failures

### DIFF
--- a/admin/class-helpers.php
+++ b/admin/class-helpers.php
@@ -167,10 +167,14 @@ class Helpers {
 			return false;
 		}
 
+		if ( ! is_array( $records ) ) {
+			return false;
+		}
+
 		foreach ( $records as $record ) {
 
 			// Do ipv6 check.
-			if ( isset( $record['type'] ) && 'AAAA' === $record['type'] ) {
+			if ( isset( $record['type'] ) && 'AAAA' === $record['type'] && ! empty( $record['ipv6'] ) ) {
 
 				// Normalize the IPv6 address for comparison.
 				$normalized_ipv6 = inet_pton( $record['ipv6'] );

--- a/tests/phpunit/Admin/HelpersLoopbackTest.php
+++ b/tests/phpunit/Admin/HelpersLoopbackTest.php
@@ -143,6 +143,27 @@ class HelpersLoopbackTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that dns_get_record failures do not emit warnings.
+	 */
+	public function test_dns_get_record_failure_does_not_emit_warning() {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Required to assert warning-free behavior.
+		set_error_handler(
+			function () {
+				throw new \RuntimeException( 'warning_emitted' );
+			}
+		);
+
+		try {
+			$result = Helpers::is_domain_loopback( '' );
+			$this->assertIsBool( $result );
+		} catch ( \RuntimeException $exception ) {
+			$this->fail( 'dns_get_record emitted a warning.' );
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	/**
 	 * Test IPv6 loopback detection (if supported).
 	 */
 	public function test_ipv6_loopback_detection() {


### PR DESCRIPTION
## Summary
- guard `Helpers::is_domain_loopback()` when `dns_get_record()` returns `false`
- avoid iterating non-array DNS results and skip malformed AAAA rows without `ipv6`
- add regression coverage to assert no warning is emitted for failed AAAA lookup paths

## Root cause
`dns_get_record( $domain, DNS_AAAA )` can return `false` and emit warnings (for example with invalid/empty domains). The helper iterated the return value directly with `foreach`, which triggers a runtime warning in PHP.

## Evidence type
- failing test added in this run (`test_dns_get_record_failure_does_not_emit_warning`)
- static certainty from direct control-flow analysis of `foreach ( $records as $record )` when `$records === false`

## Risk assessment
Low risk. Change is narrowly scoped to guard logic in one helper and preserves existing loopback behavior.

## Environment limitations
- `npm ci --ignore-scripts` is still flaky in this environment (npm internal `Exit handler never called` + log dir write issue), but required PR gates passed:
  - `npm run lint:js`
  - `npm run lint:php`
  - `npm run test:php`
