### PR TITLE
Prevent scanner crashes on invalid violation selectors

### DIFF
--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -27,8 +27,20 @@ const LANDMARK_ROLES = [
 const CONDITIONAL_LANDMARK_TAGS = [ 'SECTION', 'ARTICLE', 'FORM' ];
 const CONDITIONAL_LANDMARK_ROLES = [ 'region', 'article', 'form' ];
 
+export function safeQuerySelector( selector ) {
+	if ( ! selector || typeof selector !== 'string' ) {
+		return null;
+	}
+
+	try {
+		return document.querySelector( selector );
+	} catch ( error ) {
+		return null;
+	}
+}
+
 function getLandmarkForSelector( selector ) {
-	const el = document.querySelector( selector );
+	const el = safeQuerySelector( selector );
 	if ( ! el ) {
 		return { type: null, selector: null };
 	}
@@ -261,10 +273,10 @@ const scan = async (
 
 			//Sort the violations by order they appear in the document
 			violations.sort( function( a, b ) {
-				a = document.querySelector( a.selector );
-				b = document.querySelector( b.selector );
+				a = safeQuerySelector( a.selector );
+				b = safeQuerySelector( b.selector );
 
-				if ( a === b ) {
+				if ( ! a || ! b || a === b ) {
 					return 0;
 				}
 
@@ -380,7 +392,7 @@ function processViolation( violation, item ) {
 	const landmark = getLandmarkForSelector( selector );
 	const ancestry = violation.node.ancestry || [];
 	const xpath = violation.node.xpath || [];
-	const html = document.querySelector( selector )?.outerHTML;
+	const html = safeQuerySelector( selector )?.outerHTML;
 	return {
 		selector,
 		ancestry,

--- a/tests/jest/pageScanner/safeQuerySelector.test.js
+++ b/tests/jest/pageScanner/safeQuerySelector.test.js
@@ -1,0 +1,17 @@
+import { safeQuerySelector } from '../../../src/pageScanner/index';
+
+describe( 'safeQuerySelector', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'returns null for invalid selectors without throwing', () => {
+		expect( () => safeQuerySelector( 'div>>' ) ).not.toThrow();
+		expect( safeQuerySelector( 'div>>' ) ).toBeNull();
+	} );
+
+	test( 'returns element for a valid selector', () => {
+		document.body.innerHTML = '<div class="target"></div>';
+		expect( safeQuerySelector( '.target' ) ).not.toBeNull();
+	} );
+} );


### PR DESCRIPTION
## Summary
- add a safe selector helper for scanner DOM lookups
- use the helper when deriving landmark info, violation HTML, and sort order
- add Jest coverage for invalid and valid selectors

## Root Cause
`document.querySelector()` was called with selector values coming from scan results. Invalid selectors can throw `DOMException`, and missing elements can produce `null` values that were then passed to `compareDocumentPosition`, crashing the scan flow.

## Evidence Type
- test evidence: added `tests/jest/pageScanner/safeQuerySelector.test.js`
- validation: `npm run lint:js`, `npm run lint:php`, `npm run test:jest`, `npm run test:php`

## Risk Assessment
Low risk. The change is localized to selector lookups and only adds defensive handling for invalid/missing selectors.

## Environment Limitations
`npm ci --ignore-scripts` failed earlier in this run with npm internal error `Exit handler never called!` and log-write failure to `/Users/stevejones/.npm/_logs`, but existing dependencies in the workspace allowed lint and tests to run successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened DOM element querying throughout the page scanner with improved error handling to prevent runtime exceptions and increase stability.

* **Tests**
  * Added comprehensive test coverage for DOM query validation and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->