### PR TITLE
Fix frontend highlighter crash when issue ID is missing

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -531,15 +531,27 @@ class AccessibilityCheckerHighlight {
 	 * @param {string} id - The ID of the element.
 	 */
 
-	showIssue = ( id ) => {
+	showIssue( id ) {
 		this.removeSelectedClasses();
 
 		if ( id === undefined ) {
 			return;
 		}
 
+		if ( ! Array.isArray( this.issues ) ) {
+			this.currentButtonIndex = -1;
+			this.currentIssueStatus = __( 'The element was not found on the page.', 'accessibility-checker' );
+			this.descriptionOpen( id );
+			return;
+		}
+
 		const issue = this.issues.find( ( i ) => i.id === id );
 		this.currentButtonIndex = this.issues.findIndex( ( i ) => i.id === id );
+		if ( ! issue ) {
+			this.currentIssueStatus = __( 'The element was not found on the page.', 'accessibility-checker' );
+			this.descriptionOpen( id );
+			return;
+		}
 
 		const tooltip = issue.tooltip;
 		const element = issue.element;
@@ -577,7 +589,7 @@ class AccessibilityCheckerHighlight {
 		}
 
 		this.descriptionOpen( id );
-	};
+	}
 
 	/**
 	 * This function checks if a given element is visible on the page.
@@ -1485,6 +1497,8 @@ class AccessibilityCheckerHighlight {
 		}
 	}
 }
+
+export { AccessibilityCheckerHighlight };
 
 // Some systems (Cloudflare Rocket Loader) defers scripts for performance but that can
 // cause some DOMContentLoaded events to be missed. This is flag tracks if it run so we

--- a/tests/jest/frontendHighlighterApp/showIssue.test.js
+++ b/tests/jest/frontendHighlighterApp/showIssue.test.js
@@ -1,0 +1,83 @@
+import { AccessibilityCheckerHighlight } from '../../../src/frontendHighlighterApp/index';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+	_n: ( single, plural, count ) => ( count === 1 ? single : plural ),
+	sprintf: ( text ) => text,
+} ) );
+
+jest.mock(
+	'@floating-ui/dom',
+	() => ( {
+		computePosition: jest.fn(),
+		autoUpdate: jest.fn(),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'focus-trap',
+	() => ( {
+		createFocusTrap: jest.fn( () => ( {
+			activate: jest.fn(),
+			deactivate: jest.fn(),
+		} ) ),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'tabbable',
+	() => ( {
+		isFocusable: jest.fn( () => true ),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '../../../src/common/saveFixSettingsRest', () => ( {
+	saveFixSettings: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/frontendHighlighterApp/fixesModal', () => ( {
+	fillFixesModal: jest.fn(),
+	fixSettingsModalInit: jest.fn(),
+	openFixesModal: jest.fn(),
+} ) );
+
+describe( 'AccessibilityCheckerHighlight.showIssue', () => {
+	it( 'does not throw when issues are not initialized', () => {
+		const subject = {
+			removeSelectedClasses: jest.fn(),
+			descriptionOpen: jest.fn(),
+			issues: null,
+			currentButtonIndex: null,
+			currentIssueStatus: null,
+		};
+
+		expect( () => {
+			AccessibilityCheckerHighlight.prototype.showIssue.call( subject, 'missing' );
+		} ).not.toThrow();
+
+		expect( subject.currentButtonIndex ).toBe( -1 );
+		expect( subject.currentIssueStatus ).toBe( 'The element was not found on the page.' );
+		expect( subject.descriptionOpen ).toHaveBeenCalledWith( 'missing' );
+	} );
+
+	it( 'does not throw when issue id is not found', () => {
+		const subject = {
+			removeSelectedClasses: jest.fn(),
+			descriptionOpen: jest.fn(),
+			issues: [],
+			currentButtonIndex: null,
+			currentIssueStatus: null,
+		};
+
+		expect( () => {
+			AccessibilityCheckerHighlight.prototype.showIssue.call( subject, 'missing' );
+		} ).not.toThrow();
+
+		expect( subject.currentButtonIndex ).toBe( -1 );
+		expect( subject.currentIssueStatus ).toBe( 'The element was not found on the page.' );
+		expect( subject.descriptionOpen ).toHaveBeenCalledWith( 'missing' );
+	} );
+} );


### PR DESCRIPTION
## Summary
- guard showIssue so it exits gracefully when `this.issues` is uninitialized
- guard showIssue when an issue id is not found instead of dereferencing `undefined`
- add Jest coverage for both missing-data paths in showIssue

## Root cause
showIssue assumed the issue list was always initialized and that every requested id existed. In those edge cases it attempted to read issue.tooltip and issue.element from undefined, causing a runtime crash.

## Evidence type
- test: added regression coverage in `tests/jest/frontendHighlighterApp/showIssue.test.js` and confirmed full Jest + PHP test suites pass

## Risk assessment
- low risk: change is localized to showIssue fallback handling and does not alter the happy path for valid issues

## Environment limitations
- npm ci --ignore-scripts still reports an npm internal error (`Exit handler never called`) in this runner, but lint and test commands executed successfully with the current dependency state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for accessibility issue detection to gracefully manage cases where issues are not found or unavailable on the page.

* **Tests**
  * Added comprehensive test coverage for edge cases in issue detection and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->