### PR TITLE
Fix opt-in modal load handler clobbering

### DIFF
--- a/src/emailOptIn/modal.js
+++ b/src/emailOptIn/modal.js
@@ -12,10 +12,10 @@ import { createFocusTrap } from 'focus-trap';
 window.edac_email_opt_in_form = window.edac_email_opt_in_form || {};
 
 export const initOptInModal = () => {
-	window.onload = function() {
+	window.addEventListener( 'load', () => {
 		window.addEventListener( 'mousemove', triggerModal, { once: true } );
 		window.addEventListener( 'scroll', triggerModal, { once: true } );
-	};
+	} );
 };
 
 const triggerModal = ( () => {

--- a/tests/jest/emailOptIn/modal.test.js
+++ b/tests/jest/emailOptIn/modal.test.js
@@ -1,0 +1,46 @@
+/**
+ * Tests for email opt-in modal initialization
+ */
+
+import { initOptInModal } from '../../../src/emailOptIn/modal';
+
+jest.mock(
+	'focus-trap',
+	() => ( {
+		createFocusTrap: jest.fn(),
+	} ),
+	{ virtual: true }
+);
+
+describe( 'email opt-in modal init', () => {
+	beforeEach( () => {
+		jest.restoreAllMocks();
+		window.onload = null;
+	} );
+
+	test( 'does not overwrite existing window.onload handler', () => {
+		const existingOnload = jest.fn();
+		window.onload = existingOnload;
+		const addEventListenerSpy = jest.spyOn( window, 'addEventListener' );
+
+		initOptInModal();
+
+		expect( window.onload ).toBe( existingOnload );
+		expect( addEventListenerSpy ).toHaveBeenCalledWith( 'load', expect.any( Function ) );
+	} );
+
+	test( 'registers mousemove and scroll listeners after load', () => {
+		const addEventListenerSpy = jest.spyOn( window, 'addEventListener' );
+
+		initOptInModal();
+
+		const loadCall = addEventListenerSpy.mock.calls.find( ( call ) => call[ 0 ] === 'load' );
+		expect( loadCall ).toBeDefined();
+
+		const loadHandler = loadCall[ 1 ];
+		loadHandler();
+
+		expect( addEventListenerSpy ).toHaveBeenCalledWith( 'mousemove', expect.any( Function ), { once: true } );
+		expect( addEventListenerSpy ).toHaveBeenCalledWith( 'scroll', expect.any( Function ), { once: true } );
+	} );
+} );


### PR DESCRIPTION
## Summary
- preserve existing `window.onload` handlers by switching `initOptInModal` to `window.addEventListener('load', ...)`
- add a Jest regression test to verify initialization does not overwrite pre-existing `window.onload`
- verify modal listeners for `mousemove` and `scroll` still register after page load

## Root Cause
`initOptInModal` assigned directly to `window.onload`, which overwrote any previously registered onload handler and could silently break unrelated page initialization behavior.

## Evidence Type
High-confidence static defect with regression test coverage (`tests/jest/emailOptIn/modal.test.js`).

## Risk Assessment
Low risk. Change is isolated to event registration in opt-in modal bootstrapping and preserves existing behavior while avoiding global handler clobbering.

## Validation
- `npm run lint:js:fix`
- `npm run lint:php:fix`
- `npm run lint:js`
- `npm run lint:php`
- `npm run test:php`
- `npm run test:jest -- tests/jest/emailOptIn/modal.test.js`

## Environment Limitations
- `npm ci --ignore-scripts` still fails in this environment with npm internal error (`Exit handler never called`), but lint and tests above completed using the current workspace dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved email opt-in modal initialization to support multiple event listeners without conflicts.

* **Tests**
  * Added comprehensive unit tests for email opt-in modal initialization, ensuring proper event listener attachment and preventing overwrites of existing handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->