### PR TITLE
Guard missing keys in remove-element helper

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -108,7 +108,7 @@ function edac_ordinal( $number ) {
  */
 function edac_remove_element_with_value( $items, $key, $value ) {
 	foreach ( $items as $sub_key => $sub_array ) {
-		if ( $sub_array[ $key ] === $value ) {
+		if ( isset( $sub_array[ $key ] ) && $sub_array[ $key ] === $value ) {
 			unset( $items[ $sub_key ] );
 		}
 	}

--- a/tests/phpunit/helper-functions/RemoveElementWithValueTest.php
+++ b/tests/phpunit/helper-functions/RemoveElementWithValueTest.php
@@ -158,4 +158,35 @@ class RemoveElementWithValueTest extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Ensures missing keys do not emit notices.
+	 */
+	public function test_edac_remove_element_with_value_missing_key() {
+		$items = [
+			[
+				'id'   => 1,
+				'name' => 'Alice',
+			],
+			[
+				'name' => 'MissingId',
+			],
+		];
+
+		$handler = static function ( ...$args ) {
+			unset( $args );
+			throw new \RuntimeException( 'Unexpected PHP warning or notice in helper call.' );
+		};
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional in test to fail on notices/warnings.
+		set_error_handler( $handler );
+
+		try {
+			$result = edac_remove_element_with_value( $items, 'id', 2 );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( $items, $result );
+	}
 }


### PR DESCRIPTION
This pull request improves the robustness of the `edac_remove_element_with_value` helper function by ensuring it does not emit PHP notices when the specified key is missing from an array item. It also adds a corresponding unit test to verify this behavior.

**Bug fix:**

* Updated `edac_remove_element_with_value` in `includes/helper-functions.php` to check for the existence of the key using `isset` before comparing its value, preventing PHP notices when the key is missing.

**Testing improvements:**

* Added a unit test `test_edac_remove_element_with_value_missing_key` in `tests/phpunit/helper-functions/RemoveElementWithValueTest.php` to ensure that missing keys do not trigger PHP warnings or notices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential undefined index notices in helper function when processing arrays with missing keys.

* **Tests**
  * Added test coverage to verify proper handling of missing keys in array processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->