### PR TITLE
Fix TypeError when post type filter returns scalar

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -186,6 +186,10 @@ function edac_post_types() {
 	 */
 	$post_types = apply_filters( 'edac_filter_post_types', [ 'post', 'page' ] );
 
+	if ( ! is_array( $post_types ) ) {
+		$post_types = [ $post_types ];
+	}
+
 	// remove duplicates.
 	$post_types = array_unique( $post_types );
 

--- a/tests/phpunit/helper-functions/PostTypesTest.php
+++ b/tests/phpunit/helper-functions/PostTypesTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Tests for edac_post_types helper.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Tests for edac_post_types.
+ */
+class PostTypesTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensures edac_post_types tolerates non-array filter values.
+	 */
+	public function test_edac_post_types_casts_filter_value_to_array(): void {
+		add_filter(
+			'edac_filter_post_types',
+			static function () {
+				return 'post';
+			}
+		);
+
+		$this->assertSame( [ 'post' ], edac_post_types() );
+
+		remove_all_filters( 'edac_filter_post_types' );
+	}
+}


### PR DESCRIPTION
## Summary
- add `PostTypesTest` to cover `edac_filter_post_types` returning a scalar string
- normalize non-array filter results in `edac_post_types()` before `array_unique()`
- preserve existing behavior for array inputs while preventing runtime TypeError

## Root Cause
`edac_post_types()` assumes the `edac_filter_post_types` hook always returns an array. If an integration returns a scalar (for example `'post'`), `array_unique()` throws a `TypeError`.

## Evidence Type
Test failure reproduced in this run (`PostTypesTest::test_edac_post_types_casts_filter_value_to_array`), then resolved after the guard was added.

## Risk Assessment
Low risk. Change is a narrow input-normalization guard in one helper and only affects unexpected non-array filter values.

## Environment Limitations
None for final verification. Commands run successfully in this run:
- `npm ci --ignore-scripts`
- `composer install`
- `npm run lint:js:fix`
- `npm run lint:php:fix`
- `npm run lint:js`
- `npm run lint:php`
- `npm run test:php`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved post type filtering to properly normalize non-array filter values, ensuring consistent array output and preventing validation errors.

* **Tests**
  * Added test coverage to verify post type filtering correctly handles non-array filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->