### PR TITLE
Fix warning in edac_filter_by_value for missing indexes

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -124,17 +124,21 @@ function edac_remove_element_with_value( $items, $key, $value ) {
  * @return array
  */
 function edac_filter_by_value( $items, $index, $value ) {
+	$newarray = [];
+
 	if ( is_array( $items ) && count( $items ) > 0 ) {
 		foreach ( array_keys( $items ) as $key ) {
-			$temp[ $key ] = $items[ $key ][ $index ];
+			if ( ! is_array( $items[ $key ] ) || ! array_key_exists( $index, $items[ $key ] ) ) {
+				continue;
+			}
 
-			if ( $temp[ $key ] === $value ) {
+			if ( $items[ $key ][ $index ] === $value ) {
 				$newarray[ $key ] = $items[ $key ];
 			}
 		}
 	}
 
-	if ( isset( $newarray ) && is_array( $newarray ) && count( $newarray ) ) {
+	if ( count( $newarray ) ) {
 		return array_values( $newarray );
 	}
 	return [];

--- a/tests/phpunit/helper-functions/FilterByValueTest.php
+++ b/tests/phpunit/helper-functions/FilterByValueTest.php
@@ -28,6 +28,49 @@ class FilterByValueTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures missing indexes do not trigger notices.
+	 */
+	public function test_edac_filter_by_value_handles_missing_index() {
+		$items = [
+			[
+				'id' => 1,
+			],
+			[
+				'id'     => 2,
+				'status' => 'active',
+			],
+		];
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Required in this test to turn warnings into failures.
+		$previous_handler = set_error_handler(
+			static function ( $errno, $errstr ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception payload is test-only diagnostic data.
+				throw new RuntimeException( $errstr, $errno );
+			},
+			E_NOTICE | E_WARNING
+		);
+
+		try {
+			$this->assertSame(
+				[
+					[
+						'id'     => 2,
+						'status' => 'active',
+					],
+				],
+				edac_filter_by_value( $items, 'status', 'active' )
+			);
+		} finally {
+			if ( null !== $previous_handler ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Restoring prior test-local error handler.
+				set_error_handler( $previous_handler );
+			} else {
+				restore_error_handler();
+			}
+		}
+	}
+
+	/**
 	 * Data provider for test_edac_filter_by_value.
 	 */
 	public function filter_by_value_data() {


### PR DESCRIPTION
## Summary
- add a regression test for `edac_filter_by_value()` when an item is missing the requested index
- guard index access in `edac_filter_by_value()` so missing keys are skipped without raising warnings
- preserve existing return behavior by collecting only exact matches

## Root cause
`edac_filter_by_value()` read `$items[$key][$index]` directly. When an element lacked `$index`, PHP emitted an undefined array key warning.

## Evidence type
- test: added `FilterByValueTest::test_edac_filter_by_value_handles_missing_index`
- reproduced failure before fix as `RuntimeException: Undefined array key "status"` via warning-to-exception handling in test
- validated passing gates after fix: `npm run lint:js:fix`, `npm run lint:php:fix`, `npm run lint:js`, `npm run lint:php`, `npm run test:php`

## Risk assessment
Low risk. Change is limited to helper filtering logic and now skips non-array entries or rows missing the requested key. Existing behavior for matching rows is unchanged.

## Environment limitations
`git fetch` failed earlier in this run due to temporary DNS resolution for `github.com`; lint and test gates completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the filter functionality to properly handle missing array keys without producing warnings or notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->