### PR TITLE
Fix stale table-name cache in validator

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -238,10 +238,10 @@ function edac_get_post_type_label( string $post_type ): string {
  */
 function edac_get_valid_table_name( $table_name ) {
 	global $wpdb;
-	static $found_table_name;
+	static $found_table_names = [];
 
-	if ( isset( $found_table_name ) ) {
-		return $found_table_name;
+	if ( isset( $found_table_names[ $table_name ] ) ) {
+		return $found_table_names[ $table_name ];
 	}
 
 	// Check if table name only contains alphanumeric characters, underscores, or hyphens.
@@ -257,8 +257,8 @@ function edac_get_valid_table_name( $table_name ) {
 		return null;
 	}
 
-	$found_table_name = $table_name;
-	return $found_table_name;
+	$found_table_names[ $table_name ] = $table_name;
+	return $table_name;
 }
 
 /**

--- a/tests/phpunit/helper-functions/GetValidTableNameTest.php
+++ b/tests/phpunit/helper-functions/GetValidTableNameTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Class GetValidTableNameTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Test cases for edac_get_valid_table_name() function.
+ */
+class GetValidTableNameTest extends WP_UnitTestCase {
+
+	/**
+	 * Secondary table used for caching regression test.
+	 *
+	 * @var string
+	 */
+	private $alt_table;
+
+	/**
+	 * Sets up tables for testing.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+
+		$charset_collate = $wpdb->get_charset_collate();
+		$main_table      = $wpdb->prefix . 'accessibility_checker';
+		$this->alt_table = $wpdb->posts;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$db_schema = "CREATE TABLE %s (
+			id bigint(20) NOT NULL AUTO_INCREMENT,
+			PRIMARY KEY  (id)
+		) $charset_collate;";
+
+		dbDelta( sprintf( $db_schema, $main_table ) );
+	}
+
+	/**
+	 * Ensures the helper validates different tables without returning cached results.
+	 */
+	public function test_returns_requested_table_name_each_time() {
+		global $wpdb;
+
+		$main_table = $wpdb->prefix . 'accessibility_checker';
+
+		$this->assertSame( $main_table, edac_get_valid_table_name( $main_table ) );
+		$this->assertSame( $this->alt_table, edac_get_valid_table_name( $this->alt_table ) );
+	}
+}


### PR DESCRIPTION
## Summary
- cache validated table names per table key instead of storing a single static result
- add unit coverage for repeated calls with different valid table names

## Root cause
`edac_get_valid_table_name()` used one static variable (`$found_table_name`) and returned it on every subsequent call. After the first successful lookup, later calls for different table names incorrectly returned the first table.

## Evidence type
- test (new PHPUnit test)

## Validation
- npm run lint:js:fix
- npm run lint:php:fix
- npm run lint:js
- npm run lint:php
- npm run test:php

## Risk assessment
Low. Change is isolated to table-name validation caching and preserves existing validation checks. New test covers repeated-call behavior.

## Environment limitations
- `git fetch` was unavailable earlier in this run due DNS resolution failure for github.com.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table name caching to use per-table-name storage, ensuring each table name is cached and retrieved independently without potential interference or conflicts from other tables in the system.

* **Tests**
  * Added comprehensive test coverage to verify that table name operations work correctly when handling multiple tables simultaneously, ensuring proper isolation and no caching conflicts between different tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->