### PR TITLE
Fix fatal in summary content grade when post is missing

### DIFF
--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -279,7 +279,11 @@ class Summary_Generator {
 	 * @since 1.9.0
 	 */
 	private function calculate_content_grade() {
-		$content_post  = get_post( $this->post_id );
+		$content_post = get_post( $this->post_id );
+		if ( ! $content_post instanceof \WP_Post ) {
+			return 0;
+		}
+
 		$content       = $content_post->post_content;
 		$content       = wp_filter_nohtml_kses( $content );
 		$content       = str_replace( ']]>', ']]&gt;', $content );

--- a/tests/phpunit/includes/classes/SummaryGeneratorTest.php
+++ b/tests/phpunit/includes/classes/SummaryGeneratorTest.php
@@ -39,4 +39,20 @@ class SummaryGeneratorTest extends WP_UnitTestCase {
 			get_post_meta( $post_id, '_edac_density_data', true )
 		);
 	}
+
+	/**
+	 * Ensures that calculate_content_grade handles missing posts gracefully.
+	 *
+	 * @throws ReflectionException If the method does not exist this is thrown.
+	 */
+	public function test_calculate_content_grade_returns_zero_when_post_missing() {
+		$post_id           = 999999;
+		$summary_generator = new Summary_Generator( $post_id );
+
+		$method = ( new ReflectionClass( get_class( $summary_generator ) ) )
+			->getMethod( 'calculate_content_grade' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 0, $method->invoke( $summary_generator ) );
+	}
 }


### PR DESCRIPTION
## Summary
- guard `Summary_Generator::calculate_content_grade()` so missing/invalid posts return `0` instead of dereferencing null
- add regression test `test_calculate_content_grade_returns_zero_when_post_missing`

## Root Cause
`calculate_content_grade()` assumed `get_post( $this->post_id )` always returns a `WP_Post`. For missing/deleted IDs, `get_post()` returns `null` and code attempted to read `post_content`, causing a fatal error.

## Evidence Type
- test
- Added failing regression test first, observed `Attempt to read property "post_content" on null`, then implemented guard and confirmed passing.

## Risk Assessment
- Low risk: change is isolated to one null-check in summary grade calculation and covered by unit test.
- Behavioral impact: missing posts now safely report grade `0`.

## Environment Limitations
- `git fetch --prune` could not run in this environment (`Could not resolve host: github.com`) at scan time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability and error handling when encountering missing or invalid post data, ensuring graceful degradation instead of errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->