### PR TITLE
Fix duplicate color_contrast_failure filter in Issues_Query

### DIFF
--- a/admin/class-issues-query.php
+++ b/admin/class-issues-query.php
@@ -258,7 +258,7 @@ class Issues_Query {
 
 				// Then add color_contrast_failure to the rule_slugs filter.
 				$key = array_search( 'color_contrast_failure', $filter['rule_slugs'], true );
-				if ( ! $key ) {
+				if ( false === $key ) {
 					$filter['rule_slugs'][] = 'color_contrast_failure';
 				}
 			}

--- a/tests/phpunit/Admin/IssuesQueryTest.php
+++ b/tests/phpunit/Admin/IssuesQueryTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Class IssuesQueryTest
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Issues_Query;
+
+/**
+ * Test cases for EDAC\Admin\Issues_Query.
+ */
+class IssuesQueryTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensure color contrast rule slug is not duplicated when already present.
+	 */
+	public function test_color_contrast_rule_slug_not_duplicated_when_first() {
+		$query = new Issues_Query(
+			[
+				'rule_types' => [ Issues_Query::RULETYPE_COLOR_CONTRAST ],
+				'rule_slugs' => [ 'color_contrast_failure' ],
+			],
+			100000,
+			Issues_Query::FLAG_INCLUDE_ALL_POST_TYPES
+		);
+
+		$sql = $query->get_sql();
+
+		$this->assertSame(
+			1,
+			substr_count( $sql, 'color_contrast_failure' ),
+			'Expected color_contrast_failure to appear once in the SQL.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add a regression test for color contrast filtering when `color_contrast_failure` is already present at index 0
- fix `array_search` handling in `Issues_Query` so an existing slug at index 0 is not treated as missing

## Root Cause
`array_search()` returns `0` when the match is at the first position, but the code checked `if ( ! $key )`, which incorrectly treated index `0` as not found and appended a duplicate `color_contrast_failure` slug.

## Evidence Type
- test
- failing test added in this run (`IssuesQueryTest::test_color_contrast_rule_slug_not_duplicated_when_first`)

## Risk Assessment
Low risk. The change is a minimal conditional fix (`false === $key`) limited to slug de-duplication logic, with targeted coverage.

## Environment Limitations
- `git fetch --prune` failed in this run due to DNS resolution (`Could not resolve host: github.com`)
- local validation gates still executed successfully: `npm run lint:js:fix`, `npm run lint:php:fix`, `npm run lint:js`, `npm run lint:php`, `npm run test:php`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where color contrast accessibility checks could create duplicate entries in query results under certain conditions, improving data accuracy

* **Tests**
  * Added test coverage to ensure color contrast validation rules are processed correctly without duplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->