### PR TITLE
Fix edac_filter_by_value missing-index warning

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -124,19 +124,26 @@ function edac_remove_element_with_value( $items, $key, $value ) {
  * @return array
  */
 function edac_filter_by_value( $items, $index, $value ) {
-	if ( is_array( $items ) && count( $items ) > 0 ) {
-		foreach ( array_keys( $items ) as $key ) {
-			$temp[ $key ] = $items[ $key ][ $index ];
+	if ( ! is_array( $items ) || 0 === count( $items ) ) {
+		return [];
+	}
 
-			if ( $temp[ $key ] === $value ) {
-				$newarray[ $key ] = $items[ $key ];
-			}
+	$newarray = [];
+
+	foreach ( $items as $key => $item ) {
+		if ( ! is_array( $item ) || ! array_key_exists( $index, $item ) ) {
+			continue;
+		}
+
+		if ( $item[ $index ] === $value ) {
+			$newarray[ $key ] = $item;
 		}
 	}
 
-	if ( isset( $newarray ) && is_array( $newarray ) && count( $newarray ) ) {
+	if ( count( $newarray ) ) {
 		return array_values( $newarray );
 	}
+
 	return [];
 }
 

--- a/tests/phpunit/helper-functions/FilterByValueTest.php
+++ b/tests/phpunit/helper-functions/FilterByValueTest.php
@@ -195,4 +195,28 @@ class FilterByValueTest extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Test edac_filter_by_value handles missing index without warnings.
+	 */
+	public function test_edac_filter_by_value_missing_index_does_not_warn() {
+		$items = [
+			[
+				'id' => 1,
+			],
+		];
+
+		$handler = function () {
+			throw new RuntimeException( 'Unexpected PHP warning raised during filter_by_value test.' );
+		};
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test intentionally converts warnings to exceptions.
+		set_error_handler( $handler );
+
+		try {
+			$this->assertSame( [], edac_filter_by_value( $items, 'status', 'active' ) );
+		} finally {
+			restore_error_handler();
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add a regression test that converts PHP warnings to exceptions for missing index access in `edac_filter_by_value`
- guard `edac_filter_by_value` against non-array rows and missing keys before comparing values
- preserve return behavior by returning a re-indexed array of matches or an empty array

## Root cause
`edac_filter_by_value` read `$items[$key][$index]` unconditionally. When a row omitted `$index`, PHP emitted `Undefined array key` warnings.

## Evidence type
Test: added `FilterByValueTest::test_edac_filter_by_value_missing_index_does_not_warn`, observed failure before fix and passing after fix.

## Risk assessment
Low. Change is localized to one helper and only skips malformed rows that lack the requested index.

## Environment limitations
None in this run. Required install/lint/test gates ran successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of the filtering function to handle edge cases gracefully without generating warnings.
  * Enhanced validation during filtering operations to better handle missing data properties.

* **Tests**
  * Added test coverage for filtering with non-existent data properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->