### PR TITLE
Fix scannable post statuses filter type handling

### DIFF
--- a/admin/class-settings.php
+++ b/admin/class-settings.php
@@ -25,10 +25,16 @@ class Settings {
 		 *
 		 * @param array $scannable_post_statuses List of scannable post statuses.
 		 */
-		return apply_filters(
+		$statuses = apply_filters(
 			'edac_scannable_post_statuses',
 			[ 'publish', 'future', 'draft', 'pending', 'private' ]
 		);
+
+		if ( ! is_array( $statuses ) ) {
+			$statuses = [ $statuses ];
+		}
+
+		return $statuses;
 	}
 
 

--- a/tests/phpunit/Admin/SettingsScannablePostStatusesTest.php
+++ b/tests/phpunit/Admin/SettingsScannablePostStatusesTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class SettingsScannablePostStatusesTest
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Settings;
+
+/**
+ * Test cases for Settings::get_scannable_post_statuses().
+ */
+class SettingsScannablePostStatusesTest extends WP_UnitTestCase {
+	/**
+	 * Ensure filter returning a string is coerced to an array.
+	 */
+	public function test_get_scannable_post_statuses_coerces_filter_to_array() {
+		$filter = function () {
+			return 'publish';
+		};
+
+		add_filter( 'edac_scannable_post_statuses', $filter );
+
+		$this->assertSame( [ 'publish' ], Settings::get_scannable_post_statuses() );
+
+		remove_filter( 'edac_scannable_post_statuses', $filter );
+	}
+}


### PR DESCRIPTION
## Summary
- add regression coverage for `Settings::get_scannable_post_statuses()` when the filter returns a scalar value
- normalize filtered statuses to an array before returning

## Root cause
`Settings::get_scannable_post_statuses()` returned the raw filter output. If a plugin/theme filter returned a string (for example `publish`), downstream code expecting an array could break or behave unpredictably.

## Evidence type
- test: added `SettingsScannablePostStatusesTest::test_get_scannable_post_statuses_coerces_filter_to_array` and verified failure before the fix and pass after the fix

## Risk assessment
Low risk. Change is narrowly scoped to normalizing function output type and adds regression coverage.

## Environment limitations
- `git fetch --prune` failed in this run due to DNS resolution (`Could not resolve host: github.com`), so latest remote sync could not be confirmed before patching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the post status filtering system to ensure filter results are consistently returned as arrays, providing more reliable and predictable behavior across all post status-related operations.
* **Tests**
  * Added comprehensive test coverage to validate that the post status filtering mechanism correctly handles and normalizes various input types and data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->