### PR TITLE
Guard admin notice removal when current screen is unavailable

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -66,7 +66,10 @@ class Admin_Notices {
 	public function edac_remove_admin_notices() {
 
 		$current_screen = get_current_screen();
-		$screens        = [
+		if ( ! $current_screen || ! isset( $current_screen->id ) ) {
+			return;
+		}
+		$screens = [
 			'toplevel_page_accessibility_checker',
 			'accessibility-checker_page_accessibility_checker_issues',
 			'accessibility-checker_page_accessibility_checker_ignored',
@@ -81,6 +84,9 @@ class Admin_Notices {
 		 * @param array $screens The screens where admin notices should be removed.
 		 */
 		$screens = apply_filters( 'edac_filter_remove_admin_notices_screens', $screens );
+		if ( ! is_array( $screens ) ) {
+			$screens = [];
+		}
 
 		if ( in_array( $current_screen->id, $screens, true ) ) {
 			remove_all_actions( 'admin_notices' );

--- a/tests/phpunit/Admin/AdminNoticesTest.php
+++ b/tests/phpunit/Admin/AdminNoticesTest.php
@@ -44,6 +44,26 @@ class AdminNoticesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that removing admin notices does not error when the current screen is unavailable.
+	 */
+	public function test_edac_remove_admin_notices_handles_missing_screen() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			$this->markTestSkipped( 'get_current_screen is not available in this test environment.' );
+		}
+
+		global $current_screen;
+		$previous_screen = $current_screen ?? null;
+		$current_screen  = null;
+
+		try {
+			$this->admin_notices->edac_remove_admin_notices();
+			$this->assertTrue( true );
+		} finally {
+			$current_screen = $previous_screen;
+		}
+	}
+
+	/**
 	 * Test that the edac_get_black_friday_message function contains the expected promotional message.
 	 */
 	public function test_edac_get_black_friday_message_contains_promo_message() {


### PR DESCRIPTION
## Summary
- add regression coverage for Admin_Notices::edac_remove_admin_notices when get_current_screen is unavailable
- return early when the current screen object or id is missing
- harden filtered screen IDs by normalizing non-array values to an empty list

## Root Cause
edac_remove_admin_notices assumed get_current_screen always returned an object. In non-standard admin contexts this can be null, causing a fatal when reading current_screen->id.

## Evidence Type
- test
- added AdminNoticesTest::test_edac_remove_admin_notices_handles_missing_screen
- confirmed failure before fix (Attempt to read property "id" on null) and pass after fix

## Risk Assessment
Low risk. Changes are narrowly scoped to guard logic in notice removal and do not alter behavior when a valid current screen exists.

## Environment Limitations
- git fetch intermittently fails in this environment due to DNS (Could not resolve host: github.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced admin notices functionality with additional validation to prevent errors when certain conditions aren't met.

* **Tests**
  * Added comprehensive test coverage for edge case handling to ensure robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->