### PR TITLE
Fix undefined help_id notice in help link generation

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -650,7 +650,7 @@ function edac_generate_link_type( $query_args = [], $type = 'pro', $args = [] ):
 
 	switch ( $type ) {
 		case 'help':
-			$base_link = trailingslashit( 'https://a11ychecker.com/help' . $args['help_id'] ?? '' );
+			$base_link = trailingslashit( 'https://a11ychecker.com/help' . ( $args['help_id'] ?? '' ) );
 			break;
 		case 'custom': // phpcs:ignore -- intentially only breaking inside the condition because if it's not set we want to hit default.
 			if ( ! empty( $args['base_link'] ) ) {

--- a/tests/phpunit/helper-functions/GenerateLinkTypeTest.php
+++ b/tests/phpunit/helper-functions/GenerateLinkTypeTest.php
@@ -44,4 +44,35 @@ class GenerateLinkTypeTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'software', $query_args );
 		$this->assertSame( $expected_software, $query_args['software'] );
 	}
+
+	/**
+	 * Ensure missing help_id does not raise notices and still builds a help URL.
+	 */
+	public function test_help_type_without_help_id_does_not_raise_notice() {
+		if ( ! function_exists( 'edac_generate_link_type' ) ) {
+			$this->markTestSkipped( 'edac_generate_link_type function is not available in test environment.' );
+		}
+
+		$errors = [];
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- needed to assert no notices are raised by this regression test.
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$errors ) {
+				$errors[] = $errstr;
+				return true;
+			}
+		);
+
+		$link = edac_generate_link_type(
+			[ 'utm_campaign' => 'help-missing-id' ],
+			'help',
+			[]
+		);
+
+		restore_error_handler();
+
+		$this->assertSame( [], $errors, 'Unexpected PHP notices were raised while generating the help link.' );
+		$this->assertIsString( $link );
+		$this->assertStringStartsWith( 'https://a11ychecker.com/help', $link );
+		$this->assertStringContainsString( 'utm_campaign=help-missing-id', $link );
+	}
 }


### PR DESCRIPTION
Summary:
- Add regression coverage for edac_generate_link_type when called with type help and no help_id.
- Fix help link concatenation precedence so missing help_id no longer triggers undefined array key notices.

Root cause:
edac_generate_link_type evaluated 'https://a11ychecker.com/help' . $args['help_id'] ?? '' without grouping, so $args['help_id'] was accessed before null coalescing when the key was absent.

Evidence type:
- Test: new PHPUnit regression test failed before the fix with Undefined array key 'help_id', then passed after the fix.

Risk assessment:
- Low risk: one-line guard change in helper function plus targeted test coverage.

Environment limitations:
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue causing PHP notices when generating help links in certain scenarios, improving application stability.

* **Tests**
  * Added test coverage to verify help link generation functions reliably in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->