### PR TITLE
Add grade level display for summary and status icon

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1064,19 +1064,21 @@ class REST_Api {
 			$simplified_summary_grade = (int) floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
 		}
 
-		$simplified_summary_grade_failed = $simplified_summary_grade >= 9;
-		$simplified_summary_prompt       = get_option( 'edac_simplified_summary_prompt' );
+		$simplified_summary_grade_failed      = $simplified_summary_grade >= 9;
+		$simplified_summary_grade_readability = edac_ordinal( $simplified_summary_grade );
+		$simplified_summary_prompt            = get_option( 'edac_simplified_summary_prompt' );
 
 		return [
-			'post_grade'                      => $post_grade,
-			'post_grade_readability'          => $post_grade_readability,
-			'post_grade_failed'               => $post_grade_failed,
-			'simplified_summary'              => $simplified_summary,
-			'simplified_summary_grade'        => $simplified_summary_grade,
-			'simplified_summary_grade_failed' => $simplified_summary_grade_failed,
-			'simplified_summary_prompt'       => $simplified_summary_prompt,
-			'simplified_summary_position'     => $simplified_summary_position,
-			'content_length'                  => strlen( $content ),
+			'post_grade'                           => $post_grade,
+			'post_grade_readability'               => $post_grade_readability,
+			'post_grade_failed'                    => $post_grade_failed,
+			'simplified_summary'                   => $simplified_summary,
+			'simplified_summary_grade'             => $simplified_summary_grade,
+			'simplified_summary_grade_readability' => $simplified_summary_grade_readability,
+			'simplified_summary_grade_failed'      => $simplified_summary_grade_failed,
+			'simplified_summary_prompt'            => $simplified_summary_prompt,
+			'simplified_summary_position'          => $simplified_summary_position,
+			'content_length'                       => strlen( $content ),
 		];
 	}
 
@@ -1106,16 +1108,17 @@ class REST_Api {
 			// Return data structure that matches the readability endpoint format.
 			return new \WP_REST_Response(
 				[
-					'success'                         => true,
-					'post_grade'                      => $readability_data['post_grade'],
-					'post_grade_readability'          => $readability_data['post_grade_readability'],
-					'post_grade_failed'               => $readability_data['post_grade_failed'],
-					'simplified_summary'              => $readability_data['simplified_summary'],
-					'simplified_summary_grade'        => $readability_data['simplified_summary_grade'],
-					'simplified_summary_grade_failed' => $readability_data['simplified_summary_grade_failed'],
-					'simplified_summary_prompt'       => $readability_data['simplified_summary_prompt'],
-					'simplified_summary_position'     => $readability_data['simplified_summary_position'],
-					'content_length'                  => $readability_data['content_length'],
+					'success'                              => true,
+					'post_grade'                           => $readability_data['post_grade'],
+					'post_grade_readability'               => $readability_data['post_grade_readability'],
+					'post_grade_failed'                    => $readability_data['post_grade_failed'],
+					'simplified_summary'                   => $readability_data['simplified_summary'],
+					'simplified_summary_grade'             => $readability_data['simplified_summary_grade'],
+					'simplified_summary_grade_readability' => $readability_data['simplified_summary_grade_readability'],
+					'simplified_summary_grade_failed'      => $readability_data['simplified_summary_grade_failed'],
+					'simplified_summary_prompt'            => $readability_data['simplified_summary_prompt'],
+					'simplified_summary_position'          => $readability_data['simplified_summary_position'],
+					'content_length'                       => $readability_data['content_length'],
 				],
 				200
 			);
@@ -1284,4 +1287,3 @@ class REST_Api {
 		);
 	}
 }
-

--- a/src/sidebar/components/Panels/ReadabilityAnalysis.js
+++ b/src/sidebar/components/Panels/ReadabilityAnalysis.js
@@ -50,6 +50,7 @@ const ReadabilityAnalysis = () => {
 	// Initialize summary text from readability data
 	const initialSummary = readabilityData?.simplified_summary || '';
 	const initialSummaryGrade = readabilityData?.simplified_summary_grade || 0;
+	const initialSummaryGradeReadable = readabilityData?.simplified_summary_grade_readability || '';
 	const initialSummaryGradeFailed = Boolean( readabilityData?.simplified_summary_grade_failed );
 
 	// Update textarea when initial summary changes
@@ -83,6 +84,7 @@ const ReadabilityAnalysis = () => {
 					post_grade_failed: response.post_grade_failed,
 					simplified_summary: response.simplified_summary,
 					simplified_summary_grade: response.simplified_summary_grade,
+					simplified_summary_grade_readability: response.simplified_summary_grade_readability,
 					simplified_summary_grade_failed: response.simplified_summary_grade_failed,
 					simplified_summary_prompt: response.simplified_summary_prompt,
 					simplified_summary_position: response.simplified_summary_position,
@@ -144,8 +146,19 @@ const ReadabilityAnalysis = () => {
 		return __( 'Not available', 'accessibility-checker' );
 	};
 
+	const getSummaryGradeLabel = () => {
+		if ( initialSummaryGradeReadable ) {
+			return sprintf( __( '%s grade', 'accessibility-checker' ), initialSummaryGradeReadable );
+		}
+		if ( summaryGrade ) {
+			return sprintf( __( '%dth grade', 'accessibility-checker' ), summaryGrade );
+		}
+		return __( 'Not available', 'accessibility-checker' );
+	};
+
 	const readingLevelStatus = getReadingLevelStatus();
 	const gradeLabel = getGradeLabel();
+	const summaryGradeLabel = getSummaryGradeLabel();
 
 	// Build screen reader text for accordion title (grade only when available)
 	let srOnlyTitle = '';
@@ -182,6 +195,14 @@ const ReadabilityAnalysis = () => {
 		}
 		if ( summaryText && summaryGrade > 0 && ! summaryGradeFailed ) {
 			return 'info';
+		}
+		return 'warning';
+	};
+
+	// Determine the correct icon for the simplified summary reading level
+	const getSummaryGradeIcon = () => {
+		if ( summaryGrade > 0 && ! summaryGradeFailed ) {
+			return 'check';
 		}
 		return 'warning';
 	};
@@ -308,12 +329,18 @@ const ReadabilityAnalysis = () => {
 										</p>
 									) }
 									{ summaryText && summaryGrade > 0 && (
-										<p className="edac-panel-section__message">
-											{ summaryGradeFailed
-												? __( 'Needs improvement, summary is above the 9th-grade reading level.', 'accessibility-checker' )
-												: __( 'Below the recommended 9th-grade reading level.', 'accessibility-checker' )
-											}
-										</p>
+										<>
+											<p className="post-grade-display">
+												<Icon name={ getSummaryGradeIcon() } />
+												{ summaryGradeLabel }
+											</p>
+											<p className="edac-panel-section__message">
+												{ summaryGradeFailed
+													? __( 'Needs improvement, summary is above the 9th-grade reading level.', 'accessibility-checker' )
+													: __( 'Below the recommended 9th-grade reading level.', 'accessibility-checker' )
+												}
+											</p>
+										</>
 									) }
 								</div>
 


### PR DESCRIPTION
This pull request enhances the readability analysis feature by improving how the simplified summary reading level is displayed in both backend and frontend code. The changes add a more user-friendly, ordinal-based grade label (e.g., "8th grade") and update the UI to show this label with an appropriate icon, making the reading level information clearer and more accessible.

Backend changes (PHP):

* Added calculation of the ordinal-form readability grade (`simplified_summary_grade_readability`) in `get_readability_data` and included it in the returned data structure, ensuring this information is available to the frontend. [[1]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8R1068) [[2]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8R1077)
* Updated `save_simplified_summary` to include the new `simplified_summary_grade_readability` field in its response payload.

Frontend changes (JavaScript):

* Updated `ReadabilityAnalysis.js` to consume and display the new `simplified_summary_grade_readability` value, showing a more readable grade label (e.g., "8th grade") in the UI. [[1]](diffhunk://#diff-e94ec8e482a553c8115f3c3a7a4a8276c0dbf2211d49c1daea48dd12ae00a8a1R53) [[2]](diffhunk://#diff-e94ec8e482a553c8115f3c3a7a4a8276c0dbf2211d49c1daea48dd12ae00a8a1R87) [[3]](diffhunk://#diff-e94ec8e482a553c8115f3c3a7a4a8276c0dbf2211d49c1daea48dd12ae00a8a1R149-R161)
* Added logic to select the correct icon ("check" for passing, "warning" for failing) and improved the display of the simplified summary reading level in the panel. [[1]](diffhunk://#diff-e94ec8e482a553c8115f3c3a7a4a8276c0dbf2211d49c1daea48dd12ae00a8a1R202-R209) [[2]](diffhunk://#diff-e94ec8e482a553c8115f3c3a7a4a8276c0dbf2211d49c1daea48dd12ae00a8a1R332-R343)

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
