### PR TITLE
Disable codemirror tab and shift-tab key handling

### DIFF
--- a/src/issueModal/components/IssueDetailsModal.js
+++ b/src/issueModal/components/IssueDetailsModal.js
@@ -66,6 +66,11 @@ const CodeMirrorViewer = ( { value } ) => {
 				readOnly: true,
 				lineNumbers: true,
 				lineWrapping: true,
+				// Disable tab handling so it doesn't capture tab key
+				extraKeys: {
+					Tab: false,
+					'Shift-Tab': false,
+				},
 			},
 		};
 


### PR DESCRIPTION
This pull request makes a minor improvement to the `CodeMirrorViewer` component by updating its configuration to prevent the editor from capturing the Tab and Shift-Tab keys, ensuring a better user experience when viewing code.

- User experience improvement:
  * Updated the `extraKeys` option in the CodeMirror configuration to disable Tab and Shift-Tab handling, so these keys are not captured by the editor.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
