### PR TITLE
Guard FixesPage sections filter output type

### DIFF
--- a/admin/AdminPage/FixesPage.php
+++ b/admin/AdminPage/FixesPage.php
@@ -145,6 +145,10 @@ class FixesPage implements PageInterface {
 			]
 		);
 
+		if ( ! is_array( $sections ) ) {
+			$sections = [];
+		}
+
 		foreach ( $sections as $section_id => $section ) {
 			if ( ! is_string( $section_id ) || ! isset( $section['title'], $section['callback'] ) ) {
 				continue;

--- a/tests/phpunit/Admin/FixesPageTest.php
+++ b/tests/phpunit/Admin/FixesPageTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Fixes Page tests.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
+
+/**
+ * Fixes Page test case.
+ */
+class FixesPageTest extends WP_UnitTestCase {
+
+	/**
+	 * Test register_settings_sections handles scalar filter output without warnings.
+	 */
+	public function test_register_settings_sections_handles_scalar_filter_output() {
+		$page = new FixesPage( 'manage_options' );
+
+		add_filter(
+			'edac_filter_fixes_settings_sections',
+			static function () {
+				return 'not-an-array';
+			}
+		);
+
+		$handler = static function () {
+			throw new \RuntimeException( 'PHP warning captured during register_settings_sections.' );
+		};
+		set_error_handler( $handler ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional in test to convert warnings into failures.
+
+		try {
+			$page->register_settings_sections();
+			$this->assertTrue( true );
+		} catch ( \RuntimeException $exception ) {
+			$this->fail( 'register_settings_sections should ignore scalar filter output without warnings.' );
+		} finally {
+			restore_error_handler();
+			remove_all_filters( 'edac_filter_fixes_settings_sections' );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add regression test for scalar `edac_filter_fixes_settings_sections` output
- guard `FixesPage::register_settings_sections()` against non-array filter return values
- keep section registration behavior unchanged for valid array input

## Root cause
`register_settings_sections()` assumed `edac_filter_fixes_settings_sections` always returned an array. A plugin returning a scalar caused `foreach()` warnings.

## Evidence type
- test (failing test added first, then fixed)

## Risk assessment
Low. Change is isolated to type guarding in Fixes settings section registration and only affects invalid filter output.

## Environment limitations
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced settings registration to gracefully validate and handle unexpected data types, preventing PHP warnings that could disrupt admin experience and ensuring continued system stability.

* **Tests**
  * Added tests verifying settings registration maintains stability when processing edge cases and unusual inputs without warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->