### PR TITLE
Minor typographical issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm run test:jest
 
 The PHP tests are a little more involved because they **require** a local WordPress installation. A Docker-based setup is included to make running them straightforward.
 
-Docker and Docker Compose must be installed and running. The build script uses Docker Compose v2 style commands (e.g., docker compose vs docker-compose).
+Docker and Docker Compose must be installed and running. The build script uses Docker Compose v2 style commands (e.g., `docker compose` instead of `docker-compose`).
 
 Start the containers to run the tests and stop them when you are finished development.
 


### PR DESCRIPTION
<!-- Always provide a short description -->

The abbreviation for exempli gratia (for example) is `e.g.`. 

It is typically written with periods and followed by a comma.

Correction: Change `eg` to `e.g.,`.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker Compose guidance in the tests README by updating inline command formatting to recommend using "docker compose" instead of "docker-compose", refining punctuation for readability. No functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->