### PR TITLE
Add a composite sort of severity then count for issues in sidebar

### DIFF
--- a/src/sidebar/components/IssuesPanel.js
+++ b/src/sidebar/components/IssuesPanel.js
@@ -100,6 +100,15 @@ const IssuesPanel = ( {
 				// Apply ignored status filter
 				rules = filterRulesByIgnoredStatus( rules );
 
+				// Sort rules by severity ascending (1=Critical … 4=Low), then by issue count descending
+				rules = [ ...rules ].sort( ( a, b ) => {
+					const severityDiff = ( a.severity ?? Infinity ) - ( b.severity ?? Infinity );
+					if ( severityDiff !== 0 ) {
+						return severityDiff;
+					}
+					return ( b.details?.length ?? 0 ) - ( a.details?.length ?? 0 );
+				} );
+
 				const count = rules.reduce(
 					( sum, rule ) => sum + ( rule.details?.length || 0 ),
 					0,


### PR DESCRIPTION
This pull request improves the sorting of rules in the `IssuesPanel` to make the most critical and relevant issues more visible to users. Now, rules are sorted first by severity (from most to least severe) and then by the number of issues (from most to least).

Enhancements to rule sorting:

* [`src/sidebar/components/IssuesPanel.js`](diffhunk://#diff-127c758be2a1644284dcf79f00c7fedfb2e86ee5f8a18c303824facee77462e2R103-R111): Added logic to sort rules by ascending severity (Critical to Low) and, for rules with the same severity, by descending issue count.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
