### PR TITLE
Help text and labels for fixes need to allow html in them

### DIFF
--- a/src/issueModal/components/FixPanel.js
+++ b/src/issueModal/components/FixPanel.js
@@ -128,8 +128,8 @@ const FixCard = ( { slug, onError } ) => {
 			return (
 				<div key={ fieldKey } className="edac-fix-field edac-fix-field--checkbox">
 					<ToggleControl
-						label={ decodedLabel }
-						help={ field.description ? decodeEntities( field.description ) : undefined }
+						label={ <span dangerouslySetInnerHTML={ { __html: field.label } } /> }
+						help={ field.description ? <span dangerouslySetInnerHTML={ { __html: field.description } } /> : undefined }
 						checked={ !! value }
 						onChange={ ( next ) => handleFieldChange( fieldKey, next ) }
 					/>


### PR DESCRIPTION
Allows the HTML in the fix descriptions and labels to render.

<img width="563" height="234" alt="Screenshot from 2026-02-27 14-24-15" src="https://github.com/user-attachments/assets/59bf42a1-5b70-4ed6-86fa-ead45b138cf3" />

Fixes: #1460 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
