### PR TITLE
When using quick access panel button focus on the first panel in sidebar

### DIFF
--- a/src/sidebar/components/QuickAccessPanel.js
+++ b/src/sidebar/components/QuickAccessPanel.js
@@ -30,6 +30,15 @@ const QuickAccessPanel = () => {
 	const openAccessibilitySidebar = useCallback( () => {
 		if ( isPostEditor && enableComplementaryArea ) {
 			enableComplementaryArea( 'core/edit-post', ACCESSIBILITY_CHECKER_SIDEBAR_NAME );
+			// once opened, focus on the first panel header.
+			requestAnimationFrame( () => {
+				const firstFocusable = document
+					.getElementById( ACCESSIBILITY_CHECKER_SIDEBAR_NAME.replace( '/', ':' ) )
+					?.querySelector( '.edac-panel-body button' );
+				if ( firstFocusable ) {
+					firstFocusable.focus();
+				}
+			} );
 		}
 	}, [ isPostEditor, enableComplementaryArea ] );
 


### PR DESCRIPTION
This pull request improves the user experience when opening the accessibility sidebar in the post editor by ensuring that keyboard focus is automatically set to the first panel header button. This makes the interface more accessible and user-friendly.

Accessibility enhancement:

* When the accessibility sidebar is opened via `openAccessibilitySidebar`, the code now sets keyboard focus to the first button in the panel body, improving accessibility for keyboard and screen reader users.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
