### PR TITLE
Tackle keyboard and labelling issues in the Link popover for dismiss comments

### DIFF
--- a/src/issueModal/components/RichTextarea.js
+++ b/src/issueModal/components/RichTextarea.js
@@ -182,7 +182,12 @@ export const RichTextarea = ( { value, onChange, label, help, rows = 3, disabled
 					label={ __( 'Link', 'accessibility-checker' ) }
 					onClick={ handleLinkButtonClick }
 					onMouseDown={ () => {
-						linkButtonMouseDownRef.current = true;
+						// Only set this flag when the popover is already open, so
+						// the Popover's onClose handler can yield to the button's
+						// onClick toggle instead of closing it a second time.
+						if ( showLinkPopover ) {
+							linkButtonMouseDownRef.current = true;
+						}
 					} }
 					disabled={ disabled }
 					size="small"
@@ -220,6 +225,7 @@ export const RichTextarea = ( { value, onChange, label, help, rows = 3, disabled
 								onKeyDown={ ( e ) => {
 									if ( e.key === 'Escape' ) {
 										e.stopPropagation();
+										linkButtonMouseDownRef.current = false;
 										setShowLinkPopover( false );
 										linkButtonRef.current?.focus();
 									} else if ( e.key === 'Enter' ) {


### PR DESCRIPTION
This pull request improves the accessibility and usability of the link insertion feature in the `RichTextarea` component. The main changes focus on better keyboard handling, accessibility attributes, and preventing unintended popover closures when interacting with the link button.

**Accessibility and keyboard usability improvements:**

* Added `aria-expanded` to the link button to indicate popover state for assistive technologies.
* Enhanced the link input with an `aria-label` and an explicit `id` for improved accessibility.
* Improved keyboard handling: pressing `Escape` closes the popover and returns focus to the link button, while pressing `Enter` adds the link without submitting a form.

**Popover and button interaction fixes:**

* Introduced a `linkButtonMouseDownRef` to track mouse interactions on the link button, preventing the popover from closing when the button itself is clicked to toggle it. [[1]](diffhunk://#diff-4f1b90789a40186e4f6d973c035fea7fb79535dbcfd3c8c6649d4be6ee85485eR34) [[2]](diffhunk://#diff-4f1b90789a40186e4f6d973c035fea7fb79535dbcfd3c8c6649d4be6ee85485eR163-R202)

Fixes: #1471 
Fixes: #1472 
Fixes: #1477 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
