### PR TITLE
Add a state in the classic metabox for when there is no reading grade able to be calulated

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -686,8 +686,8 @@ class Ajax {
 						'<strong class="' . ( ( $simplified_summary_grade_failed ) ? 'failed-text-color' : 'passed-text-color' ) . '">' . esc_html( edac_ordinal( $simplified_summary_grade ) ) . '</strong>'
 					) . '</h3>
 					<p class="edac-readability-list-item-description">' . ( ( $simplified_summary_grade_failed )
-						? esc_html__( 'Your simplified summary has a reading level higher than 9th grade.', 'accessibility-checker' )
-						: esc_html__( 'Your simplified summary has a reading level lower than 9th grade.', 'accessibility-checker' )
+						? esc_html__( 'Your simplified summary has a reading level above 9th grade.', 'accessibility-checker' )
+						: esc_html__( 'Your simplified summary has a reading level at or below 9th grade.', 'accessibility-checker' )
 					) . '</p>
 				</li>';
 				}


### PR DESCRIPTION
This pull request updates the readability feedback logic for simplified summaries in the `readability()` function. The main improvement is that it now handles cases where there is not enough content to determine a reading grade level, displaying a clear message to the user.

Enhancements to user feedback for simplified summary readability:

* Added a check for when the simplified summary grade is zero, displaying a "None" value and a message indicating insufficient content to determine a reading level.
* Refactored the grade level output to use `sprintf` and translation functions, ensuring consistent formatting and improved internationalization support.
* Improved messaging for summaries that pass or fail the grade level check, clarifying whether the reading level is higher or lower than 9th grade.

[PRO-621]

Fixes: #1476 

<img width="649" height="65" alt="Screenshot from 2026-02-27 19-05-00" src="https://github.com/user-attachments/assets/e8b4ea9d-911b-476d-8278-04ac5d67fdcf" />

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
