### PR TITLE
Add handling for svgs in the image finder for the issue modal

### DIFF
--- a/src/issueModal/components/IssueImage.js
+++ b/src/issueModal/components/IssueImage.js
@@ -64,7 +64,9 @@ const extractImageUrls = ( markup ) => {
 	while ( ( match = svgRegex.exec( decodedMarkup ) ) !== null ) {
 		if ( match[ 0 ] ) {
 			const dataUri = 'data:image/svg+xml,' + encodeURIComponent( match[ 0 ] );
-			urls.push( dataUri );
+			if ( ! urls.includes( dataUri ) ) {
+				urls.push( dataUri );
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request enhances the `extractImageUrls` utility to support extracting inline SVG images from markup. Now, the function detects embedded `<svg>` elements, converts them into data URIs, and includes them in the returned list of image URLs.

Image extraction improvements:

* Updated `extractImageUrls` in `IssueImage.js` to detect inline `<svg>` elements, convert them to `data:image/svg+xml` data URIs using `encodeURIComponent`, and add them to the list of extracted image URLs.

[PRO-611]

Fixes: #1466 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
