### PR TITLE
All users should be able to dismiss and close from modal from the split button

### DIFF
--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -207,31 +207,31 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 									rows={ 3 }
 									disabled={ isSubmitting }
 								/>
-								{ isPro ? (
-									<div className="edac-analysis__dismiss-split-button">
-										<Button
-											variant="primary"
-											type="submit"
-											disabled={ isSubmitting }
-											className="edac-analysis__dismiss-button"
-										>
-											{ dismissButtonLabel }
-										</Button>
-										<Dropdown
-											renderToggle={ ( { isOpen: isDropdownOpen, onToggle: onDropdownToggle } ) => (
-												<Button
-													variant="primary"
-													type="button"
-													icon={ chevronDown }
-													onClick={ onDropdownToggle }
-													aria-expanded={ isDropdownOpen }
-													aria-label={ __( 'More dismiss options', 'accessibility-checker' ) }
-													disabled={ isSubmitting }
-													className="edac-analysis__dismiss-dropdown-toggle"
-												/>
-											) }
-											renderContent={ ( { onClose } ) => (
-												<div className="edac-analysis__dismiss-dropdown-content">
+								<div className="edac-analysis__dismiss-split-button">
+									<Button
+										variant="primary"
+										type="submit"
+										disabled={ isSubmitting }
+										className="edac-analysis__dismiss-button"
+									>
+										{ dismissButtonLabel }
+									</Button>
+									<Dropdown
+										renderToggle={ ( { isOpen: isDropdownOpen, onToggle: onDropdownToggle } ) => (
+											<Button
+												variant="primary"
+												type="button"
+												icon={ chevronDown }
+												onClick={ onDropdownToggle }
+												aria-expanded={ isDropdownOpen }
+												aria-label={ __( 'More dismiss options', 'accessibility-checker' ) }
+												disabled={ isSubmitting }
+												className="edac-analysis__dismiss-dropdown-toggle"
+											/>
+										) }
+										renderContent={ ( { onClose } ) => (
+											<div className="edac-analysis__dismiss-dropdown-content">
+												{ isPro && (
 													<Button
 														variant="tertiary"
 														type="button"
@@ -242,34 +242,25 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 													>
 														{ __( 'Dismiss Globally', 'accessibility-checker' ) }
 													</Button>
-													<Button
-														variant="tertiary"
-														type="button"
-														onClick={ () => {
-															onClose();
-															handleToggleIgnore( true, false ).then( () => {
-																// close the entire modal after dismissing.
-																if ( onCloseModal ) {
-																	onCloseModal();
-																}
-															} );
-														} }>
-														{ __( 'Dismiss & Close Modal', 'accessibility-checker' ) }
-													</Button>
-												</div>
-											) }
-										/>
-									</div>
-								) : (
-									<Button
-										variant="primary"
-										type="submit"
-										disabled={ isSubmitting }
-										className="edac-analysis__dismiss-button"
-									>
-										{ dismissButtonLabel }
-									</Button>
-								) }
+												) }
+												<Button
+													variant="tertiary"
+													type="button"
+													onClick={ () => {
+														onClose();
+														handleToggleIgnore( true, false ).then( () => {
+															// close the entire modal after dismissing.
+															if ( onCloseModal ) {
+																onCloseModal();
+															}
+														} );
+													} }>
+													{ __( 'Dismiss & Close Modal', 'accessibility-checker' ) }
+												</Button>
+											</div>
+										) }
+									/>
+								</div>
 							</form>
 						) }
 					</div>


### PR DESCRIPTION
This pull request refactors how the "Dismiss" button and related actions are displayed in the `DismissPanel` component. The primary change is to move the conditional rendering of the "Pro" features so that the "Dismiss Globally" button is only shown to Pro users within the dropdown, and the previous non-Pro button logic has been removed.

**UI logic changes:**

* Moved the `isPro` conditional so that the "Dismiss Globally" button is only rendered for Pro users inside the dropdown, rather than conditionally rendering the entire split button or a separate button for non-Pro users. [[1]](diffhunk://#diff-def37020f18590ce1e6f29d35bc4c95f5fca9f0c9e9e23d15cbcbfde40904031L210) [[2]](diffhunk://#diff-def37020f18590ce1e6f29d35bc4c95f5fca9f0c9e9e23d15cbcbfde40904031R234) [[3]](diffhunk://#diff-def37020f18590ce1e6f29d35bc4c95f5fca9f0c9e9e23d15cbcbfde40904031R245)
* Removed the separate "Dismiss" button that was displayed for non-Pro users, simplifying the form and ensuring a more unified experience for all users.

[PRO-619]

Fixes: #1474 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
