### PR TITLE
Add aria-haspopup to the issue modal trigger button

### DIFF
--- a/src/sidebar/components/IssueRow.js
+++ b/src/sidebar/components/IssueRow.js
@@ -26,6 +26,7 @@ const IssueRow = ( { issue, rule, onAction, showIgnored = false } ) => {
 				type="button"
 				className="edac-analysis__issue-link"
 				onClick={ () => onAction( 'details', issue ) }
+				aria-haspopup="dialog"
 			>
 				{ __( 'Issue', 'accessibility-checker' ) } #{ issue.id }
 			</button>


### PR DESCRIPTION
This pull request introduces a small accessibility improvement to the `IssueRow` component. The change adds an `aria-haspopup="dialog"` attribute to the issue details button, helping assistive technologies understand that the button opens a dialog.

* Added `aria-haspopup="dialog"` to the issue details button in `IssueRow` to improve accessibility for screen readers.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
