### PR TITLE
Update sidebar actions label for clarity

### DIFF
--- a/src/sidebar/components/SidebarTitleMenu.js
+++ b/src/sidebar/components/SidebarTitleMenu.js
@@ -73,7 +73,7 @@ const SidebarTitleMenu = ( { postId, refetchData } ) => {
 		<div ref={ menuRef } className="edac-sidebar__title-menu-wrapper">
 			<DropdownMenu
 				icon={ moreVertical }
-				label={ __( 'Accessibility Checker Actions', 'accessibility-checker' ) }
+				label={ __( 'Accessibility Checker actions', 'accessibility-checker' ) }
 				className="edac-sidebar__title-menu"
 			>
 				{ ( { onClose } ) => (


### PR DESCRIPTION
This pull request makes a minor change to the sidebar menu label for improved clarity. The label is now "Accessibility Checker Actions" instead of "Sidebar actions".

[PRO-607]

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
