### PR TITLE
Add the issue ID to the label for the issue actions menu

### DIFF
--- a/src/sidebar/components/IssueRow.js
+++ b/src/sidebar/components/IssueRow.js
@@ -39,7 +39,7 @@ const IssueRow = ( { issue, rule, onAction, showIgnored = false } ) => {
 			) }
 			<DropdownMenu
 				icon={ moreVertical }
-label={ issue?.id ? sprintf( __( 'Issue actions for %s', 'accessibility-checker' ), issue.id ) : __( 'Issue actions', 'accessibility-checker' ) }
+				label={ issue?.id ? sprintf( __( 'Issue actions for %s', 'accessibility-checker' ), issue.id ) : __( 'Issue actions', 'accessibility-checker' ) }
 				className="edac-analysis__issue-menu"
 			>
 				{ ( { onClose } ) => (


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `IssueRow` component in the sidebar by improving the accessibility and clarity of the dropdown menu label.

* Accessibility improvement: The dropdown menu label now uses `sprintf` to include the specific issue ID in the label, making it clearer for screen readers and users which issue the actions pertain to. (`src/sidebar/components/IssueRow.js`)
* Added import: The `sprintf` function is now imported from `@wordpress/i18n` to support the updated label logic. (`src/sidebar/components/IssueRow.js`)

[PRO-610]

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
