### PR TITLE
Add aria-labelledby and aria-describedby to content input for dismiss comment

### DIFF
--- a/src/issueModal/components/RichTextarea.js
+++ b/src/issueModal/components/RichTextarea.js
@@ -212,7 +212,7 @@ export const RichTextarea = ( { value, onChange, label, help, rows = 3, disabled
 	return (
 		<div className="edac-rich-textarea-wrapper">
 			{ label && (
-				<label className="edac-rich-textarea-label">{ label }</label>
+				<label id="dismiss-comment-title" className="edac-rich-textarea-label">{ label }</label>
 			) }
 
 			<div className="edac-rich-textarea-toolbar">
@@ -300,6 +300,8 @@ export const RichTextarea = ( { value, onChange, label, help, rows = 3, disabled
 			<div
 				ref={ editorRef }
 				contentEditable={ ! disabled }
+				aria-labelledby="dismiss-comment-title"
+				aria-describedby="dismiss-comment-helptext"
 				suppressContentEditableWarning
 				onInput={ updateValue }
 				onKeyDown={ handleKeyDown }
@@ -309,7 +311,7 @@ export const RichTextarea = ( { value, onChange, label, help, rows = 3, disabled
 			/>
 
 			{ help && (
-				<p className="edac-rich-textarea-help">{ help }</p>
+				<p id="dismiss-comment-helptext" className="edac-rich-textarea-help">{ help }</p>
 			) }
 		</div>
 	);


### PR DESCRIPTION
This pull request makes accessibility improvements to the `RichTextarea` component by adding proper ARIA attributes and unique IDs to label and help text elements. This will help screen readers correctly associate the label and help text with the textarea, improving usability for users with assistive technologies.

**Accessibility enhancements:**

* Added an `id` (`dismiss-comment-title`) to the label element and referenced it with the `aria-labelledby` attribute on the editable div to associate the label with the textarea. [[1]](diffhunk://#diff-4f1b90789a40186e4f6d973c035fea7fb79535dbcfd3c8c6649d4be6ee85485eL215-R215) [[2]](diffhunk://#diff-4f1b90789a40186e4f6d973c035fea7fb79535dbcfd3c8c6649d4be6ee85485eR303-R304)
* Added an `id` (`dismiss-comment-helptext`) to the help text paragraph and referenced it with the `aria-describedby` attribute on the editable div to associate the help text with the textarea. [[1]](diffhunk://#diff-4f1b90789a40186e4f6d973c035fea7fb79535dbcfd3c8c6649d4be6ee85485eL312-R314) [[2]](diffhunk://#diff-4f1b90789a40186e4f6d973c035fea7fb79535dbcfd3c8c6649d4be6ee85485eR303-R304) 

<img width="528" height="224" alt="Screenshot from 2026-03-02 23-00-04" src="https://github.com/user-attachments/assets/0a608bb5-307c-43ef-b679-0160df643e20" />

Fixes: #1468 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
