### PR TITLE
Ensure post edit permission check returns a strict boolean dismiss endpoint

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -351,7 +351,7 @@ class REST_Api {
 								$wpdb->prepare( 'SELECT postid FROM %i WHERE id = %d', $table_name, $issue_id )
 							);
 
-							return $post_id > 0 ? current_user_can( 'edit_post', $post_id ) : false;
+							return (bool) ( $post_id > 0 && current_user_can( 'edit_post', $post_id ) );
 						},
 					]
 				);


### PR DESCRIPTION
This pull request makes a minor change to the permission check logic in the `class-rest-api.php` file, specifically in the REST API endpoint handler. The change ensures that the return value is always a boolean by explicitly casting the result.

* Permission check now explicitly returns a boolean by casting the result of the post existence and `current_user_can` check in the REST API handler (`class-rest-api.php`).

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal permission checking logic to ensure consistent type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->