### PR TITLE
Improve SQL compatibility for SQLite-backed WP environments

### DIFF
--- a/admin/class-issues-query.php
+++ b/admin/class-issues-query.php
@@ -183,9 +183,8 @@ class Issues_Query {
 
 		global $wpdb;
 
-		$this->query['select'] = 'SELECT COUNT( DISTINCT rule, object ) ';
-
-		$sql = $this->get_sql();
+		$sql = 'SELECT COUNT(*) FROM (SELECT DISTINCT rule, object' .
+			$this->query['from'] . ' ' . $this->query['where_base'] . ' ' . $this->query['filters'] . ' ' . $this->query['limit'] . ') AS distinct_issues';
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		return $wpdb->get_var( $sql );

--- a/admin/class-purge-post-data.php
+++ b/admin/class-purge-post-data.php
@@ -91,15 +91,36 @@ class Purge_Post_Data {
 		 */
 		do_action( 'edac_before_delete_cpt_posts', $post_type );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
-		return $wpdb->query(
+		$table_name = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
+		if ( ! $table_name ) {
+			return;
+		}
+
+		$deleted_issues = $wpdb->query(
 			$wpdb->prepare(
-				"DELETE T1,T2 from $wpdb->postmeta as T1 JOIN %i as T2 ON T1.post_id = T2.postid WHERE T1.meta_key like %s and T2.siteid=%d and T2.type=%s",
-				edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' ),
-				'_edac%',
+				'DELETE FROM %i WHERE siteid=%d and type=%s',
+				$table_name,
 				get_current_blog_id(),
 				$post_type
 			)
 		);
+
+		$post_ids = get_posts(
+			[
+				'post_type'      => $post_type,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'no_found_rows'  => true,
+			]
+		);
+
+		if ( ! empty( $post_ids ) ) {
+			foreach ( $post_ids as $post_id ) {
+				self::delete_post_meta( (int) $post_id );
+			}
+		}
+
+		return $deleted_issues;
 	}
 }

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -41,9 +41,7 @@ class Update_Database {
 
 		global $wpdb;
 		$table_name   = $wpdb->prefix . 'accessibility_checker';
-		$table_exists = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
-			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table_name ) )
-		) === $table_name;
+		$table_exists = edac_table_exists( $table_name );
 		$db_version   = get_option( 'edac_db_version' );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepare above, Safe variable used for table name, caching not required for one time operation.
@@ -106,11 +104,27 @@ class Update_Database {
 		// Find records with NULL or empty selectors and update them with a fallback value.
 		// Using the record ID ensures each record has a unique selector for backward compatibility.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration query.
-		$wpdb->query(
+		$ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"UPDATE %i SET selector = CONCAT('legacy-id-', id) WHERE selector IS NULL OR selector = ''",
-				$table_name
+				'SELECT id FROM %i WHERE selector IS NULL OR selector = %s',
+				$table_name,
+				''
 			)
 		);
+
+		if ( empty( $ids ) ) {
+			return;
+		}
+
+		foreach ( $ids as $id ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'UPDATE %i SET selector = %s WHERE id = %d',
+					$table_name,
+					'legacy-id-' . (int) $id,
+					$id
+				)
+			);
+		}
 	}
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -231,7 +231,7 @@ function edac_get_post_type_label( string $post_type ): string {
  * The function first checks if the provided table name only contains alphanumeric characters, underscores, or hyphens.
  * If not, it returns null.
  *
- * After that, it checks if a table with that name actually exists in the database using the SHOW TABLES LIKE query.
+ * After that, it checks if a table with that name actually exists in the database.
  * If the table doesn't exist, it also returns null.
  *
  * If both checks are passed, it returns the valid table name.
@@ -255,14 +255,42 @@ function edac_get_valid_table_name( $table_name ) {
 	}
 
 	// Verify that the table actually exists in the database.
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+	if ( ! edac_table_exists( $table_name ) ) {
 		// Table does not exist.
 		return null;
 	}
 
 	$found_table_name = $table_name;
 	return $found_table_name;
+}
+
+/**
+ * Check if a table exists in the current database.
+ *
+ * Supports both MySQL/MariaDB and SQLite-compatible WordPress environments.
+ *
+ * @param string $table_name Table name.
+ *
+ * @return bool
+ */
+function edac_table_exists( $table_name ) {
+	global $wpdb;
+
+	if ( ! empty( $wpdb->is_mysql ) ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+	}
+
+	// SQLite and other non-MySQL drivers.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return ! empty(
+		$wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name = %s",
+				$table_name
+			)
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Ensure the plugin runs correctly in WP Playground and other SQLite-backed WordPress environments by removing MySQL-only SQL constructs. 
- Avoid `SHOW TABLES LIKE`, `COUNT(DISTINCT col1, col2)`, multi-table `DELETE ... JOIN`, and `CONCAT()` usages that break on SQLite. 

### Description
- Replaced `COUNT(DISTINCT rule, object)` in `Issues_Query::distinct_count()` with a SQLite-compatible subquery `SELECT COUNT(*) FROM (SELECT DISTINCT rule, object ...) AS distinct_issues`. 
- Introduced `edac_table_exists()` to detect table existence using `SHOW TABLES LIKE` for MySQL and `sqlite_master` for SQLite, and switched `edac_get_valid_table_name()` and DB setup checks to use it. 
- Reworked `Purge_Post_Data::delete_cpt_posts()` to remove the MySQL multi-table `DELETE ... JOIN` by performing a single-table `DELETE FROM %i` for issue rows and cleaning `_edac*` post meta via `get_posts()`/`delete_post_meta()` for matching post IDs. 
- Modified the selector migration in `Update_Database::migrate_to_selector_based_unique_id()` to avoid MySQL `CONCAT()` by selecting IDs and updating `selector` values in PHP per-row. 

### Testing
- Ran `php -l includes/helper-functions.php` with no syntax errors. 
- Ran `php -l admin/class-update-database.php` with no syntax errors. 
- Ran `php -l admin/class-issues-query.php` with no syntax errors. 
- Ran `php -l admin/class-purge-post-data.php` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b80a7a38832894098bbef10b5f81)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cross-database compatibility for SQLite and MySQL environments.
  * Improved reliability of data cleanup operations when removing post-related information.
  * Optimized query performance for retrieving and handling data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->