### PR TITLE
Fix: orphaned settings labels on options page

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -639,10 +639,12 @@ function edac_post_types_cb() {
 		<fieldset>
 			<?php
 			if ( $all_post_types ) {
-				foreach ( $all_post_types as $index => $post_type ) {
+				$position = 0;
+				foreach ( $all_post_types as $post_type ) {
 					$disabled        = in_array( $post_type, $post_types, true ) ? '' : 'disabled';
 					$post_type_label = edac_get_post_type_label( $post_type );
-					$field_id        = ( 0 === $index ) ? 'edac_post_types' : "edac_post_types_{$post_type}";
+					$field_id        = ( 0 === $position ) ? 'edac_post_types' : "edac_post_types_{$post_type}";
+					++$position;
 					?>
 					<label>
 						<input type="checkbox" name="<?php echo 'edac_post_types[]'; ?>" id="<?php echo esc_attr( $field_id ); ?>" value="<?php echo esc_attr( $post_type ); ?>"


### PR DESCRIPTION
### Motivation
- Several settings registered with `add_settings_field()` used `label_for` but their callbacks did not render matching `id` attributes, creating orphaned labels and hurting keyboard/assistive technology usability.

### Description
- Updated `includes/options-page.php` to remove the incorrect `label_for` from the Accessibility Statement Preview field because it renders preview markup rather than a focusable input.
- Added missing `id` attributes for inputs that previously lacked them, including `edac_frontend_highlighter_position`, `edac_add_footer_accessibility_statement`, `edac_include_accessibility_statement_link`, and `edac_delete_data` so labels target real controls.
- Adjusted the post-types and ignore-roles rendering to assign a stable `id` to the first checkbox (`edac_post_types` and `edac_ignore_user_roles`) and unique IDs for subsequent items to match their registered `label_for` values.
- Small loop/index handling added to ensure the first generated checkbox matches the registered `label_for` while keeping unique IDs for remaining items.

### Testing
- Ran `php -l includes/options-page.php` to verify there are no PHP syntax errors and the file parses successfully (no syntax errors detected).

Fixes: 1531
Fixes: PRO-647

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab87dd1b8c83289acaf6c93ad2acad)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings form accessibility by adding unique IDs to all form controls for better screen reader support and usability.
  * Fixed dynamic ID generation for repeated options so each checkbox/radio has a stable, unique identifier.
  * Adjusted accessibility statement preview field registration to simplify label handling and improve form behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->