### PR TITLE
Only lint staged js files when commiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist:dotorg": "npm run dist:keep-build-folder",
     "dist:keep-build-folder": "npx webpack --mode production && composer install --no-dev && composer dump-autoload --no-dev -o && ./scripts/dist.sh --keep-build-folder",
     "lint": "./vendor/bin/phpcs && npm run lint:js",
-    "lint-staged-precommit": "lint-staged && npm run lint:js",
+    "lint-staged-precommit": "lint-staged",
     "lint:php": "./vendor/bin/phpcs",
     "lint:php:fix": "./vendor/bin/phpcbf",
     "lint:js": "wp-scripts lint-js",
@@ -27,7 +27,8 @@
     "phpstan": "./vendor/bin/phpstan"
   },
   "lint-staged": {
-    "*.php": "./vendor/bin/phpcs"
+    "*.php": "./vendor/bin/phpcs",
+    "*.js": "wp-scripts lint-js"
   },
   "files": [
     "LICENSE.txt",


### PR DESCRIPTION
This pull request makes small adjustments to the linting configuration in `package.json`. The changes streamline the linting process by ensuring that staged JavaScript files are linted and by preventing redundant linting commands during pre-commit.

* Linting workflow update: The `lint-staged-precommit` script no longer runs the JavaScript linter separately, relying on `lint-staged` to handle all staged files.
* Lint-staged configuration improvement: Added JavaScript linting to the `lint-staged` section so that staged `.js` files are automatically linted with `wp-scripts lint-js`.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code linting configuration in the development process to ensure JavaScript files are properly checked during pre-commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->