### PR TITLE
Add automated fix for empty paragraph tag rule

### DIFF
--- a/includes/classes/Fixes/Fix/RemoveEmptyParagraphTagsFix.php
+++ b/includes/classes/Fixes/Fix/RemoveEmptyParagraphTagsFix.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Remove Empty Paragraph Tags Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Removes empty paragraph tags from the frontend.
+ *
+ * @since 1.28.0
+ */
+class RemoveEmptyParagraphTagsFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'remove_empty_paragraph_tags';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Remove Empty Paragraph Tags', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers the settings field for this fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ],
+		);
+	}
+
+	/**
+	 * Get the settings fields for the fix.
+	 *
+	 * @param array $fields The array of fields that are already registered, if any.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields[ 'edac_fix_' . $this->get_slug() ] = [
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Remove Empty Paragraph Tags', 'accessibility-checker' ),
+			'labelledby'  => 'remove_empty_paragraph_tags',
+			'description' => esc_html__( 'Remove empty <p> tags from frontend output to reduce screen reader noise and prevent layout hacks.', 'accessibility-checker' ),
+			'fix_slug'    => $this->get_slug(),
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Executes the fix on the frontend.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_' . $this->get_slug(), false ) ) {
+			return;
+		}
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data[ $this->get_slug() ] = [
+					'enabled' => true,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -16,6 +16,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\EmptySearchFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveEmptyParagraphTagsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\PreventLinksOpeningNewWindowFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
@@ -134,6 +135,7 @@ class FixesManager {
 				HTMLLangAndDirFix::class,
 				TabindexFix::class,
 				RemoveTitleIfPrefferedAccessibleNameFix::class,
+				RemoveEmptyParagraphTagsFix::class,
 				LinkUnderline::class,
 				MetaViewportScalableFix::class,
 				PreventLinksOpeningNewWindowFix::class,

--- a/includes/classes/Rules/Rule/EmptyParagraphTagRule.php
+++ b/includes/classes/Rules/Rule/EmptyParagraphTagRule.php
@@ -9,6 +9,7 @@ namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
 use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveEmptyParagraphTagsFix;
 
 /**
  * EmptyParagraphTag Rule class.
@@ -28,7 +29,7 @@ class EmptyParagraphTagRule implements RuleInterface {
 			'summary'               => esc_html__( 'This page contains a <p> tag with no content inside.', 'accessibility-checker' ),
 			'summary_plural'        => esc_html__( 'These pages contain <p> tags with no content inside.', 'accessibility-checker' ),
 			'why_it_matters'        => esc_html__( 'Empty paragraph tags can be announced by screen readers as blank lines or pauses, which may confuse users or disrupt reading flow. They can also interfere with visual layout or spacing, especially in assistive technology or mobile contexts.', 'accessibility-checker' ),
-			'how_to_fix'            => esc_html__( 'Remove the empty <p> tags from your content. If spacing is needed between sections, use margin, padding, or a visual spacer block instead of inserting blank paragraphs.', 'accessibility-checker' ),
+			'how_to_fix'            => esc_html__( 'Remove the empty <p> tags from your content. If spacing is needed between sections, use margin, padding, or a visual spacer block instead of inserting blank paragraphs. To automate this site-wide, enable the \'Remove Empty Paragraph Tags\' fix in Accessibility Checker settings.', 'accessibility-checker' ),
 			'references'            => [
 				[
 					'text' => __( 'MDN Web Docs: The Paragraph Element - Accessibility', 'accessibility-checker' ),
@@ -55,6 +56,9 @@ class EmptyParagraphTagRule implements RuleInterface {
 				AffectedDisabilities::LOW_VISION,
 				AffectedDisabilities::DEAFBLIND,
 				AffectedDisabilities::COGNITIVE,
+			],
+			'fixes'                 => [
+				RemoveEmptyParagraphTagsFix::get_slug(),
 			],
 		];
 	}

--- a/src/frontendFixes/Fixes/removeEmptyParagraphTagsFix.js
+++ b/src/frontendFixes/Fixes/removeEmptyParagraphTagsFix.js
@@ -1,0 +1,40 @@
+const RemoveEmptyParagraphTagsFixData = window.edac_frontend_fixes?.remove_empty_paragraph_tags || {
+	enabled: false,
+};
+
+const hasNonTextChild = ( node ) => Array.from( node.childNodes ).some( ( child ) => child.nodeType !== Node.TEXT_NODE );
+
+const isAriaHiddenTrue = ( node ) => {
+	const value = node.getAttribute( 'aria-hidden' );
+	return value && value.toLowerCase() === 'true';
+};
+
+const isEmptyParagraph = ( node ) => {
+	if ( node.tagName.toLowerCase() !== 'p' ) {
+		return false;
+	}
+
+	if ( isAriaHiddenTrue( node ) ) {
+		return false;
+	}
+
+	if ( hasNonTextChild( node ) ) {
+		return false;
+	}
+
+	return node.textContent.trim() === '';
+};
+
+const RemoveEmptyParagraphTagsFix = () => {
+	if ( ! RemoveEmptyParagraphTagsFixData.enabled ) {
+		return;
+	}
+
+	document.querySelectorAll( 'p' ).forEach( ( paragraph ) => {
+		if ( isEmptyParagraph( paragraph ) ) {
+			paragraph.remove();
+		}
+	} );
+};
+
+export default RemoveEmptyParagraphTagsFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -55,3 +55,10 @@ if ( edacFrontendFixes?.new_window_warning?.enabled ) {
 		newWindowWarning.default();
 	} );
 }
+
+if ( edacFrontendFixes?.remove_empty_paragraph_tags?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "remove-empty-paragraph-tags" */ './Fixes/removeEmptyParagraphTagsFix' ).then( ( removeEmptyParagraphTagsFix ) => {
+		removeEmptyParagraphTagsFix.default();
+	} );
+}

--- a/tests/jest/frontendFixes/removeEmptyParagraphTagsFix.test.js
+++ b/tests/jest/frontendFixes/removeEmptyParagraphTagsFix.test.js
@@ -1,0 +1,42 @@
+describe( 'RemoveEmptyParagraphTagsFix', () => {
+	let RemoveEmptyParagraphTagsFix;
+
+	beforeEach( async () => {
+		document.body.innerHTML = '';
+		window.edac_frontend_fixes = {
+			remove_empty_paragraph_tags: {
+				enabled: true,
+			},
+		};
+
+		jest.resetModules();
+		const module = await import( '../../../src/frontendFixes/Fixes/removeEmptyParagraphTagsFix.js' );
+		RemoveEmptyParagraphTagsFix = module.default;
+	} );
+
+	test( 'removes empty paragraph tags', () => {
+		document.body.innerHTML = '<p> </p><p>Real content</p><p></p>';
+
+		RemoveEmptyParagraphTagsFix();
+
+		const paragraphs = document.querySelectorAll( 'p' );
+		expect( paragraphs ).toHaveLength( 1 );
+		expect( paragraphs[ 0 ].textContent ).toBe( 'Real content' );
+	} );
+
+	test( 'does not remove paragraphs with non-text child nodes', () => {
+		document.body.innerHTML = '<p><span></span></p>';
+
+		RemoveEmptyParagraphTagsFix();
+
+		expect( document.querySelectorAll( 'p' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'does not remove aria-hidden paragraphs', () => {
+		document.body.innerHTML = '<p aria-hidden="true"></p>';
+
+		RemoveEmptyParagraphTagsFix();
+
+		expect( document.querySelectorAll( 'p' ) ).toHaveLength( 1 );
+	} );
+} );

--- a/tests/phpunit/includes/classes/Fixes/Fix/RemoveEmptyParagraphTagsFixTest.php
+++ b/tests/phpunit/includes/classes/Fixes/Fix/RemoveEmptyParagraphTagsFixTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Test class for RemoveEmptyParagraphTagsFix.
+ *
+ * @package accessibility-checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveEmptyParagraphTagsFix;
+
+require_once __DIR__ . '/FixTestTrait.php';
+
+/**
+ * Unit tests for the RemoveEmptyParagraphTagsFix class.
+ */
+class RemoveEmptyParagraphTagsFixTest extends WP_UnitTestCase {
+
+	use FixTestTrait;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->fix = new RemoveEmptyParagraphTagsFix();
+		$this->common_setup();
+	}
+
+	/**
+	 * Clean up after tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->common_teardown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the expected slug for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_slug(): string {
+		return 'remove_empty_paragraph_tags';
+	}
+
+	/**
+	 * Get the expected type for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Get the fix class name.
+	 *
+	 * @return string
+	 */
+	protected function get_fix_class_name(): string {
+		return RemoveEmptyParagraphTagsFix::class;
+	}
+
+	/**
+	 * Test that frontend data includes this fix when enabled.
+	 *
+	 * @return void
+	 */
+	public function test_frontend_data_includes_fix_when_enabled() {
+		update_option( 'edac_fix_remove_empty_paragraph_tags', true );
+		$this->fix->run();
+
+		$data = apply_filters( 'edac_filter_frontend_fixes_data', [] );
+		$this->assertArrayHasKey( 'remove_empty_paragraph_tags', $data );
+		$this->assertTrue( $data['remove_empty_paragraph_tags']['enabled'] );
+	}
+}


### PR DESCRIPTION
### Motivation

- The existing `empty_paragraph_tag` rule had no automated remediation available.  
- Removing empty `<p>` elements site-wide reduces screen reader noise and prevents layout hacks.  
- Implement the fix following the plugin's existing fixes architecture so it can be enabled from settings.

### Description

- Add `RemoveEmptyParagraphTagsFix` (`includes/classes/Fixes/Fix/RemoveEmptyParagraphTagsFix.php`) which registers a settings toggle and injects frontend payload via the `edac_filter_frontend_fixes_data` filter.  
- Register the new fix in `FixesManager::load_fixes()` so the fix is loaded and available in the fixes lifecycle.  
- Implement frontend runtime `src/frontendFixes/Fixes/removeEmptyParagraphTagsFix.js` that removes empty `<p>` elements but skips `aria-hidden="true"` paragraphs and paragraphs with non-text child nodes, and wire lazy-loading in `src/frontendFixes/index.js`.  
- Update `EmptyParagraphTagRule` to reference the new fix in its `fixes` array and add the automated option to the `how_to_fix` guidance, and add unit tests for both PHP and JS (`tests/phpunit/.../RemoveEmptyParagraphTagsFixTest.php` and `tests/jest/frontendFixes/removeEmptyParagraphTagsFix.test.js`).

### Testing

- Ran `php -l` on the new PHP files which reported no syntax errors.  
- Ran `npm run -s lint:js` on the new JS files which completed without errors.  
- Ran Jest with `npm run -s test:jest -- --runTestsByPath tests/jest/frontendFixes/removeEmptyParagraphTagsFix.test.js` and the test suite passed.  
- Attempted `vendor/bin/phpunit` for the new PHPUnit test but it could not run in this environment due to missing `/tmp/wordpress-tests-lib/includes/functions.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc875142888328a069705b865fd7b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated empty paragraph tag removal in Accessibility Checker settings. When enabled, automatically removes empty `<p>` elements site-wide while preserving paragraphs with text, child elements, or `aria-hidden` attributes.
  * Integrated with the Empty Paragraph Tag accessibility rule for streamlined automated remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->