### PR TITLE
Add Iframe Missing Title fix (frontend + tests)

### DIFF
--- a/includes/classes/Fixes/Fix/IframeMissingTitleFix.php
+++ b/includes/classes/Fixes/Fix/IframeMissingTitleFix.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Iframe Missing Title Fix Class.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds descriptive title attributes to iframes missing one.
+ *
+ * @since 1.28.0
+ */
+class IframeMissingTitleFix implements FixInterface {
+	/**
+	 * The slug for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'iframe_missing_title';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Add Missing iFrame Titles', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Register settings fields.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ]
+		);
+	}
+
+	/**
+	 * Get the settings fields for this fix.
+	 *
+	 * @param array $fields Existing fields.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields[ 'edac_fix_' . $this->get_slug() ] = [
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Add Missing iFrame Titles', 'accessibility-checker' ),
+			'labelledby'  => $this->get_slug(),
+			'description' => esc_html__( 'Add default title attributes to iframe elements when a title is missing.', 'accessibility-checker' ),
+			'fix_slug'    => $this->get_slug(),
+			'group_name'  => $this->get_nicename(),
+			'help_id'     => 1953,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Run the fix.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_' . $this->get_slug(), false ) ) {
+			return;
+		}
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data[ $this->get_slug() ] = [
+					'enabled'        => true,
+					'fallback_title' => esc_html__( 'Embedded content', 'accessibility-checker' ),
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -15,6 +15,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\BlockPDFUploadsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\EmptySearchFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\IframeMissingTitleFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\PreventLinksOpeningNewWindowFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
@@ -143,6 +144,7 @@ class FixesManager {
 				AddMissingOrEmptyPageTitleFix::class,
 				AddLabelToUnlabelledFormFieldsFix::class,
 				AddNewWindowWarningFix::class,
+				IframeMissingTitleFix::class,
 				EmptySearchFix::class,
 			]
 		);

--- a/src/frontendFixes/Fixes/iframeMissingTitleFix.js
+++ b/src/frontendFixes/Fixes/iframeMissingTitleFix.js
@@ -1,0 +1,41 @@
+const IframeMissingTitleFixData = window.edac_frontend_fixes?.iframe_missing_title || {
+	enabled: false,
+	fallback_title: 'Embedded content',
+};
+
+const getIframeTitle = ( iframe ) => {
+	const src = iframe.getAttribute( 'src' ) || '';
+	if ( ! src ) {
+		return IframeMissingTitleFixData.fallback_title;
+	}
+
+	try {
+		const srcUrl = new URL( src, window.location.href );
+		if ( srcUrl.hostname ) {
+			return `${ IframeMissingTitleFixData.fallback_title } from ${ srcUrl.hostname }`;
+		}
+	} catch ( error ) {
+		// Ignore invalid URL and use fallback title.
+	}
+
+	return IframeMissingTitleFixData.fallback_title;
+};
+
+const IframeMissingTitleFix = () => {
+	if ( ! IframeMissingTitleFixData.enabled ) {
+		return;
+	}
+
+	const iframes = document.querySelectorAll( 'iframe' );
+
+	iframes.forEach( ( iframe ) => {
+		const currentTitle = iframe.getAttribute( 'title' );
+		if ( currentTitle && currentTitle.trim() ) {
+			return;
+		}
+
+		iframe.setAttribute( 'title', getIframeTitle( iframe ) );
+	} );
+};
+
+export default IframeMissingTitleFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -55,3 +55,10 @@ if ( edacFrontendFixes?.new_window_warning?.enabled ) {
 		newWindowWarning.default();
 	} );
 }
+
+if ( edacFrontendFixes?.iframe_missing_title?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "iframe-missing-title" */ './Fixes/iframeMissingTitleFix' ).then( ( iframeMissingTitleFix ) => {
+		iframeMissingTitleFix.default();
+	} );
+}

--- a/tests/jest/frontendFixes/iframeMissingTitleFix.test.js
+++ b/tests/jest/frontendFixes/iframeMissingTitleFix.test.js
@@ -1,0 +1,57 @@
+/**
+ * Tests for iframe missing title frontend fix.
+ */
+
+describe( 'IframeMissingTitleFix', () => {
+	let IframeMissingTitleFix;
+
+	beforeEach( async () => {
+		document.body.innerHTML = '';
+		window.edac_frontend_fixes = {
+			iframe_missing_title: {
+				enabled: true,
+				fallback_title: 'Embedded content',
+			},
+		};
+
+		jest.resetModules();
+		const module = await import( '../../../src/frontendFixes/Fixes/iframeMissingTitleFix.js' );
+		IframeMissingTitleFix = module.default;
+	} );
+
+	test( 'adds fallback title to iframe without title', () => {
+		document.body.innerHTML = '<iframe src="https://example.com/embed"></iframe>';
+
+		IframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Embedded content from example.com' );
+	} );
+
+	test( 'keeps existing non-empty title unchanged', () => {
+		document.body.innerHTML = '<iframe src="https://example.com/embed" title="Video player"></iframe>';
+
+		IframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Video player' );
+	} );
+
+	test( 'adds fallback title when iframe has empty title attribute', () => {
+		document.body.innerHTML = '<iframe src="https://example.com/embed" title="   "></iframe>';
+
+		IframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Embedded content from example.com' );
+	} );
+
+	test( 'uses fallback title when iframe has no src', () => {
+		document.body.innerHTML = '<iframe></iframe>';
+
+		IframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Embedded content' );
+	} );
+} );

--- a/tests/phpunit/includes/classes/Fixes/Fix/IframeMissingTitleFixTest.php
+++ b/tests/phpunit/includes/classes/Fixes/Fix/IframeMissingTitleFixTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Test class for IframeMissingTitleFix.
+ *
+ * @package accessibility-checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\IframeMissingTitleFix;
+
+require_once __DIR__ . '/FixTestTrait.php';
+
+/**
+ * Unit tests for the IframeMissingTitleFix class.
+ */
+class IframeMissingTitleFixTest extends WP_UnitTestCase {
+
+	use FixTestTrait;
+
+	/**
+	 * Set up test instance.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->fix = new IframeMissingTitleFix();
+		$this->common_setup();
+	}
+
+	/**
+	 * Clean up after tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->common_teardown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Get expected slug.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_slug(): string {
+		return 'iframe_missing_title';
+	}
+
+	/**
+	 * Get expected type.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Get fix class name.
+	 *
+	 * @return string
+	 */
+	protected function get_fix_class_name(): string {
+		return IframeMissingTitleFix::class;
+	}
+
+	/**
+	 * Test fallback title value is added to frontend data.
+	 *
+	 * @return void
+	 */
+	public function test_frontend_data_contains_fallback_title() {
+		update_option( 'edac_fix_iframe_missing_title', true );
+		$this->fix->run();
+
+		$data = apply_filters( 'edac_filter_frontend_fixes_data', [] );
+		$this->assertArrayHasKey( 'iframe_missing_title', $data );
+		$this->assertSame( 'Embedded content', $data['iframe_missing_title']['fallback_title'] );
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide an automated frontend fix to add descriptive `title` attributes to `iframe` elements that are missing one to improve accessibility.

### Description

- Add a new PHP fix class `IframeMissingTitleFix` that registers settings and exposes frontend data including a `fallback_title` when the fix is enabled.
- Register the new fix in `FixesManager` by including `IframeMissingTitleFix::class` in the fixes list.
- Implement the client-side behavior in `src/frontendFixes/Fixes/iframeMissingTitleFix.js` which sets a fallback title and appends the iframe hostname when available.  
- Wire the frontend module into `src/frontendFixes/index.js` for lazy loading, and add unit tests in `tests/jest/frontendFixes/iframeMissingTitleFix.test.js` and a PHPUnit test in `tests/phpunit/includes/classes/Fixes/Fix/IframeMissingTitleFixTest.php`.

### Testing

- Ran the JavaScript unit tests with `npm test` which executed `tests/jest/frontendFixes/iframeMissingTitleFix.test.js` and they passed.  
- Ran PHP unit tests with `vendor/bin/phpunit` which executed `IframeMissingTitleFixTest` and the new assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc891deef083288e479cf9ee26b816)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic title detection and assignment for embedded content (iframes) when titles are missing, with fallback text support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->