### PR TITLE
Add Remove Text Justification frontend fix and tests

### DIFF
--- a/includes/classes/Fixes/Fix/RemoveTextJustificationFix.php
+++ b/includes/classes/Fixes/Fix/RemoveTextJustificationFix.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Remove Text Justification Fix Class.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Forces justified text blocks to use left alignment.
+ *
+ * @since 1.30.0
+ */
+class RemoveTextJustificationFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'remove_text_justification';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Remove Text Justification', 'accessibility-checker' );
+	}
+
+	/**
+	 * The fancyname for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_fancyname(): string {
+		return __( 'Left-align Justified Text', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ],
+		);
+	}
+
+	/**
+	 * Get the settings fields for the fix.
+	 *
+	 * @param array $fields The array of fields that are already registered, if any.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields[ 'edac_fix_' . $this->get_slug() ] = [
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Force Left Aligned Text', 'accessibility-checker' ),
+			'labelledby'  => 'force_left_aligned_text',
+			'description' => esc_html__( 'Replace justified text alignment with left alignment for long text content.', 'accessibility-checker' ),
+			'fix_slug'    => $this->get_slug(),
+			'help_id'     => 1980,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Run the fix.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_' . $this->get_slug(), false ) ) {
+			return;
+		}
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				/**
+				 * Filters the selector used for removing text justification.
+				 *
+				 * @since 1.30.0
+				 *
+				 * @hook edac_fix_remove_text_justification_target
+				 *
+				 * @param string $target_selector The selector to find justified text elements.
+				 *
+				 * @return string Modified selector.
+				 */
+				$target_selector = apply_filters(
+					'edac_fix_remove_text_justification_target',
+					'p, span, small, strong, b, i, em, h1, h2, h3, h4, h5, h6, a, label, button, th, td, li, div, blockquote, address, cite, q, s, sub, sup, u, del, caption, dt, dd, figcaption, summary, data, time'
+				);
+
+				$data[ $this->get_slug() ] = [
+					'enabled' => true,
+					'target'  => $target_selector,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -16,6 +16,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\EmptySearchFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTextJustificationFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\PreventLinksOpeningNewWindowFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\SkipLinkFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
@@ -135,6 +136,7 @@ class FixesManager {
 				TabindexFix::class,
 				RemoveTitleIfPrefferedAccessibleNameFix::class,
 				LinkUnderline::class,
+				RemoveTextJustificationFix::class,
 				MetaViewportScalableFix::class,
 				PreventLinksOpeningNewWindowFix::class,
 				FocusOutlineFix::class,

--- a/src/frontendFixes/Fixes/removeTextJustificationFix.js
+++ b/src/frontendFixes/Fixes/removeTextJustificationFix.js
@@ -1,0 +1,27 @@
+const RemoveTextJustificationFixData = window.edac_frontend_fixes?.remove_text_justification || {
+	enabled: false,
+};
+
+const TEXT_JUSTIFIED_CHECK_THRESHOLD = 200;
+
+const RemoveTextJustificationFix = () => {
+	if ( ! RemoveTextJustificationFixData.enabled ) {
+		return;
+	}
+
+	const targets = document.querySelectorAll( RemoveTextJustificationFixData.target || 'p' );
+	targets.forEach( ( target ) => {
+		if ( target.textContent.trim().length < TEXT_JUSTIFIED_CHECK_THRESHOLD ) {
+			return;
+		}
+
+		const style = window.getComputedStyle( target );
+		if ( style.textAlign.toLowerCase() !== 'justify' ) {
+			return;
+		}
+
+		target.style.textAlign = 'left';
+	} );
+};
+
+export default RemoveTextJustificationFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -42,6 +42,14 @@ if ( edacFrontendFixes?.underline?.enabled ) {
 	} );
 }
 
+
+if ( edacFrontendFixes?.remove_text_justification?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "remove-text-justification" */ './Fixes/removeTextJustificationFix' ).then( ( removeTextJustificationFix ) => {
+		removeTextJustificationFix.default();
+	} );
+}
+
 if ( edacFrontendFixes?.prevent_links_opening_new_windows?.enabled ) {
 	// lazy import the module
 	import( /* webpackChunkName: "prevent-links-opening-in-new-window" */ './Fixes/preventLinksOpeningNewWindowFix' ).then( ( preventLinksOpeningNewWindowFix ) => {

--- a/tests/jest/frontendFixes/removeTextJustificationFix.test.js
+++ b/tests/jest/frontendFixes/removeTextJustificationFix.test.js
@@ -1,0 +1,55 @@
+/**
+ * Tests for removeTextJustificationFix
+ */
+
+describe( 'removeTextJustificationFix', () => {
+	let RemoveTextJustificationFix;
+	const originalFixes = window.edac_frontend_fixes;
+
+	beforeEach( async () => {
+		document.body.innerHTML = '';
+		window.edac_frontend_fixes = {
+			remove_text_justification: {
+				enabled: true,
+				target: 'p',
+			},
+		};
+
+		jest.resetModules();
+		const module = await import( '../../../src/frontendFixes/Fixes/removeTextJustificationFix.js' );
+		RemoveTextJustificationFix = module.default;
+	} );
+
+	afterEach( () => {
+		window.edac_frontend_fixes = originalFixes;
+	} );
+
+	test( 'changes justified long text to left aligned', () => {
+		const text = 'A'.repeat( 210 );
+		document.body.innerHTML = `<p style="text-align: justify">${ text }</p>`;
+
+		RemoveTextJustificationFix();
+
+		const paragraph = document.querySelector( 'p' );
+		expect( paragraph.style.textAlign ).toBe( 'left' );
+	} );
+
+	test( 'does not change short justified text', () => {
+		document.body.innerHTML = '<p style="text-align: justify">Short text</p>';
+
+		RemoveTextJustificationFix();
+
+		const paragraph = document.querySelector( 'p' );
+		expect( paragraph.style.textAlign ).toBe( 'justify' );
+	} );
+
+	test( 'does not change long non-justified text', () => {
+		const text = 'A'.repeat( 210 );
+		document.body.innerHTML = `<p style="text-align: left">${ text }</p>`;
+
+		RemoveTextJustificationFix();
+
+		const paragraph = document.querySelector( 'p' );
+		expect( paragraph.style.textAlign ).toBe( 'left' );
+	} );
+} );

--- a/tests/phpunit/includes/classes/Fixes/Fix/RemoveTextJustificationFixTest.php
+++ b/tests/phpunit/includes/classes/Fixes/Fix/RemoveTextJustificationFixTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Test class for RemoveTextJustificationFix.
+ *
+ * @package accessibility-checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTextJustificationFix;
+
+require_once __DIR__ . '/FixTestTrait.php';
+
+/**
+ * Unit tests for the RemoveTextJustificationFix class.
+ */
+class RemoveTextJustificationFixTest extends WP_UnitTestCase {
+
+	use FixTestTrait;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->fix = new RemoveTextJustificationFix();
+		$this->common_setup();
+	}
+
+	/**
+	 * Clean up after tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->common_teardown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the expected slug for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_slug(): string {
+		return 'remove_text_justification';
+	}
+
+	/**
+	 * Get the expected type for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Get the fix class name.
+	 *
+	 * @return string
+	 */
+	protected function get_fix_class_name(): string {
+		return RemoveTextJustificationFix::class;
+	}
+
+	/**
+	 * Test that default selector is included in frontend fix data.
+	 *
+	 * @return void
+	 */
+	public function test_frontend_data_has_default_target_selector() {
+		update_option( 'edac_fix_remove_text_justification', true );
+		$this->fix->run();
+
+		$data = apply_filters( 'edac_filter_frontend_fixes_data', [] );
+		$this->assertArrayHasKey( 'remove_text_justification', $data );
+		$this->assertArrayHasKey( 'target', $data['remove_text_justification'] );
+		$this->assertStringContainsString( 'p, span', $data['remove_text_justification']['target'] );
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a frontend fix to replace long blocks of justified text with left alignment to improve readability and accessibility.

### Description
- Add a new PHP fix class `RemoveTextJustificationFix` that implements `FixInterface`, registers a settings checkbox and exposes a target selector via the `edac_filter_frontend_fixes_data` filter.
- Register the fix in `FixesManager::load_fixes` by adding `RemoveTextJustificationFix::class` to the fixes list.
- Add a frontend module `src/frontendFixes/Fixes/removeTextJustificationFix.js` that detects long justified elements (threshold `200` characters) and forces `style.textAlign = 'left'` for matched targets.
- Wire the frontend module into the lazy-loading entry in `src/frontendFixes/index.js` and add corresponding Jest and PHPUnit tests for the new functionality.

### Testing
- Added and ran the Jest unit test `tests/jest/frontendFixes/removeTextJustificationFix.test.js`, which verifies long justified text is left-aligned and short/non-justified text is unchanged, and the tests passed.
- Added and ran the PHPUnit test `tests/phpunit/includes/classes/Fixes/Fix/RemoveTextJustificationFixTest.php`, which verifies registration, type and frontend data target selector, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc8d4408a88328964994dee81a749f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new accessibility enhancement that removes text justification from page elements. Users can enable this fix through the settings interface. When activated, the system automatically adjusts any justified text alignment to left alignment for improved readability. The fix intelligently targets specific page elements and only processes text content longer than 200 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->