### PR TITLE
Add frontend fix to remove empty <p> tags

### DIFF
--- a/includes/classes/Fixes/Fix/EmptyParagraphTagFix.php
+++ b/includes/classes/Fixes/Fix/EmptyParagraphTagFix.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Empty Paragraph Tag Fix Class.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles removing empty paragraph tags on the frontend.
+ *
+ * @since 1.16.0
+ */
+class EmptyParagraphTagFix implements FixInterface {
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'remove_empty_paragraph_tags';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Remove Empty Paragraph Tags', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers the settings field for removing empty paragraph tags.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ]
+		);
+	}
+
+	/**
+	 * Returns the settings field for removing empty paragraph tags.
+	 *
+	 * @param array $fields Existing fields.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields['edac_fix_remove_empty_paragraph_tags'] = [
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Remove Empty Paragraph Tags', 'accessibility-checker' ),
+			'labelledby'  => 'remove_empty_paragraph_tags',
+			// translators: %s is <code>&lt;p&gt;</code>.
+			'description' => sprintf( __( 'Remove empty %s tags from the page output.', 'accessibility-checker' ), '<code>&lt;p&gt;</code>' ),
+			'fix_slug'    => $this->get_slug(),
+			'group_name'  => $this->get_nicename(),
+			'help_id'     => 7870,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Executes the empty paragraph tag fix on the frontend.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( ! get_option( 'edac_fix_remove_empty_paragraph_tags', false ) ) {
+			return;
+		}
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data['empty_paragraph_tag'] = [
+					'enabled' => true,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -14,6 +14,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddNewWindowWarningFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\BlockPDFUploadsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\EmptySearchFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\EmptyParagraphTagFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\PreventLinksOpeningNewWindowFix;
@@ -144,6 +145,7 @@ class FixesManager {
 				AddLabelToUnlabelledFormFieldsFix::class,
 				AddNewWindowWarningFix::class,
 				EmptySearchFix::class,
+				EmptyParagraphTagFix::class,
 			]
 		);
 		if ( ! is_array( $fixes ) ) {

--- a/src/frontendFixes/Fixes/emptyParagraphTagFix.js
+++ b/src/frontendFixes/Fixes/emptyParagraphTagFix.js
@@ -1,0 +1,30 @@
+const EmptyParagraphTagFixData = window.edac_frontend_fixes?.empty_paragraph_tag || {
+	enabled: false,
+};
+
+const EmptyParagraphTagFix = () => {
+	if ( ! EmptyParagraphTagFixData.enabled ) {
+		return;
+	}
+
+	const paragraphElements = document.querySelectorAll( 'p' );
+
+	paragraphElements.forEach( ( paragraphElement ) => {
+		if ( paragraphElement.getAttribute( 'aria-hidden' )?.toLowerCase() === 'true' ) {
+			return;
+		}
+
+		const hasNonTextChildNodes = Array.from( paragraphElement.childNodes ).some( ( childNode ) => childNode.nodeType !== 3 );
+		if ( hasNonTextChildNodes ) {
+			return;
+		}
+
+		if ( paragraphElement.textContent.trim() !== '' ) {
+			return;
+		}
+
+		paragraphElement.remove();
+	} );
+};
+
+export default EmptyParagraphTagFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -55,3 +55,10 @@ if ( edacFrontendFixes?.new_window_warning?.enabled ) {
 		newWindowWarning.default();
 	} );
 }
+
+if ( edacFrontendFixes?.empty_paragraph_tag?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "empty-paragraph-tag" */ './Fixes/emptyParagraphTagFix' ).then( ( emptyParagraphTagFix ) => {
+		emptyParagraphTagFix.default();
+	} );
+}


### PR DESCRIPTION
### Motivation

- Provide a frontend fix that removes empty paragraph tags from page output to reduce extraneous empty `<p>` elements and improve accessibility/markup cleanliness.

### Description

- Add a new PHP fix class `EmptyParagraphTagFix` that implements `FixInterface`, registers a settings field `edac_fix_remove_empty_paragraph_tags`, and exposes frontend fix data when the option is enabled.
- Register the new fix in `FixesManager` by adding `EmptyParagraphTagFix::class` to the list of loaded fixes.
- Add a frontend module `src/frontendFixes/Fixes/emptyParagraphTagFix.js` that removes `<p>` elements which contain only text nodes and whose trimmed `textContent` is empty and not `aria-hidden`, and wire it into `src/frontendFixes/index.js` with a lazy import guarded by `edacFrontendFixes.empty_paragraph_tag.enabled`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc8fc2dd7c8328b95ff37f8ab168a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configurable frontend fix for automatically removing empty paragraph tags from web pages. When enabled via the accessibility checker settings, this fix efficiently detects and removes empty `<p>` HTML elements while maintaining respect for accessibility attributes and preserving any paragraphs that contain meaningful text content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->