### PR TITLE
Add 'Minimum Text Size' frontend fix with JS implementation and tests

### DIFF
--- a/includes/classes/Fixes/Fix/MinimumTextSizeFix.php
+++ b/includes/classes/Fixes/Fix/MinimumTextSizeFix.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Minimum Text Size Fix.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enforces a minimum text size on frontend content.
+ *
+ * @since 1.16.0
+ */
+class MinimumTextSizeFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'minimum_text_size';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Enforce Minimum Text Size', 'accessibility-checker' );
+	}
+
+	/**
+	 * The fancyname for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_fancyname(): string {
+		return __( 'Increase Small Text', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ],
+		);
+	}
+
+	/**
+	 * Get the settings fields for the fix.
+	 *
+	 * @param array $fields The array of fields that are already registered, if any.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields['edac_fix_minimum_text_size'] = [
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Enforce Minimum Text Size', 'accessibility-checker' ),
+			'labelledby'  => 'minimum_text_size',
+			'description' => esc_html__( 'Increase text smaller than the minimum size to improve readability.', 'accessibility-checker' ),
+			'fix_slug'    => $this->get_slug(),
+			'group_name'  => $this->get_nicename(),
+			'help_id'     => 1975,
+		];
+
+		$fields['edac_fix_minimum_text_size_px'] = [
+			'type'        => 'text',
+			'label'       => esc_html__( 'Minimum Text Size (px)', 'accessibility-checker' ),
+			'labelledby'  => 'minimum_text_size_px',
+			'description' => esc_html__( 'Set the minimum font size in pixels. Values below 10 default to 10.', 'accessibility-checker' ),
+			'default'     => '10',
+			'fix_slug'    => $this->get_slug(),
+			'group_name'  => $this->get_nicename(),
+			'help_id'     => 1975,
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Run the fix for minimum text size.
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		if ( ! get_option( 'edac_fix_minimum_text_size', false ) ) {
+			return;
+		}
+
+		$min_size = max( 10, absint( get_option( 'edac_fix_minimum_text_size_px', 10 ) ) );
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) use ( $min_size ) {
+				$data[ $this->get_slug() ] = [
+					'enabled'  => true,
+					'min_size' => $min_size,
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -22,6 +22,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\LinkUnderline;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\MetaViewportScalableFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\FocusOutlineFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\MinimumTextSizeFix;
 use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -144,6 +145,7 @@ class FixesManager {
 				AddLabelToUnlabelledFormFieldsFix::class,
 				AddNewWindowWarningFix::class,
 				EmptySearchFix::class,
+				MinimumTextSizeFix::class,
 			]
 		);
 		if ( ! is_array( $fixes ) ) {

--- a/includes/classes/Rules/Rule/TextSmallRule.php
+++ b/includes/classes/Rules/Rule/TextSmallRule.php
@@ -9,6 +9,7 @@ namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
 use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\MinimumTextSizeFix;
 
 /**
  * TextSmall Rule class.
@@ -48,6 +49,9 @@ class TextSmallRule implements RuleInterface {
 			'severity'              => 3, // Medium.
 			'affected_disabilities' => [
 				AffectedDisabilities::LOW_VISION,
+			],
+			'fixes'                 => [
+				MinimumTextSizeFix::get_slug(),
 			],
 		];
 	}

--- a/src/frontendFixes/Fixes/minimumTextSizeFix.js
+++ b/src/frontendFixes/Fixes/minimumTextSizeFix.js
@@ -1,0 +1,56 @@
+const EXCLUDED_SELECTOR = [
+	'script',
+	'style',
+	'svg',
+	'path',
+	'code',
+	'pre',
+	'textarea',
+	'input',
+	'select',
+	'option',
+].join( ',' );
+
+const isElementExcluded = ( element ) => element.matches( EXCLUDED_SELECTOR ) || element.closest( EXCLUDED_SELECTOR );
+
+const hasReadableTextNode = ( element ) => {
+	const text = Array.from( element.childNodes )
+		.filter( ( node ) => node.nodeType === Node.TEXT_NODE )
+		.map( ( node ) => node.textContent.trim() )
+		.join( ' ' );
+
+	return text.length > 0;
+};
+
+const applyMinimumTextSize = ( element, minSize ) => {
+	if ( isElementExcluded( element ) ) {
+		return;
+	}
+
+	if ( ! hasReadableTextNode( element ) ) {
+		return;
+	}
+
+	const computedStyle = window.getComputedStyle( element );
+	const fontSize = parseFloat( computedStyle.fontSize || '0' );
+	if ( Number.isNaN( fontSize ) || fontSize >= minSize ) {
+		return;
+	}
+
+	element.style.fontSize = `${ minSize }px`;
+};
+
+const minimumTextSizeFix = () => {
+	const edacFrontendFixes = window.edac_frontend_fixes || {};
+	const minSize = Math.max( 10, Number.parseInt( edacFrontendFixes.minimum_text_size?.min_size || 10, 10 ) );
+
+	const walker = document.createTreeWalker( document.body, NodeFilter.SHOW_ELEMENT );
+	const elements = [];
+	while ( walker.nextNode() ) {
+		elements.push( walker.currentNode );
+	}
+
+	elements.forEach( ( element ) => applyMinimumTextSize( element, minSize ) );
+};
+
+export default minimumTextSizeFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -55,3 +55,10 @@ if ( edacFrontendFixes?.new_window_warning?.enabled ) {
 		newWindowWarning.default();
 	} );
 }
+
+if ( edacFrontendFixes?.minimum_text_size?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "minimum-text-size" */ './Fixes/minimumTextSizeFix' ).then( ( minimumTextSizeFix ) => {
+		minimumTextSizeFix.default();
+	} );
+}

--- a/tests/jest/frontendFixes/minimumTextSizeFix.test.js
+++ b/tests/jest/frontendFixes/minimumTextSizeFix.test.js
@@ -1,0 +1,47 @@
+describe( 'minimumTextSizeFix', () => {
+	let minimumTextSizeFix;
+
+	beforeEach( async () => {
+		document.body.innerHTML = '';
+		window.edac_frontend_fixes = {
+			minimum_text_size: {
+				enabled: true,
+				min_size: 10,
+			},
+		};
+
+		jest.resetModules();
+		( { default: minimumTextSizeFix } = await import( '../../../src/frontendFixes/Fixes/minimumTextSizeFix' ) );
+	} );
+
+	test( 'increases text size for readable text below minimum', () => {
+		document.body.innerHTML = '<p id="small">small text</p>';
+		const el = document.getElementById( 'small' );
+		el.style.fontSize = '8px';
+
+		minimumTextSizeFix();
+
+		expect( el.style.fontSize ).toBe( '10px' );
+	} );
+
+	test( 'does not modify excluded elements', () => {
+		document.body.innerHTML = '<code id="code">tiny code</code>';
+		const el = document.getElementById( 'code' );
+		el.style.fontSize = '8px';
+
+		minimumTextSizeFix();
+
+		expect( el.style.fontSize ).toBe( '8px' );
+	} );
+
+	test( 'respects configured minimum when higher than default', () => {
+		window.edac_frontend_fixes.minimum_text_size.min_size = 14;
+		document.body.innerHTML = '<span id="small">small text</span>';
+		const el = document.getElementById( 'small' );
+		el.style.fontSize = '11px';
+
+		minimumTextSizeFix();
+
+		expect( el.style.fontSize ).toBe( '14px' );
+	} );
+} );

--- a/tests/phpunit/includes/classes/Fixes/Fix/MinimumTextSizeFixTest.php
+++ b/tests/phpunit/includes/classes/Fixes/Fix/MinimumTextSizeFixTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Test class for MinimumTextSizeFix.
+ *
+ * @package accessibility-checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\MinimumTextSizeFix;
+
+require_once __DIR__ . '/FixTestTrait.php';
+
+/**
+ * Unit tests for the MinimumTextSizeFix class.
+ */
+class MinimumTextSizeFixTest extends WP_UnitTestCase {
+
+	use FixTestTrait;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->fix = new MinimumTextSizeFix();
+		$this->common_setup();
+	}
+
+	/**
+	 * Clean up after tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->common_teardown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the expected slug for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_slug(): string {
+		return 'minimum_text_size';
+	}
+
+	/**
+	 * Get the expected type for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Get the fix class name.
+	 *
+	 * @return string
+	 */
+	protected function get_fix_class_name(): string {
+		return MinimumTextSizeFix::class;
+	}
+
+	/**
+	 * Get the options used by this fix.
+	 *
+	 * @return array
+	 */
+	protected function get_fix_option_names(): array {
+		return [
+			'edac_fix_minimum_text_size',
+			'edac_fix_minimum_text_size_px',
+		];
+	}
+
+	/**
+	 * Test that minimum size setting is sanitized.
+	 *
+	 * @return void
+	 */
+	public function test_frontend_data_enforces_minimum_floor() {
+		update_option( 'edac_fix_minimum_text_size', true );
+		update_option( 'edac_fix_minimum_text_size_px', 4 );
+
+		$this->fix->run();
+
+		$data = apply_filters( 'edac_filter_frontend_fixes_data', [] );
+		$this->assertArrayHasKey( 'minimum_text_size', $data );
+		$this->assertEquals( 10, $data['minimum_text_size']['min_size'] );
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide an automated frontend fix to increase text that is too small to improve readability and satisfy the existing "Text Too Small" rule.
- Surface a configurable setting so administrators can enable the behavior and choose a pixel floor while enforcing a sensible minimum.

### Description

- Add a new PHP fix class `MinimumTextSizeFix` that registers settings fields (`edac_fix_minimum_text_size` and `edac_fix_minimum_text_size_px`), enforces a minimum floor of `10` pixels, and exposes frontend configuration via the `edac_filter_frontend_fixes_data` filter.
- Register the new fix in `FixesManager` and reference the fix slug in the `TextSmallRule` `fixes` array so the rule can suggest the fix.
- Implement the frontend behavior in `src/frontendFixes/Fixes/minimumTextSizeFix.js`, which walks the DOM, ignores excluded elements (e.g. `script`, `style`, `code`, `pre`, form controls, SVG), detects readable text nodes, and sets inline `font-size` to the configured minimum when smaller than that minimum.
- Wire lazy loading for the frontend fix in `src/frontendFixes/index.js` and add unit tests for both frontend and backend behavior.

### Testing

- Added Jest tests in `tests/jest/frontendFixes/minimumTextSizeFix.test.js` that verify small readable elements are increased, excluded elements are untouched, and custom minimums are respected; these tests were run with `npm test` and passed.
- Added PHPUnit tests in `tests/phpunit/includes/classes/Fixes/Fix/MinimumTextSizeFixTest.php` to validate settings, option names, type/slug, and that the minimum floor of `10` is enforced; these tests were run with `phpunit` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc936c449483288b32cd78c11b78af)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Enforce Minimum Text Size" accessibility fix. Site administrators can enable this feature and set the minimum font size (default 10px) to ensure text readability across the site. The feature automatically increases small text while preserving code blocks and other special content.

* **Tests**
  * Added comprehensive test coverage for the minimum text size feature, including functionality and configuration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->