### PR TITLE
Add iframe missing title fix (backend + frontend) with tests

### DIFF
--- a/includes/classes/Fixes/Fix/IframeMissingTitleFix.php
+++ b/includes/classes/Fixes/Fix/IframeMissingTitleFix.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Iframe Missing Title Fix class.
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds fallback titles to iframes when they are missing.
+ *
+ * @since 1.33.0
+ */
+class IframeMissingTitleFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'iframe_missing_title';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Add Missing iframe Titles', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers everything needed for the fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ],
+		);
+	}
+
+	/**
+	 * Get the settings fields for the fix.
+	 *
+	 * @param array $fields The array of fields that are already registered, if any.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields[ 'edac_fix_' . $this->get_slug() ] = [
+			'label'       => esc_html__( 'Add Missing iframe Titles', 'accessibility-checker' ),
+			'type'        => 'checkbox',
+			'labelledby'  => '',
+			'description' => esc_html__( 'Adds a generated, descriptive title to iframe elements that are missing one.', 'accessibility-checker' ),
+			'fix_slug'    => $this->get_slug(),
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Run the iframe title fix.
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		if ( ! get_option( 'edac_fix_' . $this->get_slug(), false ) ) {
+			return;
+		}
+
+		add_filter(
+			'edac_filter_frontend_fixes_data',
+			function ( $data ) {
+				$data[ $this->get_slug() ] = [
+					'enabled' => get_option( 'edac_fix_' . $this->get_slug(), false ),
+				];
+				return $data;
+			}
+		);
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -22,6 +22,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\TabindexFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\LinkUnderline;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\MetaViewportScalableFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\FocusOutlineFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\IframeMissingTitleFix;
 use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\FixesPage;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -144,6 +145,7 @@ class FixesManager {
 				AddLabelToUnlabelledFormFieldsFix::class,
 				AddNewWindowWarningFix::class,
 				EmptySearchFix::class,
+				IframeMissingTitleFix::class,
 			]
 		);
 		if ( ! is_array( $fixes ) ) {

--- a/includes/classes/Rules/Rule/IframeMissingTitleRule.php
+++ b/includes/classes/Rules/Rule/IframeMissingTitleRule.php
@@ -9,6 +9,7 @@ namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
 use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\IframeMissingTitleFix;
 
 /**
  * IframeMissingTitle Rule class.
@@ -38,7 +39,7 @@ class IframeMissingTitleRule implements RuleInterface {
 			'why_it_matters'        => esc_html__( 'Screen readers rely on the title attribute of an iframe to describe its purpose or content. Without a title, users may not understand what the embedded content is, making the page harder to navigate and use.', 'accessibility-checker' ),
 			'how_to_fix'            => sprintf(
 			// translators: %1$s is <code>&lt;iframe&gt;</code.
-				esc_html__( 'Add a title attribute to the %1$s tag that accurately describes the content or function of the embedded frame. If the iframe is added by a plugin and the title cannot be edited directly, check the plugin settings for an accessibility option, or contact the developer for support. Consider switching to a WordPress core embed instead.', 'accessibility-checker' ),
+				esc_html__( 'Add a title attribute to the %1$s tag that accurately describes the content or function of the embedded frame. If the iframe is added by a plugin and the title cannot be edited directly, check the plugin settings for an accessibility option, or contact the developer for support. Consider switching to a WordPress core embed instead. To add fallback titles site-wide, enable the \'Add Missing iframe Titles\' fix in Accessibility Checker settings.', 'accessibility-checker' ),
 				'<code>&lt;iframe&gt;</code>'
 			),
 			'references'            => [
@@ -62,6 +63,9 @@ class IframeMissingTitleRule implements RuleInterface {
 			],
 			'combines'              => [
 				'frame-title',
+			],
+			'fixes'                 => [
+				IframeMissingTitleFix::get_slug(),
 			],
 		];
 	}

--- a/src/frontendFixes/Fixes/iframeMissingTitleFix.js
+++ b/src/frontendFixes/Fixes/iframeMissingTitleFix.js
@@ -1,0 +1,37 @@
+const iframeMissingTitle = window.edac_frontend_fixes?.iframe_missing_title || {
+	enabled: false,
+};
+
+const getFallbackIframeTitle = ( iframe ) => {
+	const src = iframe.getAttribute( 'src' )?.trim();
+
+	if ( src ) {
+		try {
+			const parsedUrl = new URL( src, window.location.href );
+			return `Embedded content from ${ parsedUrl.hostname }`;
+		} catch ( e ) {
+			// Continue to generic fallback if the URL can't be parsed.
+		}
+	}
+
+	return 'Embedded content';
+};
+
+const iframeMissingTitleFix = () => {
+	if ( ! iframeMissingTitle.enabled ) {
+		return;
+	}
+
+	const iframes = document.querySelectorAll( 'iframe' );
+
+	iframes.forEach( ( iframe ) => {
+		const title = iframe.getAttribute( 'title' );
+		if ( title && title.trim() ) {
+			return;
+		}
+
+		iframe.setAttribute( 'title', getFallbackIframeTitle( iframe ) );
+	} );
+};
+
+export default iframeMissingTitleFix;

--- a/src/frontendFixes/index.js
+++ b/src/frontendFixes/index.js
@@ -55,3 +55,10 @@ if ( edacFrontendFixes?.new_window_warning?.enabled ) {
 		newWindowWarning.default();
 	} );
 }
+
+if ( edacFrontendFixes?.iframe_missing_title?.enabled ) {
+	// lazy import the module
+	import( /* webpackChunkName: "iframe-missing-title" */ './Fixes/iframeMissingTitleFix' ).then( ( iframeMissingTitleFix ) => {
+		iframeMissingTitleFix.default();
+	} );
+}

--- a/tests/jest/frontendFixes/iframeMissingTitleFix.test.js
+++ b/tests/jest/frontendFixes/iframeMissingTitleFix.test.js
@@ -1,0 +1,47 @@
+/**
+ * Tests for iframe missing title frontend fix.
+ */
+
+describe( 'iframeMissingTitleFix', () => {
+	let iframeMissingTitleFix;
+
+	beforeEach( async () => {
+		document.body.innerHTML = '';
+		jest.resetModules();
+		window.edac_frontend_fixes = {
+			iframe_missing_title: {
+				enabled: true,
+			},
+		};
+
+		const module = await import( '../../../src/frontendFixes/Fixes/iframeMissingTitleFix.js' );
+		iframeMissingTitleFix = module.default;
+	} );
+
+	test( 'adds fallback title using iframe hostname when src exists', () => {
+		document.body.innerHTML = '<iframe src="https://www.youtube.com/embed/example"></iframe>';
+
+		iframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Embedded content from www.youtube.com' );
+	} );
+
+	test( 'adds generic fallback title when src is missing', () => {
+		document.body.innerHTML = '<iframe></iframe>';
+
+		iframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Embedded content' );
+	} );
+
+	test( 'does not overwrite existing title attributes', () => {
+		document.body.innerHTML = '<iframe src="https://example.com" title="Custom iframe title"></iframe>';
+
+		iframeMissingTitleFix();
+
+		const iframe = document.querySelector( 'iframe' );
+		expect( iframe.getAttribute( 'title' ) ).toBe( 'Custom iframe title' );
+	} );
+} );

--- a/tests/phpunit/includes/classes/Fixes/Fix/IframeMissingTitleFixTest.php
+++ b/tests/phpunit/includes/classes/Fixes/Fix/IframeMissingTitleFixTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Test class for IframeMissingTitleFix.
+ *
+ * @package accessibility-checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\IframeMissingTitleFix;
+
+require_once __DIR__ . '/FixTestTrait.php';
+
+/**
+ * Unit tests for the IframeMissingTitleFix class.
+ */
+class IframeMissingTitleFixTest extends WP_UnitTestCase {
+
+	use FixTestTrait;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->fix = new IframeMissingTitleFix();
+		$this->common_setup();
+	}
+
+	/**
+	 * Clean up after tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->common_teardown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the expected slug for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_slug(): string {
+		return 'iframe_missing_title';
+	}
+
+	/**
+	 * Get the expected type for this fix.
+	 *
+	 * @return string
+	 */
+	protected function get_expected_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Get the fix class name.
+	 *
+	 * @return string
+	 */
+	protected function get_fix_class_name(): string {
+		return IframeMissingTitleFix::class;
+	}
+
+	/**
+	 * Test frontend data is provided when the setting is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_iframe_missing_title_fix_data_is_added() {
+		update_option( 'edac_fix_iframe_missing_title', true );
+		$this->fix->run();
+
+		$data = apply_filters( 'edac_filter_frontend_fixes_data', [] );
+		$this->assertArrayHasKey( 'iframe_missing_title', $data );
+		$this->assertTrue( $data['iframe_missing_title']['enabled'] );
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide an opt-in fix that adds descriptive fallback `title` attributes to `<iframe>` elements that are missing them to improve accessibility for screen reader users.

### Description

- Add a new backend fix class `IframeMissingTitleFix` that registers a settings field and exposes frontend data when enabled.
- Register the new fix in `FixesManager` so it is loaded with other fixes.
- Update `IframeMissingTitleRule` to reference the new fix in the rule definition and to update the `how_to_fix` guidance.
- Implement the frontend behavior in `src/frontendFixes/Fixes/iframeMissingTitleFix.js` which computes a hostname-based or generic fallback and sets `title` on iframes without overwriting existing titles, and wire it into `src/frontendFixes/index.js` for lazy loading.
- Add automated tests: a PHPUnit test `tests/phpunit/.../IframeMissingTitleFixTest.php` for the fix class and Jest tests `tests/jest/frontendFixes/iframeMissingTitleFix.test.js` for the frontend behavior.

### Testing

- Ran the new PHPUnit test `tests/phpunit/includes/classes/Fixes/Fix/IframeMissingTitleFixTest.php`, which succeeded.
- Ran the new Jest tests `tests/jest/frontendFixes/iframeMissingTitleFix.test.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc98a7748c8328bf5fbe9330cb870e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic iframe title detection and assignment for improved accessibility. When enabled in Accessibility Checker settings, missing iframe titles are automatically populated with descriptive labels.

* **Tests**
  * Added comprehensive test coverage for iframe title functionality across frontend and backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->