### PR TITLE
Add Custom Color Contrast Override Fix

### DIFF
--- a/includes/classes/Fixes/Fix/ColorContrastCustomValuesFix.php
+++ b/includes/classes/Fixes/Fix/ColorContrastCustomValuesFix.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Color Contrast Custom Values Fix Class
+ *
+ * @package accessibility-checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Fixes\Fix;
+
+use EqualizeDigital\AccessibilityChecker\Fixes\FixInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Allows users to apply custom foreground/background color overrides
+ * to a selector when color contrast issues are detected.
+ *
+ * @since 1.39.0
+ */
+class ColorContrastCustomValuesFix implements FixInterface {
+
+	/**
+	 * The slug of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'color_contrast_custom_values';
+	}
+
+	/**
+	 * The nicename for the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_nicename(): string {
+		return __( 'Custom Color Contrast Override', 'accessibility-checker' );
+	}
+
+	/**
+	 * The type of the fix.
+	 *
+	 * @return string
+	 */
+	public static function get_type(): string {
+		return 'frontend';
+	}
+
+	/**
+	 * Registers fields for the custom contrast override fix.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter(
+			'edac_filter_fixes_settings_fields',
+			[ $this, 'get_fields_array' ],
+		);
+	}
+
+	/**
+	 * Get the settings fields for this fix.
+	 *
+	 * @param array $fields Existing settings fields.
+	 *
+	 * @return array
+	 */
+	public function get_fields_array( array $fields = [] ): array {
+		$fields['edac_fix_color_contrast_custom_values_enabled'] = [
+			'label'       => esc_html__( 'Enable Custom Color Contrast Override', 'accessibility-checker' ),
+			'type'        => 'checkbox',
+			'labelledby'  => 'color_contrast_custom_values_enabled',
+			'description' => esc_html__( 'Apply custom text and background colors to matching elements site-wide.', 'accessibility-checker' ),
+			'fix_slug'    => $this->get_slug(),
+			'group_name'  => $this->get_nicename(),
+			'help_id'     => 1983,
+		];
+
+		$fields['edac_fix_color_contrast_custom_values_selector'] = [
+			'label'             => esc_html__( 'CSS Selector', 'accessibility-checker' ),
+			'type'              => 'text',
+			'labelledby'        => 'color_contrast_custom_values_selector',
+			'description'       => esc_html__( 'Enter a CSS selector to target affected elements (example: .entry-content a, .entry-content p).', 'accessibility-checker' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'fix_slug'          => $this->get_slug(),
+		];
+
+		$fields['edac_fix_color_contrast_custom_values_text_color'] = [
+			'label'             => esc_html__( 'Text Color (hex)', 'accessibility-checker' ),
+			'type'              => 'text',
+			'labelledby'        => 'color_contrast_custom_values_text_color',
+			'description'       => esc_html__( 'Enter a hex color value like #111111.', 'accessibility-checker' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'fix_slug'          => $this->get_slug(),
+		];
+
+		$fields['edac_fix_color_contrast_custom_values_background_color'] = [
+			'label'             => esc_html__( 'Background Color (hex)', 'accessibility-checker' ),
+			'type'              => 'text',
+			'labelledby'        => 'color_contrast_custom_values_background_color',
+			'description'       => esc_html__( 'Enter a hex color value like #FFFFFF.', 'accessibility-checker' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'fix_slug'          => $this->get_slug(),
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Run the custom override fix.
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		if ( ! get_option( 'edac_fix_color_contrast_custom_values_enabled', false ) ) {
+			return;
+		}
+
+		$selector = $this->sanitize_selector( get_option( 'edac_fix_color_contrast_custom_values_selector', '' ) );
+		if ( '' === $selector ) {
+			return;
+		}
+
+		$text_color       = sanitize_hex_color( (string) get_option( 'edac_fix_color_contrast_custom_values_text_color', '' ) );
+		$background_color = sanitize_hex_color( (string) get_option( 'edac_fix_color_contrast_custom_values_background_color', '' ) );
+
+		if ( ! $text_color && ! $background_color ) {
+			return;
+		}
+
+		add_action(
+			'wp_head',
+			function () use ( $selector, $text_color, $background_color ) {
+				$rules = [];
+
+				if ( $text_color ) {
+					$rules[] = 'color: ' . $text_color . ' !important';
+				}
+				if ( $background_color ) {
+					$rules[] = 'background-color: ' . $background_color . ' !important';
+				}
+
+				if ( empty( $rules ) ) {
+					return;
+				}
+				?>
+				<style id="edac-fix-color-contrast-custom-values">
+					<?php echo esc_html( $selector ); ?> {
+						<?php echo esc_html( implode( '; ', $rules ) ); ?>;
+					}
+				</style>
+				<?php
+			}
+		);
+	}
+
+	/**
+	 * Sanitizes user-provided CSS selector input.
+	 *
+	 * @param string $selector CSS selector string.
+	 *
+	 * @return string
+	 */
+	private function sanitize_selector( string $selector ): string {
+		$selector = sanitize_text_field( $selector );
+		$selector = str_replace( [ '{', '}', ';' ], '', $selector );
+		$selector = preg_replace( '/[^a-zA-Z0-9#\.\,\-_:\s>\+\~\*\[\]\(\)=\"\'\|\^\$]/', '', $selector );
+
+		return trim( $selector );
+	}
+}

--- a/includes/classes/Fixes/FixesManager.php
+++ b/includes/classes/Fixes/FixesManager.php
@@ -13,6 +13,7 @@ use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddMissingOrEmptyPageTitleFix
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\AddNewWindowWarningFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\BlockPDFUploadsFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\CommentSearchLabelFix;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ColorContrastCustomValuesFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\EmptySearchFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\HTMLLangAndDirFix;
 use EqualizeDigital\AccessibilityChecker\Fixes\Fix\RemoveTitleIfPrefferedAccessibleNameFix;
@@ -144,6 +145,7 @@ class FixesManager {
 				AddLabelToUnlabelledFormFieldsFix::class,
 				AddNewWindowWarningFix::class,
 				EmptySearchFix::class,
+				ColorContrastCustomValuesFix::class,
 			]
 		);
 		if ( ! is_array( $fixes ) ) {

--- a/includes/classes/Rules/Rule/ColorContrastFailureRule.php
+++ b/includes/classes/Rules/Rule/ColorContrastFailureRule.php
@@ -9,6 +9,7 @@ namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
 
 use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
 use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
+use EqualizeDigital\AccessibilityChecker\Fixes\Fix\ColorContrastCustomValuesFix;
 
 /**
  * ColorContrastFailure Rule class.
@@ -49,6 +50,9 @@ class ColorContrastFailureRule implements RuleInterface {
 			'affected_disabilities' => [
 				AffectedDisabilities::LOW_VISION,
 				AffectedDisabilities::COLORBLIND,
+			],
+			'fixes'                 => [
+				ColorContrastCustomValuesFix::get_slug(),
 			],
 		];
 	}

--- a/src/frontendHighlighterApp/fixesModal.js
+++ b/src/frontendHighlighterApp/fixesModal.js
@@ -6,6 +6,98 @@ let focusRestoreTarget = null;
 const CloseEvent = new Event( 'edac-fixes-modal-closed', { bubbles: true } );
 const changeEventListeners = [];
 
+
+const COLOR_CONTRAST_FIX_FIELD_NAMES = {
+	enabled: 'edac_fix_color_contrast_custom_values_enabled',
+	selector: 'edac_fix_color_contrast_custom_values_selector',
+	textColor: 'edac_fix_color_contrast_custom_values_text_color',
+	backgroundColor: 'edac_fix_color_contrast_custom_values_background_color',
+};
+
+const rgbToHex = ( colorString ) => {
+	if ( ! colorString ) {
+		return '';
+	}
+
+	const rgbMatch = colorString.match( /rgba?\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i );
+	if ( ! rgbMatch ) {
+		return '';
+	}
+
+	const [ , r, g, b ] = rgbMatch;
+	const toHex = ( channel ) => Number.parseInt( channel, 10 ).toString( 16 ).padStart( 2, '0' );
+	return `#${ toHex( r ) }${ toHex( g ) }${ toHex( b ) }`.toLowerCase();
+};
+
+const isHexColor = ( value ) => /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test( value || '' );
+
+const getPreferredSelectorForElement = ( element ) => {
+	if ( ! element ) {
+		return '';
+	}
+
+	if ( element.id ) {
+		return `#${ CSS.escape( element.id ) }`;
+	}
+
+	if ( element.classList?.length ) {
+		const firstClass = element.classList[ 0 ];
+		if ( firstClass ) {
+			return `${ element.tagName.toLowerCase() }.${ CSS.escape( firstClass ) }`;
+		}
+	}
+
+	return element.tagName?.toLowerCase() || '';
+};
+
+const enhanceColorContrastFixFields = ( modalBody ) => {
+	if ( ! modalBody ) {
+		return;
+	}
+
+	const textColorInput = modalBody.querySelector( `[name="${ COLOR_CONTRAST_FIX_FIELD_NAMES.textColor }"]` );
+	const backgroundColorInput = modalBody.querySelector( `[name="${ COLOR_CONTRAST_FIX_FIELD_NAMES.backgroundColor }"]` );
+	const selectorInput = modalBody.querySelector( `[name="${ COLOR_CONTRAST_FIX_FIELD_NAMES.selector }"]` );
+	const enabledInput = modalBody.querySelector( `[name="${ COLOR_CONTRAST_FIX_FIELD_NAMES.enabled }"]` );
+
+	if ( ! textColorInput || ! backgroundColorInput || ! selectorInput ) {
+		return;
+	}
+
+	const selectedElement = document.querySelector( '.edac-highlight-element-selected' );
+	const computedStyles = selectedElement ? window.getComputedStyle( selectedElement ) : null;
+
+	textColorInput.type = 'color';
+	backgroundColorInput.type = 'color';
+	textColorInput.setAttribute( 'aria-label', __( 'Text color', 'accessibility-checker' ) );
+	backgroundColorInput.setAttribute( 'aria-label', __( 'Background color', 'accessibility-checker' ) );
+
+	const fallbackTextColor = rgbToHex( computedStyles?.color || '' ) || '#000000';
+	const fallbackBackgroundColor = rgbToHex( computedStyles?.backgroundColor || '' ) || '#ffffff';
+
+	if ( ! isHexColor( textColorInput.value ) ) {
+		textColorInput.value = fallbackTextColor;
+	}
+	if ( ! isHexColor( backgroundColorInput.value ) ) {
+		backgroundColorInput.value = fallbackBackgroundColor;
+	}
+
+	if ( ! selectorInput.value ) {
+		selectorInput.value = getPreferredSelectorForElement( selectedElement );
+	}
+
+	const onFieldChange = () => {
+		if ( enabledInput ) {
+			enabledInput.checked = true;
+		}
+	};
+
+	textColorInput.addEventListener( 'change', onFieldChange );
+	backgroundColorInput.addEventListener( 'change', onFieldChange );
+	selectorInput.addEventListener( 'change', onFieldChange );
+};
+
+
 const buildFixesModalBase = () => {
 	// Create the modal
 	const modal = document.createElement( 'div' );
@@ -157,6 +249,7 @@ export const fillFixesModal = ( content = '', fieldsElement = '' ) => {
 	modalTitle.innerText = fancyName;
 	modalBody.innerHTML = content;
 	modalBody.appendChild( fieldsWrapper );
+	enhanceColorContrastFixFields( modalBody );
 
 	modal.querySelectorAll( 'input, select, textarea' ).forEach( ( field ) => {
 		const changeListener = () => {


### PR DESCRIPTION
### Motivation

- Provide a way to automatically apply site-wide custom foreground/background colors to selectors when a color contrast failure is detected so administrators can quickly mitigate contrast issues without editing theme files.

### Description

- Adds a new frontend fix class `ColorContrastCustomValuesFix` that registers settings fields and outputs an inline `<style>` block on `wp_head` to apply user-provided `color` and `background-color` rules to a sanitized CSS selector.
- Introduces a `sanitize_selector` helper that strips unsafe characters and sanitizes the selector input before use.
- Registers the new fix in `FixesManager` by importing `ColorContrastCustomValuesFix` and adding it to the fixes list so it is loaded at runtime.
- Associates the new fix with the `color_contrast_failure` rule by adding the fix slug to `ColorContrastFailureRule` under the `fixes` key.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce414f148832893173ef173b90b6e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a custom color-contrast override allowing users to apply custom text and/or background colors to specific page elements via a selector.
  * New settings to enable/disable the override and enter target selector and hex color values.
  * Fix is now available in the list of remediation options for contrast failures.
  * Modal UI enhancements: color pickers, auto-filled selector and colors, and improved validation/auto-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->