### PR TITLE
🧪 POC: Add scan-to-scan accessibility regression detection and sidebar trend messaging

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -874,6 +874,29 @@ class REST_Api {
 				'warnings'        => 0,
 				'ignored'         => 0,
 				'readability'     => 0,
+				'regression'      => [
+					'has_baseline' => false,
+					'status'       => 'stable',
+					'delta'        => [
+						'errors'          => 0,
+						'warnings'        => 0,
+						'contrast_errors' => 0,
+						'passed_tests'    => 0,
+					],
+					'scanned_at'   => '',
+				],
+			];
+		} elseif ( ! isset( $summary['regression'] ) || ! is_array( $summary['regression'] ) ) {
+			$summary['regression'] = [
+				'has_baseline' => false,
+				'status'       => 'stable',
+				'delta'        => [
+					'errors'          => 0,
+					'warnings'        => 0,
+					'contrast_errors' => 0,
+					'passed_tests'    => 0,
+				],
+				'scanned_at'   => '',
 			];
 		}
 

--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -58,8 +58,8 @@ class Summary_Generator {
 	public function generate_summary() {
 		global $wpdb;
 
-		$table_name = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
-		$summary    = [];
+		$table_name       = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
+		$summary          = [];
 		$previous_summary = get_post_meta( $this->post_id, '_edac_summary', true );
 
 		if ( ! $table_name ) {
@@ -81,11 +81,43 @@ class Summary_Generator {
 		$summary['content_grade']      = $this->calculate_content_grade();
 		$summary['readability']        = $this->get_readability( $summary );
 		$summary['simplified_summary'] = (bool) ( get_post_meta( $this->post_id, '_edac_simplified_summary', true ) );
-		$summary['regression']         = $this->build_regression_data( $previous_summary, $summary );
+
+		// If issue counts haven't changed since the last save, preserve existing regression
+		// data to avoid a second generate_summary() call overwriting deltas with zeros.
+		if ( $this->issue_counts_match( $previous_summary, $summary ) && ! empty( $previous_summary['regression'] ) ) {
+			$summary['regression'] = $previous_summary['regression'];
+		} else {
+			$summary['regression'] = $this->build_regression_data( $previous_summary, $summary );
+		}
+
 		$this->update_issue_density( $summary );
 		$this->save_summary_meta_data( $summary );
 
 		return $summary;
+	}
+
+	/**
+	 * Checks whether issue-related counts in the current summary match a previously saved summary.
+	 *
+	 * @param mixed $previous_summary The previously saved summary meta.
+	 * @param array $current_summary  The current summary data.
+	 *
+	 * @return bool True when all issue counts are identical.
+	 */
+	private function issue_counts_match( $previous_summary, array $current_summary ): bool {
+		if ( ! is_array( $previous_summary ) ) {
+			return false;
+		}
+
+		$metrics = [ 'errors', 'warnings', 'contrast_errors', 'passed_tests', 'content_grade' ];
+
+		foreach ( $metrics as $metric ) {
+			if ( absint( $previous_summary[ $metric ] ?? 0 ) !== absint( $current_summary[ $metric ] ?? 0 ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -102,12 +134,13 @@ class Summary_Generator {
 			'warnings',
 			'contrast_errors',
 			'passed_tests',
+			'content_grade',
 		];
 
 		$deltas = [];
 		foreach ( $metrics as $metric ) {
-			$current_value = absint( $current_summary[ $metric ] ?? 0 );
-			$previous_value = is_array( $previous_summary ) ? absint( $previous_summary[ $metric ] ?? 0 ) : 0;
+			$current_value     = absint( $current_summary[ $metric ] ?? 0 );
+			$previous_value    = is_array( $previous_summary ) ? absint( $previous_summary[ $metric ] ?? 0 ) : 0;
 			$deltas[ $metric ] = $current_value - $previous_value;
 		}
 
@@ -132,6 +165,7 @@ class Summary_Generator {
 				'warnings'        => intval( $deltas['warnings'] ),
 				'contrast_errors' => intval( $deltas['contrast_errors'] ),
 				'passed_tests'    => intval( $deltas['passed_tests'] ),
+				'content_grade'   => intval( $deltas['content_grade'] ),
 			],
 			'scanned_at'   => current_time( 'mysql', true ),
 		];
@@ -396,13 +430,30 @@ class Summary_Generator {
 		$history   = is_array( $history ) ? $history : [];
 		$timestamp = current_time( 'mysql', true );
 
-		$history[] = [
+		$new_entry = [
 			'scanned_at'      => $timestamp,
 			'errors'          => absint( $summary['errors'] ?? 0 ),
 			'warnings'        => absint( $summary['warnings'] ?? 0 ),
 			'contrast_errors' => absint( $summary['contrast_errors'] ?? 0 ),
 			'passed_tests'    => absint( $summary['passed_tests'] ?? 0 ),
+			'content_grade'   => absint( $summary['content_grade'] ?? 0 ),
 		];
+
+		// Skip duplicate entries when generate_summary() is called multiple times per scan.
+		if ( ! empty( $history ) ) {
+			$last = end( $history );
+			if (
+				absint( $last['errors'] ?? -1 ) === $new_entry['errors'] &&
+				absint( $last['warnings'] ?? -1 ) === $new_entry['warnings'] &&
+				absint( $last['contrast_errors'] ?? -1 ) === $new_entry['contrast_errors'] &&
+				absint( $last['passed_tests'] ?? -1 ) === $new_entry['passed_tests'] &&
+				absint( $last['content_grade'] ?? -1 ) === $new_entry['content_grade']
+			) {
+				return;
+			}
+		}
+
+		$history[] = $new_entry;
 
 		if ( count( $history ) > 10 ) {
 			$history = array_slice( $history, -10 );
@@ -438,6 +489,7 @@ class Summary_Generator {
 					'warnings'        => intval( $summary['regression']['delta']['warnings'] ?? 0 ),
 					'contrast_errors' => intval( $summary['regression']['delta']['contrast_errors'] ?? 0 ),
 					'passed_tests'    => intval( $summary['regression']['delta']['passed_tests'] ?? 0 ),
+					'content_grade'   => intval( $summary['regression']['delta']['content_grade'] ?? 0 ),
 				],
 				'scanned_at'   => sanitize_text_field( $summary['regression']['scanned_at'] ?? '' ),
 			],

--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -60,6 +60,7 @@ class Summary_Generator {
 
 		$table_name = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
 		$summary    = [];
+		$previous_summary = get_post_meta( $this->post_id, '_edac_summary', true );
 
 		if ( ! $table_name ) {
 			return $summary;
@@ -80,10 +81,60 @@ class Summary_Generator {
 		$summary['content_grade']      = $this->calculate_content_grade();
 		$summary['readability']        = $this->get_readability( $summary );
 		$summary['simplified_summary'] = (bool) ( get_post_meta( $this->post_id, '_edac_simplified_summary', true ) );
+		$summary['regression']         = $this->build_regression_data( $previous_summary, $summary );
 		$this->update_issue_density( $summary );
 		$this->save_summary_meta_data( $summary );
 
 		return $summary;
+	}
+
+	/**
+	 * Build regression/trend data by comparing the current summary with the previous scan summary.
+	 *
+	 * @param mixed $previous_summary The previously saved summary meta.
+	 * @param array $current_summary  The current summary data.
+	 *
+	 * @return array
+	 */
+	private function build_regression_data( $previous_summary, array $current_summary ) {
+		$metrics = [
+			'errors',
+			'warnings',
+			'contrast_errors',
+			'passed_tests',
+		];
+
+		$deltas = [];
+		foreach ( $metrics as $metric ) {
+			$current_value = absint( $current_summary[ $metric ] ?? 0 );
+			$previous_value = is_array( $previous_summary ) ? absint( $previous_summary[ $metric ] ?? 0 ) : 0;
+			$deltas[ $metric ] = $current_value - $previous_value;
+		}
+
+		$regression_score = max( 0, $deltas['errors'] ) + max( 0, $deltas['warnings'] ) + max( 0, $deltas['contrast_errors'] );
+
+		$status = 'stable';
+		if ( $regression_score >= 5 || $deltas['passed_tests'] <= -10 ) {
+			$status = 'declining';
+		} elseif ( $regression_score > 0 || $deltas['passed_tests'] < 0 ) {
+			$status = 'watch';
+		} elseif ( $deltas['errors'] < 0 || $deltas['warnings'] < 0 || $deltas['contrast_errors'] < 0 || $deltas['passed_tests'] > 0 ) {
+			$status = 'improving';
+		}
+
+		$has_baseline = is_array( $previous_summary ) && ! empty( $previous_summary );
+
+		return [
+			'has_baseline' => (bool) $has_baseline,
+			'status'       => sanitize_key( $status ),
+			'delta'        => [
+				'errors'          => intval( $deltas['errors'] ),
+				'warnings'        => intval( $deltas['warnings'] ),
+				'contrast_errors' => intval( $deltas['contrast_errors'] ),
+				'passed_tests'    => intval( $deltas['passed_tests'] ),
+			],
+			'scanned_at'   => current_time( 'mysql', true ),
+		];
 	}
 
 	/**
@@ -330,6 +381,34 @@ class Summary_Generator {
 		update_post_meta( $this->post_id, '_edac_summary_warnings', absint( $summary['warnings'] ) );
 		update_post_meta( $this->post_id, '_edac_summary_ignored', absint( $summary['ignored'] ) );
 		update_post_meta( $this->post_id, '_edac_summary_contrast_errors', absint( $summary['contrast_errors'] ) );
+		$this->update_summary_history( $summary );
+	}
+
+	/**
+	 * Stores compact summary scan history used for trend/regression messaging.
+	 *
+	 * @param array $summary The latest summary.
+	 *
+	 * @return void
+	 */
+	private function update_summary_history( array $summary ) {
+		$history   = get_post_meta( $this->post_id, '_edac_summary_history', true );
+		$history   = is_array( $history ) ? $history : [];
+		$timestamp = current_time( 'mysql', true );
+
+		$history[] = [
+			'scanned_at'      => $timestamp,
+			'errors'          => absint( $summary['errors'] ?? 0 ),
+			'warnings'        => absint( $summary['warnings'] ?? 0 ),
+			'contrast_errors' => absint( $summary['contrast_errors'] ?? 0 ),
+			'passed_tests'    => absint( $summary['passed_tests'] ?? 0 ),
+		];
+
+		if ( count( $history ) > 10 ) {
+			$history = array_slice( $history, -10 );
+		}
+
+		update_post_meta( $this->post_id, '_edac_summary_history', $history );
 	}
 
 	/**
@@ -351,6 +430,17 @@ class Summary_Generator {
 			'content_grade'      => absint( $summary['content_grade'] ?? 0 ),
 			'readability'        => sanitize_text_field( $summary['readability'] ?? '' ),
 			'simplified_summary' => filter_var( $summary['simplified_summary'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+			'regression'         => [
+				'has_baseline' => filter_var( $summary['regression']['has_baseline'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+				'status'       => sanitize_key( $summary['regression']['status'] ?? 'stable' ),
+				'delta'        => [
+					'errors'          => intval( $summary['regression']['delta']['errors'] ?? 0 ),
+					'warnings'        => intval( $summary['regression']['delta']['warnings'] ?? 0 ),
+					'contrast_errors' => intval( $summary['regression']['delta']['contrast_errors'] ?? 0 ),
+					'passed_tests'    => intval( $summary['regression']['delta']['passed_tests'] ?? 0 ),
+				],
+				'scanned_at'   => sanitize_text_field( $summary['regression']['scanned_at'] ?? '' ),
+			],
 		];
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessibility-checker",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "accessibility-checker",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "hasInstallScript": true,
       "license": "GPL-2.0+",
       "devDependencies": {

--- a/src/sidebar/components/Panels/AccessibilityStatus.js
+++ b/src/sidebar/components/Panels/AccessibilityStatus.js
@@ -86,6 +86,7 @@ const AccessibilityStatus = () => {
 		( regressionDelta.errors || 0 ) + ( regressionDelta.contrast_errors || 0 );
 	const warningDelta = regressionDelta.warnings || 0;
 	const passedDelta = regressionDelta.passed_tests || 0;
+	const readingLevelDelta = regressionDelta.content_grade || 0;
 
 	const renderRegressionMessage = useCallback(
 		( delta, noun, invertMeaning = false ) => {
@@ -119,7 +120,7 @@ const AccessibilityStatus = () => {
 	const retentionMessage =
 		regressionStatus === 'declining'
 			? __( 'Accessibility is declining. If you stop scanning, this drift may go unnoticed until users are blocked.', 'accessibility-checker' )
-			: __( 'Ongoing scans prove whether accessibility is improving or slipping over time.', 'accessibility-checker' );
+			: '';
 
 	// Determine status icon based on errors and warnings
 	let statusIconName = 'check';
@@ -319,11 +320,12 @@ const AccessibilityStatus = () => {
 						<div className="edac-status-card__value">
 							{ readingLevelText }
 						</div>
-						{ summaryStatus && (
-							<div className="edac-status-card__meta">
-								{ summaryStatus }
-							</div>
-						) }
+						<div className="edac-status-card__meta edac-status-card__meta--trend">
+							{ summaryStatus && (
+								<span>{ summaryStatus }. </span>
+							) }
+							{ renderRegressionMessage( readingLevelDelta, __( 'reading level', 'accessibility-checker' ) ) }
+						</div>
 					</div>
 					{/* Passed Checks (Coverage) */}
 					<div className="edac-status-card">
@@ -341,9 +343,11 @@ const AccessibilityStatus = () => {
 						</div>
 					</div>
 				</PanelRow>
-				<PanelRow className="edac-status-retention-message">
-					<p>{ retentionMessage }</p>
-				</PanelRow>
+				{ retentionMessage && (
+					<PanelRow className="edac-status-retention-message">
+						<p>{ retentionMessage }</p>
+					</PanelRow>
+				) }
 			</PanelBody>
 		</Panel>
 	);

--- a/src/sidebar/components/Panels/AccessibilityStatus.js
+++ b/src/sidebar/components/Panels/AccessibilityStatus.js
@@ -69,6 +69,8 @@ const AccessibilityStatus = () => {
 	// Extract data from store
 	const summary = data?.summary || {};
 	const readability = data?.readability || {};
+	const regression = summary.regression || {};
+	const regressionDelta = regression.delta || {};
 
 	const coveragePercent = summary.passed_tests || 0;
 	const problems = ( summary.errors || 0 ) + ( summary.contrast_errors || 0 );
@@ -78,6 +80,46 @@ const AccessibilityStatus = () => {
 	const postGradeReadable = readability.post_grade_readability || '';
 	const needsSummary = !! readability.post_grade_failed;
 	const hasSummary = !! readability.simplified_summary;
+	const hasRegressionBaseline = !! regression.has_baseline;
+	const regressionStatus = regression.status || 'stable';
+	const problemsDelta =
+		( regressionDelta.errors || 0 ) + ( regressionDelta.contrast_errors || 0 );
+	const warningDelta = regressionDelta.warnings || 0;
+	const passedDelta = regressionDelta.passed_tests || 0;
+
+	const renderRegressionMessage = useCallback(
+		( delta, noun, invertMeaning = false ) => {
+			if ( ! hasRegressionBaseline ) {
+				return __( 'Run another scan to start tracking trend changes.', 'accessibility-checker' );
+			}
+
+			if ( delta === 0 ) {
+				return sprintf( __( 'No change in %s since the last scan.', 'accessibility-checker' ), noun );
+			}
+
+			const increase = delta > 0;
+			const absDelta = Math.abs( delta );
+			const directionWord = increase ? __( 'up', 'accessibility-checker' ) : __( 'down', 'accessibility-checker' );
+			const impactWord = ( increase && ! invertMeaning ) || ( ! increase && invertMeaning )
+				? __( 'Regression', 'accessibility-checker' )
+				: __( 'Improvement', 'accessibility-checker' );
+
+			return sprintf(
+				// translators: 1: regression/improvement label, 2: magnitude, 3: metric label, 4: up/down.
+				__( '%1$s: %2$d %3$s %4$s since last scan.', 'accessibility-checker' ),
+				impactWord,
+				absDelta,
+				noun,
+				directionWord,
+			);
+		},
+		[ hasRegressionBaseline ],
+	);
+
+	const retentionMessage =
+		regressionStatus === 'declining'
+			? __( 'Accessibility is declining. If you stop scanning, this drift may go unnoticed until users are blocked.', 'accessibility-checker' )
+			: __( 'Ongoing scans prove whether accessibility is improving or slipping over time.', 'accessibility-checker' );
 
 	// Determine status icon based on errors and warnings
 	let statusIconName = 'check';
@@ -206,7 +248,9 @@ const AccessibilityStatus = () => {
 						<div className="edac-status-card__value">
 							{ problems }
 						</div>
-						{/* Placeholder for 30-day trend - will be implemented later */}
+						<div className="edac-status-card__meta edac-status-card__meta--trend">
+							{ renderRegressionMessage( problemsDelta, __( 'problems', 'accessibility-checker' ) ) }
+						</div>
 					</div>
 
 					{/* Needs Review (Warnings) */}
@@ -240,7 +284,9 @@ const AccessibilityStatus = () => {
 						<div className="edac-status-card__value">
 							{ needsReview }
 						</div>
-						{/* Placeholder for 30-day trend - will be implemented later */}
+						<div className="edac-status-card__meta edac-status-card__meta--trend">
+							{ renderRegressionMessage( warningDelta, __( 'warnings', 'accessibility-checker' ) ) }
+						</div>
 					</div>
 					{/* Reading Level */}
 					<div
@@ -290,8 +336,13 @@ const AccessibilityStatus = () => {
 						<div className="edac-status-card__value">
 							{ coveragePercent }%
 						</div>
-						{/* Placeholder for 30-day trend - will be implemented later */}
+						<div className="edac-status-card__meta edac-status-card__meta--trend">
+							{ renderRegressionMessage( passedDelta, __( 'passed checks', 'accessibility-checker' ), true ) }
+						</div>
 					</div>
+				</PanelRow>
+				<PanelRow className="edac-status-retention-message">
+					<p>{ retentionMessage }</p>
 				</PanelRow>
 			</PanelBody>
 		</Panel>
@@ -299,4 +350,3 @@ const AccessibilityStatus = () => {
 };
 
 export default AccessibilityStatus;
-

--- a/src/sidebar/sass/components/accessibility-status.scss
+++ b/src/sidebar/sass/components/accessibility-status.scss
@@ -110,6 +110,25 @@
 			font-size: 10px;
 			color: $info-blue;
 			margin-top: 2px;
+
+			&--trend {
+				line-height: 1.35;
+				min-height: 28px;
+				color: $subtext-gray;
+			}
+		}
+	}
+
+	.edac-status-retention-message {
+		margin: 10px 0 0;
+		padding-top: 10px;
+		border-top: 1px dashed $outline-grey;
+
+		p {
+			margin: 0;
+			font-size: 11px;
+			line-height: 1.4;
+			color: $info-grey;
 		}
 	}
 
@@ -126,4 +145,3 @@
 		}
 	}
 }
-

--- a/tests/phpunit/includes/classes/RestApiSidebarDataTest.php
+++ b/tests/phpunit/includes/classes/RestApiSidebarDataTest.php
@@ -123,6 +123,17 @@ class RestApiSidebarDataTest extends WP_UnitTestCase {
 			'warnings'        => 0,
 			'ignored'         => 0,
 			'readability'     => 0,
+			'regression'      => [
+				'has_baseline' => false,
+				'status'       => 'stable',
+				'delta'        => [
+					'errors'          => 0,
+					'warnings'        => 0,
+					'contrast_errors' => 0,
+					'passed_tests'    => 0,
+				],
+				'scanned_at'   => '',
+			],
 		];
 
 		$this->assertSame( $expected, $summary );
@@ -146,7 +157,11 @@ class RestApiSidebarDataTest extends WP_UnitTestCase {
 		$method = $this->get_private_method( $api, 'get_summary_data' );
 		$result = $method->invoke( $api, self::$post_id );
 
-		$this->assertSame( $meta, $result );
+		$this->assertSame( 5, $result['passed_tests'] );
+		$this->assertSame( 2, $result['errors'] );
+		$this->assertArrayHasKey( 'regression', $result );
+		$this->assertFalse( $result['regression']['has_baseline'] );
+		$this->assertSame( 'stable', $result['regression']['status'] );
 	}
 
 	/**

--- a/tests/phpunit/includes/classes/SummaryGeneratorTest.php
+++ b/tests/phpunit/includes/classes/SummaryGeneratorTest.php
@@ -55,4 +55,39 @@ class SummaryGeneratorTest extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $method->invoke( $summary_generator ) );
 	}
+
+	/**
+	 * Ensures that regression data marks worsening scans as declining.
+	 *
+	 * @throws ReflectionException If the method does not exist this is thrown.
+	 */
+	public function test_build_regression_data_marks_declining_status() {
+		$post_id           = self::factory()->post->create();
+		$summary_generator = new Summary_Generator( $post_id );
+
+		$method = ( new ReflectionClass( get_class( $summary_generator ) ) )
+			->getMethod( 'build_regression_data' );
+		$method->setAccessible( true );
+
+		$previous = [
+			'errors'          => 1,
+			'warnings'        => 1,
+			'contrast_errors' => 0,
+			'passed_tests'    => 85,
+		];
+
+		$current = [
+			'errors'          => 4,
+			'warnings'        => 3,
+			'contrast_errors' => 0,
+			'passed_tests'    => 70,
+		];
+
+		$regression = $method->invoke( $summary_generator, $previous, $current );
+
+		$this->assertTrue( $regression['has_baseline'] );
+		$this->assertSame( 'declining', $regression['status'] );
+		$this->assertSame( 3, $regression['delta']['errors'] );
+		$this->assertSame( -15, $regression['delta']['passed_tests'] );
+	}
 }


### PR DESCRIPTION
### Motivation
- Provide an early-warning/regression feature so users can see when accessibility is declining between scans and understand the risk of stopping ongoing checks.
- Make the sidebar UI actionable by replacing placeholder trend text with concrete, scan-to-scan messages and a retention-focused callout about what will break if scanning stops.

### Description
- Added scan-to-scan regression detection in `Summary_Generator` by comparing the current scan summary with the previously saved summary and producing a `regression` payload containing `status`, `delta`, `has_baseline`, and `scanned_at` via `build_regression_data` (new private method) and added `regression` into the sanitized summary output in `sanitize_summary_meta_data` (file: `includes/classes/class-summary-generator.php`).
- Persisted a compact scan history in post meta (`_edac_summary_history`) for up to 10 scans to support trend messaging via `update_summary_history` (new private method) and continue writing the primary `_edac_summary` meta (file: `includes/classes/class-summary-generator.php`).
- Ensured the REST sidebar summary payload always contains a `regression` object (defaults provided) so older summaries and UI consumers remain compatible (file: `includes/classes/class-rest-api.php`).
- Replaced sidebar placeholders with dynamic microcopy that shows regression/improvement/no-change statements for Problems, Needs Review, and Passed Checks, added a retention-focused message when status is `declining`, and added styles to support the new microcopy (files: `src/sidebar/components/Panels/AccessibilityStatus.js`, `src/sidebar/sass/components/accessibility-status.scss`).
- Added/updated PHPUnit unit tests to cover regression defaults and the regression classification logic (files: `tests/phpunit/includes/classes/RestApiSidebarDataTest.php`, `tests/phpunit/includes/classes/SummaryGeneratorTest.php`).
- Bumped `package-lock.json` version metadata to match package version.

### Testing
- Ran JavaScript linting for the modified sidebar component with `npm run lint:js -- src/sidebar/components/Panels/AccessibilityStatus.js`, which completed successfully.
- Checked PHP syntax with `php -l` on modified PHP files: `includes/classes/class-summary-generator.php`, `includes/classes/class-rest-api.php`, and related test files, which returned no syntax errors.
- Attempted to run the PHPUnit tests with `vendor/bin/phpunit tests/phpunit/includes/classes/SummaryGeneratorTest.php tests/phpunit/includes/classes/RestApiSidebarDataTest.php`, however the environment is missing the WordPress test library (`/tmp/wordpress-tests-lib/includes/functions.php`) so full test execution could not be completed in this run (the unit test assertions were added and verify expected behavior when run in CI or a properly provisioned local test environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd86e4b46083289999a84f691581f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Always-show regression summary with baseline detection and per-metric deltas
  * Historical scan retention (compact entries, up to 10) for trend tracking
  * Accessibility panel now displays regression messages and a retention/drift note

* **Style**
  * Added styles for trend text and retention message layout

* **Tests**
  * Updated expectations and added a test validating declining regression behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->