### PR TITLE
Add contrast information data collection and output for contrast failures

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -41,7 +41,7 @@ if ( ! defined( 'EDAC_VERSION' ) ) {
 
 // Current database version.
 if ( ! defined( 'EDAC_DB_VERSION' ) ) {
-	define( 'EDAC_DB_VERSION', '1.0.6' );
+	define( 'EDAC_DB_VERSION', '1.0.7' );
 }
 
 // Plugin Folder Path.

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -346,7 +346,7 @@ class Ajax {
 
 			foreach ( $rules as $rule ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.
-				$results        = $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment, ignre_reason, ignre_global, landmark, landmark_selector FROM %i where postid = %d and rule = %s and siteid = %d', $table_name, $postid, $rule['slug'], $siteid ), ARRAY_A );
+				$results        = $wpdb->get_results( $wpdb->prepare( 'SELECT id, postid, object, ruletype, ignre, ignre_user, ignre_date, ignre_comment, ignre_reason, ignre_global, landmark, landmark_selector, extra_data FROM %i where postid = %d and rule = %s and siteid = %d', $table_name, $postid, $rule['slug'], $siteid ), ARRAY_A );
 				$count_classes  = ( 'error' === $rule['rule_type'] ) ? ' edac-details-rule-count-error' : ' edac-details-rule-count-warning';
 				$count_classes .= ( 0 !== $rule['count'] ) ? ' active' : '';
 
@@ -507,7 +507,9 @@ class Ajax {
 							$id
 						) . '</h4>';
 
-						$html .= '<div id="edac-details-rule-records-record-' . $id . '" class="edac-details-rule-records-record">';
+						$extra_data_attr = ! empty( $row['extra_data'] ) ? ' data-extra-data="' . esc_attr( $row['extra_data'] ) . '"' : '';
+						
+						$html .= '<div id="edac-details-rule-records-record-' . $id . '" class="edac-details-rule-records-record"' . $extra_data_attr . '>';
 
 						$html .= '<div class="edac-details-rule-records-record-cell edac-details-rule-records-record-object">';
 

--- a/admin/class-frontend-highlight.php
+++ b/admin/class-frontend-highlight.php
@@ -65,7 +65,7 @@ class Frontend_Highlight {
 		$table_name = $wpdb->prefix . 'accessibility_checker';
 		$post_id    = (int) $post_id;
 		$siteid     = get_current_blog_id();
-		$results    = $wpdb->get_results( $wpdb->prepare( 'SELECT id, rule, ignre, object, ruletype, selector, ancestry, xpath FROM %i where postid = %d and siteid = %d', $table_name, $post_id, $siteid ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name.
+		$results    = $wpdb->get_results( $wpdb->prepare( 'SELECT id, rule, ignre, object, ruletype, selector, ancestry, xpath, extra_data FROM %i where postid = %d and siteid = %d', $table_name, $post_id, $siteid ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name.
 		if ( ! $results ) {
 			return null;
 		}
@@ -143,6 +143,7 @@ class Frontend_Highlight {
 			$array['selector']   = $result['selector'] ?? '';
 			$array['ancestry']   = $result['ancestry'] ?? '';
 			$array['xpath']      = $result['xpath'] ?? '';
+			$array['extra_data'] = ! empty( $result['extra_data'] ) ? json_decode( $result['extra_data'], true ) : null;
 
 			$issues[] = $array;
 

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -36,11 +36,12 @@ class Insert_Rule_Data {
 	 * @param string|null $landmark          The landmark type (main, header, footer, nav), optional.
 	 * @param string|null $landmark_selector The landmark selector, optional.
 	 * @param array       $selectors         An array of selectors that point to the object, optional.
+	 * @param array|null  $extra_data        Optional extra data to store as JSON (e.g. color contrast values).
 	 *
 	 * @return void|int|\WP_Error The ID of the inserted record, void if no
 	 * record was inserted or a WP_Error if the insert failed.
 	 */
-	public function insert( object $post, string $rule, string $ruletype, string $rule_obj, ?string $landmark = null, ?string $landmark_selector = null, array $selectors = [] ) {
+	public function insert( object $post, string $rule, string $ruletype, string $rule_obj, ?string $landmark = null, ?string $landmark_selector = null, array $selectors = [], ?array $extra_data = null ) {
 
 		if ( ! isset( $post->ID, $post->post_type )
 			|| empty( $rule )
@@ -66,6 +67,7 @@ class Insert_Rule_Data {
 			'rule'              => $rule,
 			'ruletype'          => $ruletype,
 			'object'            => esc_attr( $rule_obj ),
+			'extra_data'        => $extra_data ? wp_json_encode( $extra_data ) : null,
 			'recordcheck'       => 1,
 			'user'              => get_current_user_id(),
 			'ignre'             => 0,
@@ -111,7 +113,7 @@ class Insert_Rule_Data {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 				$wpdb->query(
 					$wpdb->prepare(
-						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d  WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
+						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d, extra_data = %s  WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
 						$table_name,
 						1,
 						$rule_data['landmark'],
@@ -120,6 +122,7 @@ class Insert_Rule_Data {
 						$rule_data['ancestry'],
 						$rule_data['xpath'],
 						$rule_data['ignre'],
+						$rule_data['extra_data'],
 						$rule_data['siteid'],
 						$rule_data['postid'],
 						$rule_data['rule'],
@@ -160,6 +163,7 @@ class Insert_Rule_Data {
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
 				'object'            => esc_attr( $rule_data['object'] ),
+				'extra_data'        => isset( $rule_data['extra_data'] ) ? sanitize_text_field( $rule_data['extra_data'] ) : null,
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -63,6 +63,7 @@ class Update_Database {
 				rule text NOT NULL,
 				ruletype text NOT NULL,
 				object mediumtext NOT NULL,
+				extra_data text NULL,
 				recordcheck mediumint(9) NOT NULL,
 				created timestamp NOT NULL default CURRENT_TIMESTAMP,
 				user bigint(20) NOT NULL,

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -536,7 +536,10 @@ class REST_Api {
 							'ancestry' => $violation['ancestry'] ?? [],
 							'xpath'    => $violation['xpath'] ?? [],
 						];
-						( new Insert_Rule_Data() )->insert( $post, $actual_rule_id, $impact, $html, $landmark, $landmark_selector, $selectors );
+
+						$extra_data = isset( $violation['extraData'] ) && is_array( $violation['extraData'] ) ? $violation['extraData'] : null;
+
+						( new Insert_Rule_Data() )->insert( $post, $actual_rule_id, $impact, $html, $landmark, $landmark_selector, $selectors, $extra_data );
 
 						/**
 						 * Fires after a rule is run against the content.

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -995,6 +995,9 @@ class REST_Api {
 				}
 				$result['ignre_user_name'] = $user_cache[ $user_id ];
 			}
+			if ( isset( $result['extra_data'] ) && null !== $result['extra_data'] ) {
+				$result['extra_data'] = json_decode( $result['extra_data'], true );
+			}
 			$results_by_rule[ $rule_slug ][] = $result;
 		}
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -777,6 +777,28 @@ class AccessibilityCheckerHighlight {
 				</div>`;
 			}
 
+			// Color contrast data
+			if ( matchingObj.extra_data?.fgColor && matchingObj.extra_data?.bgColor ) {
+				const { fgColor, bgColor, contrastRatio, expectedContrastRatio } = matchingObj.extra_data;
+				content += `
+					<div class="edac-highlight-panel-description-contrast">
+						<div class="edac-highlight-panel-description-contrast-swatches">
+							<div class="edac-highlight-panel-description-contrast-swatch">
+								<div class="edac-highlight-panel-description-contrast-swatch-color" style="background-color: ${ fgColor }; color: ${ bgColor };">Aa</div>
+								<div class="edac-highlight-panel-description-contrast-swatch-label">${ __( 'Foreground', 'accessibility-checker' ) }<br>${ fgColor }</div>
+							</div>
+							<div class="edac-highlight-panel-description-contrast-swatch">
+								<div class="edac-highlight-panel-description-contrast-swatch-color" style="background-color: ${ bgColor }; color: ${ fgColor };">Aa</div>
+								<div class="edac-highlight-panel-description-contrast-swatch-label">${ __( 'Background', 'accessibility-checker' ) }<br>${ bgColor }</div>
+							</div>
+						</div>
+						<div class="edac-highlight-panel-description-contrast-ratio">
+							${ __( 'Contrast ratio:', 'accessibility-checker' ) } <strong>${ contrastRatio }:1</strong> (${ __( 'required:', 'accessibility-checker' ) } ${ expectedContrastRatio })
+						</div>
+					</div>
+				`;
+			}
+
 			if ( this.fixes[ matchingObj.slug ] && window.edacFrontendHighlighterApp?.userCanFix ) {
 				// this is the markup to put in the modal.
 				content += `

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -302,6 +302,48 @@ body {
 					margin-bottom: 5px !important;
 				}
 			}
+
+			&-contrast {
+				margin-top: 12px !important;
+				margin-bottom: 8px !important;
+
+				&-swatches {
+					display: flex !important;
+					gap: 8px !important;
+					margin-bottom: 8px !important;
+				}
+
+				&-swatch {
+					flex: 1 !important;
+
+					&-color {
+						height: 52px !important;
+						display: flex !important;
+						align-items: center !important;
+						justify-content: center !important;
+						font-size: 22px !important;
+						font-weight: bold !important;
+						border-radius: 4px !important;
+						border: 1px solid rgba(0, 0, 0, 0.25) !important;
+					}
+
+					&-label {
+						font-size: 11px !important;
+						margin-top: 4px !important;
+						text-align: center !important;
+						line-height: 1.4 !important;
+					}
+				}
+
+				&-ratio {
+					font-size: 13px !important;
+					margin-top: 4px !important;
+
+					strong {
+						font-weight: bold !important;
+					}
+				}
+			}
 		}
 
 		&-controls {

--- a/src/issueModal/components/IssueDetailsModal.js
+++ b/src/issueModal/components/IssueDetailsModal.js
@@ -425,6 +425,45 @@ export const IssueDetailsModal = ( { issue, rule, onClose, isOpen, focusSection,
 						)
 					) }
 
+					{ /* Color Contrast Data */ }
+					{ issue?.extra_data?.fgColor && issue?.extra_data?.bgColor && (
+						<div className="edac-analysis__contrast" data-section="contrast">
+							<div className="edac-analysis__contrast-swatches">
+								<div className="edac-analysis__contrast-swatch">
+									<div
+										className="edac-analysis__contrast-swatch-color"
+										style={ { backgroundColor: issue.extra_data.fgColor, color: issue.extra_data.bgColor } }
+										aria-hidden="true"
+									>
+										Aa
+									</div>
+									<div className="edac-analysis__contrast-swatch-label">
+										<span>{ __( 'Foreground', 'accessibility-checker' ) }</span>
+										<code>{ issue.extra_data.fgColor }</code>
+									</div>
+								</div>
+								<div className="edac-analysis__contrast-swatch">
+									<div
+										className="edac-analysis__contrast-swatch-color"
+										style={ { backgroundColor: issue.extra_data.bgColor, color: issue.extra_data.fgColor } }
+										aria-hidden="true"
+									>
+										Aa
+									</div>
+									<div className="edac-analysis__contrast-swatch-label">
+										<span>{ __( 'Background', 'accessibility-checker' ) }</span>
+										<code>{ issue.extra_data.bgColor }</code>
+									</div>
+								</div>
+							</div>
+							<p className="edac-analysis__contrast-ratio">
+								{ __( 'Contrast ratio:', 'accessibility-checker' ) }{ ' ' }
+								<strong>{ issue.extra_data.contrastRatio }:1</strong>{ ' ' }
+								({ __( 'required:', 'accessibility-checker' ) } { issue.extra_data.expectedContrastRatio })
+							</p>
+						</div>
+					) }
+
 					<hr aria-hidden="true" />
 
 					{ /* Affected Code */ }

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -395,7 +395,7 @@ function processViolation( violation, item ) {
 	};
 
 	if ( item.id === 'color_contrast_failure' ) {
-		const check = violation.node.any?.find( ( c ) => c.id === 'color-contrast' );
+		const check = violation.any?.find( ( c ) => c.id === 'color-contrast' );
 		if ( check?.data ) {
 			result.extraData = {
 				fgColor: check.data.fgColor,

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -381,7 +381,8 @@ function processViolation( violation, item ) {
 	const ancestry = violation.node.ancestry || [];
 	const xpath = violation.node.xpath || [];
 	const html = document.querySelector( selector )?.outerHTML;
-	return {
+
+	const result = {
 		selector,
 		ancestry,
 		xpath,
@@ -392,4 +393,20 @@ function processViolation( violation, item ) {
 		landmark: landmark.type,
 		landmarkSelector: landmark.selector,
 	};
+
+	if ( item.id === 'color_contrast_failure' ) {
+		const check = violation.node.any?.find( ( c ) => c.id === 'color-contrast' );
+		if ( check?.data ) {
+			result.extraData = {
+				fgColor: check.data.fgColor,
+				bgColor: check.data.bgColor,
+				contrastRatio: check.data.contrastRatio,
+				expectedContrastRatio: check.data.expectedContrastRatio,
+				fontSize: check.data.fontSize,
+				fontWeight: check.data.fontWeight,
+			};
+		}
+	}
+
+	return result;
 }


### PR DESCRIPTION
This pull request adds support for storing and displaying additional color contrast data for accessibility issues, specifically for color contrast failures. The changes span backend data handling, database schema, and frontend display, enabling more detailed color contrast information (such as foreground/background colors and contrast ratios) to be saved, retrieved, and shown in the user interface.

**Database and Backend Enhancements:**

* The database schema is updated to add a new `extra_data` column to the accessibility checker table, and the plugin database version is incremented to `1.0.7` to reflect this change. [[1]](diffhunk://#diff-0f526aacdc188df5ddc0b157ba0d63ef2825de8a129f16154d9e05bed8a0b31bR66) [[2]](diffhunk://#diff-350d3eed90dcfd8d1466cc7e406d1b17b604e284b62d478a7eb271cdd11287e7L44-R44)
* The backend logic for inserting and updating rule data is extended to accept, store, and sanitize an optional `extra_data` field (as JSON), ensuring that color contrast details can be saved with each relevant issue. [[1]](diffhunk://#diff-b27e1336fd25c1252eed980c5edde9a5b6826f0a544debce5c35408c63921d8fR39-R44) [[2]](diffhunk://#diff-b27e1336fd25c1252eed980c5edde9a5b6826f0a544debce5c35408c63921d8fR70) [[3]](diffhunk://#diff-b27e1336fd25c1252eed980c5edde9a5b6826f0a544debce5c35408c63921d8fL114-R116) [[4]](diffhunk://#diff-b27e1336fd25c1252eed980c5edde9a5b6826f0a544debce5c35408c63921d8fR125) [[5]](diffhunk://#diff-b27e1336fd25c1252eed980c5edde9a5b6826f0a544debce5c35408c63921d8fR166) [[6]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8L539-R542)
* All relevant database queries and API responses are updated to include the `extra_data` field, and it is properly decoded from JSON when retrieved. [[1]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL349-R349) [[2]](diffhunk://#diff-68f824f5d8b6cebe1f89f49f19aa21fca016a5b41e67adf665ec9e97f7839730L68-R68) [[3]](diffhunk://#diff-68f824f5d8b6cebe1f89f49f19aa21fca016a5b41e67adf665ec9e97f7839730R146) [[4]](diffhunk://#diff-9172675c3f2e6e6e28d065b5a71d77d1859bd3d1b2b2e368cd56c0f1c123e5f8R998-R1000) [[5]](diffhunk://#diff-87159e3bf5e81593c7698827c5dc895f087a1766d135de0dd7588b340903404eL510-R512)

**Frontend Display Improvements:**

* The frontend highlighter and issue details modal are updated to display color contrast information (foreground/background color swatches, contrast ratio, and requirements) when available, enhancing the clarity of color contrast issues for users. [[1]](diffhunk://#diff-bece1bbb785a9261a7e6aca0d5cb83eda772f26999f3c83a31e4e57f728c75acR780-R801) [[2]](diffhunk://#diff-5f3d1ffe256f8ef5a5022af1290af05b5cfea4faae92e7c870dba92f294e474dR428-R466)
* Corresponding SCSS styles are added for the new color contrast UI elements, ensuring they are visually distinct and accessible.

**Scanner and Data Collection:**

* The page scanner is updated to extract and attach detailed color contrast data (foreground/background colors, contrast ratios, font size/weight) to violations of type `color_contrast_failure`, making this information available throughout the stack. [[1]](diffhunk://#diff-dfb86049e76745f75b4b756a00137c09d0ea1b1bb7bd8d3db94e8c5f38728c10L384-R385) [[2]](diffhunk://#diff-dfb86049e76745f75b4b756a00137c09d0ea1b1bb7bd8d3db94e8c5f38728c10R396-R411)

Fixes: #1562 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color contrast information now displays visually in accessibility issues, showing foreground and background color swatches alongside actual and expected contrast ratio values. This enhancement appears in both the issue highlighter and the issue details modal for comprehensive analysis.

* **Chores**
  * Database schema updated to version 1.0.7 to support additional issue metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->