### PR TITLE
Update new window warning css variables and make some tweaks to allow code reuse

### DIFF
--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -141,12 +141,12 @@ class AddNewWindowWarningFix implements FixInterface {
 			}
 
 			:root {
-				--font-base: 'anww', sans-serif;
-				--icon-size: 0.75em;
+				--edac-nww-font-base: 'anww', sans-serif;
+				--edac-nww-icon-size: 0.75em;
 			}
 
 			.edac-nww-external-link-icon {
-				font: normal normal normal 1em var(--font-base) !important;
+				font: normal normal normal 1em var(--edac-nww-font-base) !important;
 				speak: never;
 				text-transform: none;
 				-webkit-font-smoothing: antialiased;
@@ -155,7 +155,7 @@ class AddNewWindowWarningFix implements FixInterface {
 
 			.edac-nww-external-link-icon:before {
 				content: " \e900";
-				font-size: var(--icon-size);
+				font-size: var(--edac-nww-icon-size);
 			}
 
 			.edac-nww-external-link-icon.elementor-button-link-content:before {

--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -147,6 +147,7 @@ class AddNewWindowWarningFix implements FixInterface {
 				--edac-nww-icon-size: 0.75em;
 			}
 
+			.anww-external-link-icon,
 			.edac-nww-external-link-icon {
 				font: normal normal normal 1em var(--edac-nww-font-base) !important;
 				speak: never;
@@ -155,17 +156,19 @@ class AddNewWindowWarningFix implements FixInterface {
 				-moz-osx-font-smoothing: grayscale;
 			}
 
+			.anww-external-link-icon:before,
 			.edac-nww-external-link-icon:before {
 				content: " \e900";
 				font-size: var(--edac-nww-icon-size);
 			}
 
+			.anww-external-link-icon.elementor-button-link-content:before,
 			.edac-nww-external-link-icon.elementor-button-link-content:before {
 				vertical-align: middle;
 			}
 
 			/* Modifier classes: add these to a container element to opt out of specific behaviors. */
-			.anww-no-icon .edac-nww-external-link-icon,
+			.anww-no-icon .anww-external-link-icon,
 			.edac-nww-no-icon .edac-nww-external-link-icon {
 				display: none !important;
 			}

--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -112,7 +112,9 @@ class AddNewWindowWarningFix implements FixInterface {
 			function ( $data ) {
 
 				$data[ $this->get_slug() ] = [
-					'enabled' => true,
+					'enabled'         => true,
+					'classPrefix'     => 'edac-nww',
+					'localizedString' => __( 'opens a new window', 'accessibility-checker' ),
 				];
 				return $data;
 			}

--- a/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
+++ b/includes/classes/Fixes/Fix/AddNewWindowWarningFix.php
@@ -169,6 +169,8 @@ class AddNewWindowWarningFix implements FixInterface {
 
 			/* Modifier classes: add these to a container element to opt out of specific behaviors. */
 			.anww-no-icon .anww-external-link-icon,
+			.anww-no-icon .edac-nww-external-link-icon,
+			.edac-nww-no-icon .anww-external-link-icon,
 			.edac-nww-no-icon .edac-nww-external-link-icon {
 				display: none !important;
 			}

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -25,7 +25,7 @@ let tooltipTimeout;
 const initializeTooltip = () => {
 	anwwLinkTooltip = document.createElement( 'div' );
 	anwwLinkTooltip.setAttribute( 'role', 'tooltip' );
-	anwwLinkTooltip.classList.add( 'anww-tooltip' );
+	anwwLinkTooltip.classList.add( `${ classPrefix }-tooltip` );
 	Object.assign( anwwLinkTooltip.style, {
 		position: 'absolute',
 		background: 'white',
@@ -44,7 +44,7 @@ const initializeTooltip = () => {
 
 	// Hide tooltip when clicking outside or pressing Escape
 	document.addEventListener( 'click', ( event ) => {
-		if ( ! event.target.closest( ".anww-tooltip, a[target='_blank']" ) ) {
+		if ( ! event.target.closest( `.${ classPrefix }-tooltip, a[target='_blank']` ) ) {
 			hideTooltip();
 		}
 	} );

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -4,8 +4,8 @@
  * Adds an icon and tooltip to links that open in a new window, improving accessibility by informing users of the behavior.
  */
 
-const classPrefix = window.edac_frontend_fixes?.new_window_warning?.classPrefix ?? 'edac-nww';
-const localizedString = window.edac_frontend_fixes?.new_window_warning?.localizedString ?? 'opens a new window';
+const classPrefix = window.edac_frontend_fixes?.new_window_warning?.classPrefix || window.anww_localized?.classPrefix || 'edac-nww';
+const localizedString = window.edac_frontend_fixes?.new_window_warning?.localizedString || window.anww_localized?.localizedString || 'opens a new window';
 const iconClass = `${ classPrefix }-external-link-icon`;
 
 const NewWindowWarning = () => {

--- a/src/frontendFixes/Fixes/newWindowWarning.js
+++ b/src/frontendFixes/Fixes/newWindowWarning.js
@@ -1,6 +1,12 @@
-import { __ } from '@wordpress/i18n';
+/**
+ * New Window Warning Fix
+ *
+ * Adds an icon and tooltip to links that open in a new window, improving accessibility by informing users of the behavior.
+ */
 
-const localizedNewWindowWarning = __( 'opens a new window', 'accessibility-checker' );
+const classPrefix = window.edac_frontend_fixes?.new_window_warning?.classPrefix ?? 'edac-nww';
+const localizedString = window.edac_frontend_fixes?.new_window_warning?.localizedString ?? 'opens a new window';
+const iconClass = `${ classPrefix }-external-link-icon`;
 
 const NewWindowWarning = () => {
 	initializeTooltip();
@@ -76,7 +82,7 @@ const processLinks = () => {
 			if ( ! link.closest( '.anww-no-tooltip, .edac-nww-no-tooltip' ) ) {
 				addTooltipHandlers( link );
 			}
-			link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed.
+			link.setAttribute( 'data-nww-processed', 'true' );
 			return;
 		}
 
@@ -93,7 +99,7 @@ const processLinks = () => {
 				if ( ! link.closest( '.anww-no-tooltip, .edac-nww-no-tooltip' ) ) {
 					addTooltipHandlers( link );
 				}
-				link.setAttribute( 'data-nww-processed', 'true' ); // Mark link as processed.
+				link.setAttribute( 'data-nww-processed', 'true' );
 			}
 		}
 	} );
@@ -104,22 +110,20 @@ const processLinks = () => {
  * @param {HTMLElement} link - The link element to modify.
  */
 const addExternalLinkIcon = ( link ) => {
-	// Add icon to link.
 	const header = link.querySelector( 'h1, h2, h3, h4, h5, h6' );
 	if ( header ) {
-		header.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon" aria-hidden="true"></i>' );
+		header.insertAdjacentHTML( 'beforeend', `<i class="${ iconClass }" aria-hidden="true"></i>` );
 		return;
 	}
 
 	// If this link is an Elementor button, place the icon inside its content wrapper.
-	// Note: This relies on Elementor's specific '.elementor-button-content-wrapper' class, which might change in future Elementor updates.
 	const elementorButtonContent = link.querySelector( '.elementor-button-content-wrapper' );
 	if ( elementorButtonContent ) {
-		elementorButtonContent.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon elementor-button-link-content" aria-hidden="true"></i>' );
+		elementorButtonContent.insertAdjacentHTML( 'beforeend', `<i class="${ iconClass } elementor-button-link-content" aria-hidden="true"></i>` );
 		return;
 	}
 
-	link.insertAdjacentHTML( 'beforeend', '<i class="edac-nww-external-link-icon" aria-hidden="true"></i>' );
+	link.insertAdjacentHTML( 'beforeend', `<i class="${ iconClass }" aria-hidden="true"></i>` );
 };
 
 /**
@@ -127,19 +131,19 @@ const addExternalLinkIcon = ( link ) => {
  * @param {HTMLElement} link - The link element to modify.
  */
 const updateAriaLabel = ( link ) => {
-	let anwwLabel = '';
+	let label = '';
 
 	if ( link.hasAttribute( 'aria-label' ) ) {
-		anwwLabel = link.getAttribute( 'aria-label' );
+		label = link.getAttribute( 'aria-label' );
 	} else if ( link.querySelector( 'img' ) ) {
 		const img = link.querySelector( 'img' );
-		anwwLabel = img.getAttribute( 'alt' ) || '';
+		label = img.getAttribute( 'alt' ) || '';
 	} else if ( link.textContent ) {
-		anwwLabel = link.textContent.trim();
+		label = link.textContent.trim();
 	}
 
-	anwwLabel = anwwLabel ? `${ anwwLabel }, ${ localizedNewWindowWarning }` : localizedNewWindowWarning;
-	link.setAttribute( 'aria-label', anwwLabel );
+	label = label ? `${ label }, ${ localizedString }` : localizedString;
+	link.setAttribute( 'aria-label', label );
 };
 
 /**
@@ -169,7 +173,7 @@ const addTooltipHandlers = ( link ) => {
 const showTooltip = ( link, x, y ) => {
 	clearTimeout( tooltipTimeout );
 
-	anwwLinkTooltip.textContent = localizedNewWindowWarning;
+	anwwLinkTooltip.textContent = localizedString;
 	anwwLinkTooltip.style.display = 'block';
 
 	const tooltipWidth = anwwLinkTooltip.offsetWidth;

--- a/tests/jest/frontendFixes/newWindowWarning.test.js
+++ b/tests/jest/frontendFixes/newWindowWarning.test.js
@@ -43,14 +43,14 @@ describe( 'New Window Warning Tooltip', () => {
 
 	afterEach( () => {
 		// Clean up any tooltips
-		document.querySelectorAll( '.anww-tooltip' ).forEach( ( el ) => el.remove() );
+		document.querySelectorAll( '.edac-nww-tooltip' ).forEach( ( el ) => el.remove() );
 	} );
 
 	describe( 'Tooltip Initialization', () => {
 		test( 'creates tooltip element when initialized', () => {
 			NewWindowWarning();
 
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 			expect( anwwLinkTooltip ).not.toBeNull();
 			expect( anwwLinkTooltip.getAttribute( 'role' ) ).toBe( 'tooltip' );
 		} );
@@ -58,7 +58,7 @@ describe( 'New Window Warning Tooltip', () => {
 		test( 'tooltip is initially hidden', () => {
 			NewWindowWarning();
 
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 			expect( anwwLinkTooltip.style.display ).toBe( 'none' );
 		} );
 	} );
@@ -75,7 +75,7 @@ describe( 'New Window Warning Tooltip', () => {
 			const event = new MouseEvent( 'mouseenter', { bubbles: true, pageX: 1000, pageY: 100 } );
 			link.dispatchEvent( event );
 
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			// Tooltip should be visible and positioned
 			expect( anwwLinkTooltip.style.display ).toBe( 'block' );
@@ -93,7 +93,7 @@ describe( 'New Window Warning Tooltip', () => {
 			const event = new MouseEvent( 'mouseenter', { bubbles: true, pageX: 100, pageY: 100 } );
 			link.dispatchEvent( event );
 
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			// Tooltip should be positioned and visible
 			expect( anwwLinkTooltip.style.display ).toBe( 'block' );
@@ -125,7 +125,7 @@ describe( 'New Window Warning Tooltip', () => {
 			NewWindowWarning();
 
 			const link = document.querySelector( 'a' );
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 			expect( anwwLinkTooltip.style.display ).toBe( 'none' );
 
 			const event = new MouseEvent( 'mouseenter', { bubbles: true, pageX: 100, pageY: 100 } );
@@ -140,7 +140,7 @@ describe( 'New Window Warning Tooltip', () => {
 			NewWindowWarning();
 
 			const link = document.querySelector( 'a' );
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			const enterEvent = new MouseEvent( 'mouseenter', { bubbles: true, pageX: 100, pageY: 100 } );
 			link.dispatchEvent( enterEvent );
@@ -182,7 +182,7 @@ describe( 'New Window Warning Tooltip', () => {
 			NewWindowWarning();
 
 			const link = document.querySelector( 'a' );
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			// Should still update aria-label
 			expect( link.getAttribute( 'aria-label' ) ).toContain( 'opens a new window' );
@@ -203,7 +203,7 @@ describe( 'New Window Warning Tooltip', () => {
 			NewWindowWarning();
 
 			const link = document.querySelector( 'a' );
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			// Should still update aria-label
 			expect( link.getAttribute( 'aria-label' ) ).toContain( 'opens a new window' );
@@ -255,7 +255,7 @@ describe( 'New Window Warning Tooltip', () => {
 			NewWindowWarning();
 
 			const link = document.querySelector( 'a' );
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			// Should still update aria-label
 			expect( link.getAttribute( 'aria-label' ) ).toContain( 'opens a new window' );
@@ -276,7 +276,7 @@ describe( 'New Window Warning Tooltip', () => {
 			NewWindowWarning();
 
 			const link = document.querySelector( 'a' );
-			anwwLinkTooltip = document.querySelector( '.anww-tooltip' );
+			anwwLinkTooltip = document.querySelector( '.edac-nww-tooltip' );
 
 			// Should still update aria-label
 			expect( link.getAttribute( 'aria-label' ) ).toContain( 'opens a new window' );


### PR DESCRIPTION
Added some prefixes to some css vars that were too generic. Also make some code refactor to make the fix code able to be reused across here and the ANWW plugin.

* Localized in the string (to avoid needing wp-i18n in the fix).
* Localized in a class prefix to use for the css targeting.

With some updates to the ANWW plugin the fix code should be able to be dropped in 1:1.

## Copilot summary

This pull request updates the "New Window Warning" accessibility fix to be more flexible and consistent by introducing a configurable class prefix and localized string. This allows for better integration with different environments and improves maintainability. The changes affect both the PHP backend (which provides configuration) and the JavaScript/CSS frontend (which applies the fix).

**Configurability and Theming Improvements:**

* Added support for a configurable `classPrefix` and `localizedString` for the new window warning, allowing for easier customization and localization. These are now passed from the PHP backend (`AddNewWindowWarningFix.php`) to the frontend via the global window object and used throughout the JavaScript and CSS. [[1]](diffhunk://#diff-7607fd2921e5cb4f92bc579512375f45b6646aa7e0c804c3fa4fc441e10e2982R116-R117) [[2]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL1-R9) [[3]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL107-R146) [[4]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL172-R176)

* Updated CSS variable names and selectors to use the configurable class prefix, ensuring consistent styling regardless of the chosen prefix. This includes changes to variable names (e.g., `--edac-nww-font-base`) and class selectors for icons and tooltips.

**Frontend JavaScript Enhancements:**

* Refactored the JavaScript to use the new configurable `classPrefix` and `localizedString` throughout, including for icon classes, tooltip classes, and ARIA labels, improving code clarity and maintainability. [[1]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL1-R9) [[2]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL22-R28) [[3]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL41-R47) [[4]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL107-R146) [[5]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL172-R176)

* Improved logic for adding icons and tooltips to links, ensuring that the correct class names and localized strings are always used, and that the ARIA labels are updated appropriately for accessibility. [[1]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL107-R146) [[2]](diffhunk://#diff-8a209b43b90ed27fd5bec15cfd2d60300f399c23525f07ed67e6774162ae34dbL96-R102)

These updates make the new window warning fix more robust, customizable, and accessible.

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced new-window warning to support runtime-configurable class prefixes and localized tooltip text for greater flexibility.
  * Scoped styling to use feature-specific CSS properties and expanded selector coverage for more consistent appearance.
* **Tests**
  * Updated frontend tests to align with the revised tooltip class and selector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->