### PR TITLE
Update backport action to use env vars on process.* instead of inlined

### DIFF
--- a/.github/workflows/backport-to-develop.yml
+++ b/.github/workflows/backport-to-develop.yml
@@ -27,23 +27,26 @@ jobs:
         id: get-branch
         env:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          # Get the head branch name from the merged PR
+          # Get the head branch name and repo from the merged PR
           echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "Merged branch: $BRANCH_NAME"
+          echo "head-repo=$HEAD_REPO" >> $GITHUB_OUTPUT
+          echo "Merged branch: $BRANCH_NAME from $HEAD_REPO"
 
       - name: Check if branch exists
         id: check-branch
         env:
-          BRANCH_NAME: ${{ steps.get-branch.outputs.branch-name }}
+          HEAD_REF: ${{ steps.get-branch.outputs.branch-name }}
+          HEAD_REPO: ${{ steps.get-branch.outputs.head-repo }}
         run: |
-          # Check if the branch still exists on the remote
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+          # Check if the branch still exists on the fork remote
+          if git ls-remote "https://github.com/${HEAD_REPO}.git" "refs/heads/${HEAD_REF}" | grep -q "refs/heads/${HEAD_REF}"; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
-            echo "Branch $BRANCH_NAME exists and can be used for backport"
+            echo "Branch $HEAD_REF exists in $HEAD_REPO and can be used for backport"
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
-            echo "Branch $BRANCH_NAME no longer exists, cannot create backport PR"
+            echo "Branch $HEAD_REF no longer exists in $HEAD_REPO, cannot create backport PR"
           fi
 
       - name: Create backport PR

--- a/.github/workflows/backport-to-develop.yml
+++ b/.github/workflows/backport-to-develop.yml
@@ -25,17 +25,18 @@ jobs:
 
       - name: Get merged branch name
         id: get-branch
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
           # Get the head branch name from the merged PR
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "Merged branch: $BRANCH_NAME"
 
       - name: Check if branch exists
         id: check-branch
+        env:
+          BRANCH_NAME: ${{ steps.get-branch.outputs.branch-name }}
         run: |
-          BRANCH_NAME="${{ steps.get-branch.outputs.branch-name }}"
-          
           # Check if the branch still exists on the remote
           if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
             echo "branch-exists=true" >> $GITHUB_OUTPUT
@@ -48,15 +49,21 @@ jobs:
       - name: Create backport PR
         if: steps.check-branch.outputs.branch-exists == 'true'
         uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ steps.get-branch.outputs.branch-name }}
+          ORIGINAL_PR_NUMBER: ${{ github.event.pull_request.number }}
+          ORIGINAL_PR_TITLE: ${{ github.event.pull_request.title }}
+          ORIGINAL_PR_BODY: ${{ github.event.pull_request.body }}
+          ORIGINAL_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const branchName = '${{ steps.get-branch.outputs.branch-name }}';
-            const originalPrNumber = context.payload.pull_request.number;
-            const originalPrTitle = context.payload.pull_request.title;
-            const originalPrBody = context.payload.pull_request.body || '';
-            const originalPrAuthor = context.payload.pull_request.user.login;
-            
+            const branchName = process.env.BRANCH_NAME;
+            const originalPrNumber = process.env.ORIGINAL_PR_NUMBER;
+            const originalPrTitle = process.env.ORIGINAL_PR_TITLE;
+            const originalPrBody = process.env.ORIGINAL_PR_BODY || '';
+            const originalPrAuthor = process.env.ORIGINAL_PR_AUTHOR;
+
             // Create the backport PR
             try {
               const response = await github.rest.pulls.create({


### PR DESCRIPTION
This pull request updates the `.github/workflows/backport-to-develop.yml` workflow to improve how environment variables are managed and accessed between workflow steps. The main focus is on passing key data as environment variables instead of inline shell variable assignments or direct context access, which helps make the workflow more robust and easier to maintain.

**Workflow environment variable handling:**

* Passes the branch name as an environment variable (`BRANCH_NAME`) instead of setting it as a shell variable in the "Get merged branch name" and "Check if branch exists" steps, improving consistency and reliability.
* In the "Create backport PR" step, passes all relevant pull request metadata (branch name, PR number, title, body, author) as environment variables, and updates the script to read these from `process.env` instead of using direct context access. This makes the script more portable and less dependent on the workflow context object.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backport workflow reliability by correctly handling pull requests from forks when verifying branch existence and capturing PR metadata. The workflow now properly references fork repositories instead of the current origin, ensuring accurate branch validation during backport operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->