### PR TITLE
Added: save _edac_summary_content_grade as individual post meta

### DIFF
--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -330,6 +330,7 @@ class Summary_Generator {
 		update_post_meta( $this->post_id, '_edac_summary_warnings', absint( $summary['warnings'] ) );
 		update_post_meta( $this->post_id, '_edac_summary_ignored', absint( $summary['ignored'] ) );
 		update_post_meta( $this->post_id, '_edac_summary_contrast_errors', absint( $summary['contrast_errors'] ) );
+		update_post_meta( $this->post_id, '_edac_summary_content_grade', absint( $summary['content_grade'] ) );
 	}
 
 	/**


### PR DESCRIPTION
This pull request makes a minor update to the summary metadata saving function. It now also saves the `content_grade` value to the post meta data, ensuring this additional piece of information is stored alongside other summary details.

* Added saving of the `content_grade` value to post meta in the `save_summary_meta_data` function in `class-summary-generator.php`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Content grade scores are now properly persisted and stored alongside other assessment metrics for improved data retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->