### PR TITLE
Email reports admin page change legal language

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -96,11 +96,11 @@ class AccessibilityReportsPage implements PageInterface {
 			]
 		);
 
-		$dashboard_url        = edac_link_wrapper( 'https://my.equalizedigital.com/', 'accessibility-reports', 'account', false );
-		$email_reports_url    = edac_link_wrapper( 'https://my.equalizedigital.com/email-reports', 'accessibility-reports', 'email-reports', false );
-		$signup_url           = edac_link_wrapper( 'https://my.equalizedigital.com/sign-up/', 'accessibility-reports', 'signup', false );
-		$privacy_url          = edac_link_wrapper( 'https://equalizedigital.com/privacy-policy/', 'accessibility-reports', 'privacy', false );
-		$data_processing_link = edac_link_wrapper( 'https://equalizedigital.com/data-terms/', 'accessibility-reports', 'dpa', false );
+		$dashboard_url       = edac_link_wrapper( 'https://my.equalizedigital.com/', 'accessibility-reports', 'account', false );
+		$email_reports_url   = edac_link_wrapper( 'https://my.equalizedigital.com/email-reports', 'accessibility-reports', 'email-reports', false );
+		$signup_url          = edac_link_wrapper( 'https://my.equalizedigital.com/sign-up/', 'accessibility-reports', 'signup', false );
+		$privacy_url         = edac_link_wrapper( 'https://equalizedigital.com/privacy-policy/', 'accessibility-reports', 'privacy', false );
+		$data_processing_url = edac_link_wrapper( 'https://equalizedigital.com/data-terms/', 'accessibility-reports', 'dpa', false );
 
 		$allowed_icon_html = [
 			'span' => [
@@ -282,7 +282,7 @@ class AccessibilityReportsPage implements PageInterface {
 							/* translators: %1$s: privacy link, %2$s: data processing agreement link. */
 							wp_kses_post( __( 'By connecting this site, you agree to Equalize Digital\'s <a href="%1$s" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">Data Processing Agreement</a>.', 'accessibility-checker' ) ),
 							esc_url( $privacy_url ),
-							esc_url( $data_processing_link )
+							esc_url( $data_processing_url )
 						);
 						?>
 					</p>

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -89,17 +89,19 @@ class AccessibilityReportsPage implements PageInterface {
 		$summary         = $scans_stats->summary();
 		$preview_data    = is_array( $summary ) ? $this->get_preview_data( $summary, $is_pro ) : [];
 
-		$upgrade_url       = edac_generate_link_type(
+		$upgrade_url = edac_generate_link_type(
 			[
 				'utm_campaign' => 'settings-page',
 				'utm_content'  => 'accessibility-reports-upgrade',
 			]
 		);
-		$dashboard_url     = edac_link_wrapper( 'https://my.equalizedigital.com/', 'accessibility-reports', 'account', false );
-		$email_reports_url = edac_link_wrapper( 'https://my.equalizedigital.com/email-reports', 'accessibility-reports', 'email-reports', false );
-		$signup_url        = edac_link_wrapper( 'https://my.equalizedigital.com/sign-up/', 'accessibility-reports', 'signup', false );
-		$terms_url         = edac_link_wrapper( 'https://equalizedigital.com/terms-of-service/', 'accessibility-reports', 'terms', false );
-		$privacy_url       = edac_link_wrapper( 'https://equalizedigital.com/privacy-policy/', 'accessibility-reports', 'privacy', false );
+
+		$dashboard_url        = edac_link_wrapper( 'https://my.equalizedigital.com/', 'accessibility-reports', 'account', false );
+		$email_reports_url    = edac_link_wrapper( 'https://my.equalizedigital.com/email-reports', 'accessibility-reports', 'email-reports', false );
+		$signup_url           = edac_link_wrapper( 'https://my.equalizedigital.com/sign-up/', 'accessibility-reports', 'signup', false );
+		$privacy_url          = edac_link_wrapper( 'https://equalizedigital.com/privacy-policy/', 'accessibility-reports', 'privacy', false );
+		$data_processing_link = edac_link_wrapper( 'https://equalizedigital.com/data-terms/', 'accessibility-reports', 'dpa', false );
+
 		$allowed_icon_html = [
 			'span' => [
 				'class'       => true,
@@ -278,9 +280,9 @@ class AccessibilityReportsPage implements PageInterface {
 						<?php
 						printf(
 							/* translators: %1$s: terms link, %2$s: privacy link. */
-							wp_kses_post( __( 'By connecting this site, you agree to the Equalize Digital <a href="%1$s" target="_blank" rel="noopener noreferrer">Terms of Service</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.', 'accessibility-checker' ) ),
-							esc_url( $terms_url ),
-							esc_url( $privacy_url )
+							wp_kses_post( __( 'By connecting this site, you agree to the Equalize Digital <a href="%1$s" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">Data Processing Agreement</a>.', 'accessibility-checker' ) ),
+							esc_url( $privacy_url ),
+							esc_url( $data_processing_link )
 						);
 						?>
 					</p>

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -280,7 +280,7 @@ class AccessibilityReportsPage implements PageInterface {
 						<?php
 						printf(
 							/* translators: %1$s: terms link, %2$s: privacy link. */
-							wp_kses_post( __( 'By connecting this site, you agree to the Equalize Digital <a href="%1$s" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">Data Processing Agreement</a>.', 'accessibility-checker' ) ),
+							wp_kses_post( __( 'By connecting this site, you agree to Equalize Digital\'s <a href="%1$s" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">Data Processing Agreement</a>.', 'accessibility-checker' ) ),
 							esc_url( $privacy_url ),
 							esc_url( $data_processing_link )
 						);

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -279,7 +279,7 @@ class AccessibilityReportsPage implements PageInterface {
 					<p class="edac-reports-page__legal">
 						<?php
 						printf(
-							/* translators: %1$s: terms link, %2$s: privacy link. */
+							/* translators: %1$s: privacy link, %2$s: data processing agreement link. */
 							wp_kses_post( __( 'By connecting this site, you agree to Equalize Digital\'s <a href="%1$s" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">Data Processing Agreement</a>.', 'accessibility-checker' ) ),
 							esc_url( $privacy_url ),
 							esc_url( $data_processing_link )


### PR DESCRIPTION
Adds the DPA link to the disclaimer on email reports

<img width="646" height="51" alt="Screenshot from 2026-04-21 14-57-01" src="https://github.com/user-attachments/assets/6d9706f3-18ef-4956-ab04-15fb46e49bdc" />

Produces a link like this:

```
<a href="https://equalizedigital.com/privacy-policy/?utm_source=accessibility-checker&amp;utm_medium=software&amp;utm_campaign=accessibility-reports&amp;php_version=8.2.15&amp;platform=wordpress&amp;platform_version=7.0-RC2-62242&amp;software=free&amp;software_version=1.40.0&amp;days_active=28&amp;utm_content=privacy" target="_blank" rel="noopener noreferrer" aria-label="Privacy Policy (opens in a new window)">Privacy Policy <span aria-hidden="true">↗</span></a>
```
Fixes: #1639 

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes
