### PR TITLE
Use <th scope="row"> for dashboard 'Issues By Post Type' table rows

### DIFF
--- a/admin/class-widgets.php
+++ b/admin/class-widgets.php
@@ -206,7 +206,7 @@ class Widgets {
 
 					$html .= '
 							<tr>
-								<th scope="col">' . esc_html( $post_type_label ) . '</th>
+								<th scope="row">' . esc_html( $post_type_label ) . '</th>
 								<td id="' . esc_attr( $post_type ) . '-errors">-</td>
 								<td id="' . esc_attr( $post_type ) . '-contrast-errors">-</td>
 								<td id="' . esc_attr( $post_type ) . '-warnings">-</td>
@@ -214,7 +214,7 @@ class Widgets {
 				} else {
 					$html .= '
 							<tr>
-								<th scope="col">' . esc_html( $post_type_label ) . '</th>
+								<th scope="row">' . esc_html( $post_type_label ) . '</th>
 								<td>-</td>
 								<td>-</td>
 								<td>-</td>
@@ -225,7 +225,7 @@ class Widgets {
 
 				$html .= '
 						<tr >
-							<th scope="col">' . esc_html( $post_type_label ) . '</th>
+							<th scope="row">' . esc_html( $post_type_label ) . '</th>
 							<td>-</td>
 							<td>-</td>
 							<td>-</td>
@@ -245,7 +245,7 @@ class Widgets {
 				);
 				$html                            .= '
 						<tr >
-							<th scope="col">' . esc_html( $post_type_label ) . '</th>
+							<th scope="row">' . esc_html( $post_type_label ) . '</th>
 							<td colspan="3">
 								<div class="edac-issues-summary-notice-upgrade-to-edacp">
 									<a class="button" href="' . esc_url( $non_scannable_post_type_pro_link ) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr__( 'Upgrade to Scan (opens in a new window)', 'accessibility-checker' ) . '">


### PR DESCRIPTION
### Motivation
- Improve accessibility of the dashboard widget by making the first cell in each table body row a row header so screen readers and other assistive technologies can identify row labels correctly.

### Description
- Replaced `th scope="col"` with `th scope="row"` for the first cell in every body row of the "Issues By Post Type" table in `admin/class-widgets.php` across all row-rendering branches (scannable rows, default rows, Pro-valid rows, and upgrade CTA rows).
- This is a markup-only change and does not modify business logic or data output.

### Testing
- Ran `php -l admin/class-widgets.php` and it returned no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78edd9a3883288641505e13bd3635)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table header semantics in the dashboard scan summary for better accessibility with screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->