### PR TITLE
Fix focus returning to panel close button instead of Fix Issue trigger

### DIFF
--- a/src/frontendHighlighterApp/fixesModal.js
+++ b/src/frontendHighlighterApp/fixesModal.js
@@ -131,11 +131,12 @@ const closeFixesModal = () => {
 		}
 	} );
 	document.body.classList.remove( 'edac-fixes-modal--open' );
-	if ( focusRestoreTarget ) {
-		focusRestoreTarget.focus();
-	}
 	unbindChangeEvents();
 	document.dispatchEvent( CloseEvent );
+	if ( focusRestoreTarget ) {
+		const target = focusRestoreTarget;
+		setTimeout( () => target.focus(), 0 );
+	}
 };
 
 export const fillFixesModal = ( content = '', fieldsElement = '' ) => {

--- a/src/frontendHighlighterApp/fixesModal.js
+++ b/src/frontendHighlighterApp/fixesModal.js
@@ -135,6 +135,7 @@ const closeFixesModal = () => {
 	document.dispatchEvent( CloseEvent );
 	if ( focusRestoreTarget ) {
 		const target = focusRestoreTarget;
+		focusRestoreTarget = null;
 		setTimeout( () => target.focus(), 0 );
 	}
 };


### PR DESCRIPTION
This pull request makes a small but important update to the way focus is restored when closing the fixes modal. The change ensures that focus is reliably set back to the previous target by using a zero-delay `setTimeout`, which helps avoid timing issues that can occur during DOM updates.

* Improved focus restoration: When closing the fixes modal in `fixesModal.js`, focus is now restored to the previous target using `setTimeout` to ensure it happens after the DOM updates.

<img width="1204" height="699" alt="2026-04-21 13 30 11" src="https://github.com/user-attachments/assets/2694e18b-d9f6-41d0-b72e-53324f2f851e" />
