### PR TITLE
Fix aria-label not updating when enable/disable styles button state changes

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -1422,6 +1422,7 @@ class AccessibilityCheckerHighlight {
 
 		this.stylesDisabled = true;
 		this.disableStylesButton.querySelector( 'span' ).textContent = __( 'Enable Styles', 'accessibility-checker' );
+		this.disableStylesButton.setAttribute( 'aria-label', __( 'Enable Page Styles', 'accessibility-checker' ) );
 	}
 
 	/**
@@ -1457,6 +1458,7 @@ class AccessibilityCheckerHighlight {
 
 		this.stylesDisabled = false;
 		this.disableStylesButton.querySelector( 'span' ).textContent = __( 'Disable Styles', 'accessibility-checker' );
+		this.disableStylesButton.setAttribute( 'aria-label', __( 'Disable Page Styles', 'accessibility-checker' ) );
 
 		// Re-render the current issue to restore panel state after styles are re-enabled.
 		if ( this.currentButtonIndex !== null && this.issues[ this.currentButtonIndex ] ) {


### PR DESCRIPTION
This pull request makes a small accessibility improvement to the `AccessibilityCheckerHighlight` class by updating the `aria-label` attribute for the styles toggle button. This ensures that screen readers provide more descriptive information about the button's current action.

- Accessibility improvements:
  * When styles are disabled, the button's `aria-label` is set to "Enable Page Styles" to reflect the action that will occur if clicked.
  * When styles are enabled, the button's `aria-label` is set to "Disable Page Styles" to accurately describe the button's function.