### PR TITLE
Add role and aria-labelledby attributes to highlight panel controls for improved accessibility

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -597,9 +597,9 @@ class AccessibilityCheckerHighlight {
                         <div id="edac-highlight-announcer" class="edac-sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
                         <div id="edac-highlight-panel" class="edac-highlight-panel edac-highlight-panel--${ widgetPosition }">
                                 <button id="edac-highlight-panel-toggle" class="edac-highlight-panel-toggle" aria-haspopup="dialog" aria-label="${ __( 'Accessibility Checker Tools', 'accessibility-checker' ) }"></button>
-                                <div id="edac-highlight-panel-controls" class="edac-highlight-panel-controls" tabindex="0">
+                                <div id="edac-highlight-panel-controls" class="edac-highlight-panel-controls" tabindex="0" role="dialog" aria-labelledby="edac-highlight-panel-controls-title">
                                         <div class="edac-highlight-panel-controls-header">
-                                                <div class="edac-highlight-panel-controls-title" role="heading" aria-level="2"><span class="edac-highlight-panel-controls-title-icon" aria-hidden="true"></span>${ __( 'Accessibility Checker', 'accessibility-checker' ) }</div>
+                                                <div id="edac-highlight-panel-controls-title" class="edac-highlight-panel-controls-title" role="heading" aria-level="2"><span class="edac-highlight-panel-controls-title-icon" aria-hidden="true"></span>${ __( 'Accessibility Checker', 'accessibility-checker' ) }</div>
                                                 <div class="edac-highlight-panel-controls-header-actions">
                                                         <div class="edac-highlight-menu-container">
                                                                 <button id="edac-highlight-menu-button" class="edac-highlight-menu-button" aria-haspopup="menu" aria-expanded="false" aria-label="${ __( 'More options', 'accessibility-checker' ) }">&#8943;</button>


### PR DESCRIPTION
This pull request makes accessibility improvements to the highlight panel in the `src/frontendHighlighterApp/index.js` file. The main changes involve enhancing ARIA attributes and labeling to improve screen reader support.

Accessibility improvements:

* Added `role="dialog"` and `aria-labelledby="edac-highlight-panel-controls-title"` to the `edac-highlight-panel-controls` container to better identify the panel as a dialog and associate it with its title for assistive technologies.
* Added an `id` to the panel title (`edac-highlight-panel-controls-title`) so it can be referenced by `aria-labelledby`, improving accessibility for screen readers.