### PR TITLE
Add screen-reader announcement for admin notices on reports page

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -80,6 +80,8 @@ class AccessibilityReportsPage implements PageInterface {
 	 * @return void
 	 */
 	public function render_page() {
+		wp_enqueue_script( 'wp-a11y' );
+
 		$license_context = $this->get_license_context();
 		$is_pro          = $license_context['is_pro'];
 		$license_key     = (string) get_option( 'edacp_license_key', '' );
@@ -299,6 +301,43 @@ class AccessibilityReportsPage implements PageInterface {
 				/>
 			</aside>
 		</div>
+		<?php $this->render_notice_announcement_script(); ?>
+		<?php
+	}
+
+	/**
+	 * Announce admin notices on reports tab after full-page form submissions.
+	 *
+	 * @return void
+	 */
+	private function render_notice_announcement_script(): void {
+		$selector         = '.edac-settings--reports .notice.notice-success p, .edac-settings--reports .notice.notice-error p, .edac-settings--reports .notice.notice-warning p, .edac-settings--reports .notice.notice-info p';
+		$fallback_message = __( 'Status message updated.', 'accessibility-checker' );
+		?>
+		<script>
+			document.addEventListener( 'DOMContentLoaded', function() {
+				var notice = document.querySelector( <?php echo wp_json_encode( $selector ); ?> );
+				if ( ! notice ) {
+					return;
+				}
+
+				var message = notice.textContent ? notice.textContent.trim() : '';
+				if ( ! message ) {
+					message = <?php echo wp_json_encode( $fallback_message ); ?>;
+				}
+
+				if ( window.wp && window.wp.a11y && 'function' === typeof window.wp.a11y.speak ) {
+					window.wp.a11y.speak( message, 'polite' );
+					return;
+				}
+
+				var noticeContainer = notice.closest( '.notice' );
+				if ( noticeContainer ) {
+					noticeContainer.setAttribute( 'tabindex', '-1' );
+					noticeContainer.focus();
+				}
+			} );
+		</script>
 		<?php
 	}
 

--- a/tests/phpunit/Admin/AccessibilityReportsPageTest.php
+++ b/tests/phpunit/Admin/AccessibilityReportsPageTest.php
@@ -158,4 +158,16 @@ class AccessibilityReportsPageTest extends WP_UnitTestCase {
 
 		$this->assertSame( '2030-01-15', $next_collection );
 	}
+
+	/**
+	 * Ensures the reports page renders a screen-reader announcement script for admin notices.
+	 */
+	public function test_render_page_outputs_notice_announcement_script() {
+		ob_start();
+		$this->page->render_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wp.a11y.speak', $output );
+		$this->assertStringContainsString( '.edac-settings--reports .notice.notice-success p', $output );
+	}
 }


### PR DESCRIPTION
This pull request enhances accessibility for admin notices on the reports tab by announcing status messages to screen readers using the WordPress Accessibility (wp-a11y) library. It also adds a corresponding test to ensure the new functionality is rendered correctly.

**Accessibility improvements:**

* Enqueues the `wp-a11y` script in the `render_page` method of `AccessibilityReportsPage.php` to provide accessibility utilities for screen readers.
* Adds a private method `render_notice_announcement_script` to inject a JavaScript snippet that announces admin notice messages using `wp.a11y.speak` or focuses the notice if the library is unavailable. This script is rendered at the end of the reports tab content.

**Testing:**

* Adds a PHPUnit test `test_render_page_outputs_notice_announcement_script` to verify that the notice announcement script is present in the rendered output.