### PR TITLE
William/pro 772 remove email report dashboard link in the plugin

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -216,7 +216,7 @@ class AccessibilityReportsPage implements PageInterface {
 								<p class="edac-reports-card__meta">
 									<?php if ( $next_send_date ) : ?>
 										<?php /* translators: %s: next report date. */ ?>
-										<span><?php printf( esc_html__( 'Next report: %s', 'accessibility-checker' ), esc_html( wp_date( get_option( 'date_format' ), strtotime( $next_send_date ) ) ) ); ?></span>
+										<span><?php printf( esc_html__( 'Next report: %s', 'accessibility-checker' ), esc_html( mysql2date( get_option( 'date_format' ), $next_send_date ) ) ); ?></span>
 									<?php endif; ?>
 									</p>
 							</div>

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -84,7 +84,7 @@ class AccessibilityReportsPage implements PageInterface {
 		$is_pro          = $license_context['is_pro'];
 		$license_key     = (string) get_option( 'edacp_license_key', '' );
 		$is_connected    = $license_context['is_connected'];
-		$next_collection = $this->get_next_collection_date();
+		$next_send_date  = $this->get_next_send_estimate_date();
 		$scans_stats     = new Scans_Stats();
 		$summary         = $scans_stats->summary();
 		$preview_data    = is_array( $summary ) ? $this->get_preview_data( $summary, $is_pro ) : [];
@@ -214,9 +214,9 @@ class AccessibilityReportsPage implements PageInterface {
 								</div>
 								<p><?php esc_html_e( 'You’ll receive weekly accessibility reports for this site.', 'accessibility-checker' ); ?></p>
 								<p class="edac-reports-card__meta">
-									<?php if ( $next_collection ) : ?>
+									<?php if ( $next_send_date ) : ?>
 										<?php /* translators: %s: next report date. */ ?>
-										<span><?php printf( esc_html__( 'Next report: %s', 'accessibility-checker' ), esc_html( wp_date( get_option( 'date_format' ), strtotime( $next_collection ) ) ) ); ?></span>
+										<span><?php printf( esc_html__( 'Next report: %s', 'accessibility-checker' ), esc_html( wp_date( get_option( 'date_format' ), strtotime( $next_send_date ) ) ) ); ?></span>
 									<?php endif; ?>
 									</p>
 							</div>
@@ -340,21 +340,25 @@ class AccessibilityReportsPage implements PageInterface {
 	}
 
 	/**
-	 * Get the next report collection date for display.
-	 *
-	 * Prefers the schedule returned by the connector service and falls back to a
-	 * local estimate when no remote schedule has been stored yet.
+	 * Gets the next estimated send data, assuming each send will be on
+	 * Mondays.
 	 *
 	 * @return string
 	 */
-	private function get_next_collection_date(): string {
-		$next_collection = (string) get_option( 'edac_next_collection', '' );
-		if ( '' !== $next_collection ) {
-			return $next_collection;
-		}
+	private function get_next_send_estimate_date(): string {
+		try {
+			// If today is Monday, use today. Otherwise, use next Monday.
+			$today = new \DateTime( 'now', wp_timezone() );
 
-		$next_monday = new \DateTime( 'next monday', wp_timezone() );
-		return $next_monday->format( 'Y-m-d' );
+			if ( '1' === $today->format( 'N' ) ) {
+				return $today->format( 'Y-m-d' );
+			}
+
+			$next_monday = new \DateTime( 'next monday', wp_timezone() );
+			return $next_monday->format( 'Y-m-d' );
+		} catch ( \Exception $exception ) {
+			return '';
+		}
 	}
 
 	/**

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -319,28 +319,30 @@ class AccessibilityReportsPage implements PageInterface {
 	/**
 	 * Resolve effective license context from current status values.
 	 *
-	 * @param bool   $has_pro_plugin Whether the Pro plugin is installed.
-	 * @param string $pro_status     Current Pro license status.
-	 * @param string $free_status    Current free license status.
-	 * @param string $site_id        Current connected site ID.
+	 * @param bool   $has_pro_plugin  Whether the Pro plugin is installed.
+	 * @param string $pro_status      Current Pro license status.
+	 * @param string $free_status     Current free license status.
+	 * @param string $site_id         Current connected site ID.
+	 * @param bool   $fallback_active Whether a fallback from Pro to Free is currently active.
 	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool}
 	 */
-	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id ): array {
-		$is_pro       = $has_pro_plugin && 'valid' === $pro_status;
+	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id, bool $fallback_active = false ): array {
+		$is_pro       = $has_pro_plugin && 'valid' === $pro_status && ! $fallback_active;
 		$status       = $is_pro ? $pro_status : $free_status;
 		$is_connected = 'valid' === $status && '' !== $site_id;
 
 
 		return [
-			'has_pro_plugin' => $has_pro_plugin,
-			'is_pro'         => $is_pro,
-			'status'         => $status,
-			'is_connected'   => $is_connected,
+			'has_pro_plugin'  => $has_pro_plugin,
+			'is_pro'          => $is_pro,
+			'status'          => $status,
+			'is_connected'    => $is_connected,
+			'fallback_active' => $fallback_active,
 		];
 	}
 
 	/**
-	 * Gets the next estimated send data, assuming each send will be on
+	 * Gets the next estimated send date, assuming each send will be on
 	 * Mondays.
 	 *
 	 * @return string

--- a/tests/phpunit/Admin/AccessibilityReportsPageTest.php
+++ b/tests/phpunit/Admin/AccessibilityReportsPageTest.php
@@ -160,8 +160,8 @@ class AccessibilityReportsPageTest extends WP_UnitTestCase {
 			$expected = ( new DateTime( 'next monday', wp_timezone() ) )->format( 'Y-m-d' );
 		}
 
-		$next_collection = $this->invoke_private_method( 'get_next_send_estimate_date' );
+		$next_send_date = $this->invoke_private_method( 'get_next_send_estimate_date' );
 
-		$this->assertSame( $expected, $next_collection );
+		$this->assertSame( $expected, $next_send_date );
 	}
 }

--- a/tests/phpunit/Admin/AccessibilityReportsPageTest.php
+++ b/tests/phpunit/Admin/AccessibilityReportsPageTest.php
@@ -147,15 +147,21 @@ class AccessibilityReportsPageTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures stored next collection date is preferred over local fallback estimate.
+	 * Ensures the next send estimate returns today when it is Monday, otherwise next Monday.
 	 *
 	 * @throws ReflectionException If reflection fails.
 	 */
-	public function test_get_next_collection_date_uses_stored_value_when_available() {
-		update_option( 'edac_next_collection', '2030-01-15' );
+	public function test_get_next_send_estimate_date_returns_today_or_next_monday() {
+		$today = new DateTime( 'now', wp_timezone() );
 
-		$next_collection = $this->invoke_private_method( 'get_next_collection_date' );
+		if ( '1' === $today->format( 'N' ) ) {
+			$expected = $today->format( 'Y-m-d' );
+		} else {
+			$expected = ( new DateTime( 'next monday', wp_timezone() ) )->format( 'Y-m-d' );
+		}
 
-		$this->assertSame( '2030-01-15', $next_collection );
+		$next_collection = $this->invoke_private_method( 'get_next_send_estimate_date' );
+
+		$this->assertSame( $expected, $next_collection );
 	}
 }


### PR DESCRIPTION
This pull request updates how the next report date is estimated and displayed in the Accessibility Reports admin page. It replaces the use of a stored "next collection" date with a local calculation that always returns today if it is Monday, or the next Monday otherwise. The UI is also refactored for improved consistency, and the related test is updated accordingly.

**Date estimation changes:**

* Replaced the `get_next_collection_date` method with `get_next_send_estimate_date`, which now estimates the next report date based on the current day (today if Monday, otherwise next Monday), instead of relying on a stored option.
* Updated all references in the UI logic and display from `next_collection` to `next_send_date` to use the new estimation method. [[1]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL87-R87) [[2]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL206-R224)

**UI and code refactoring:**

* Changed report card containers in the UI from `<article>` elements to `<div>` elements for consistency and semantic simplification. [[1]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL164-R163) [[2]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL175-R176) [[3]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL206-R224) [[4]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL252-R259) [[5]](diffhunk://#diff-b1cfd227691877c8b35dc7fac20a7b5451c6e7abb4736d2b1539a21f68a973bbL275-R271)
* Removed the unused `$email_reports_url` variable.

**Testing updates:**

* Replaced the test for the old collection date logic with a new test that verifies the next send date is today if it's Monday, or the next Monday otherwise.
