### PR TITLE
Fix stale @return docblock on license context methods

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -304,7 +304,7 @@ class AccessibilityReportsPage implements PageInterface {
 	 * Pro should only be treated as authoritative when it is both installed and valid.
 	 * Otherwise the reports page should fall back to the free plugin state.
 	 *
-	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool}
+	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool,fallback_active:bool}
 	 */
 	private function get_license_context(): array {
 		$has_pro_plugin  = defined( 'EDACP_VERSION' );
@@ -324,7 +324,7 @@ class AccessibilityReportsPage implements PageInterface {
 	 * @param string $free_status     Current free license status.
 	 * @param string $site_id         Current connected site ID.
 	 * @param bool   $fallback_active Whether a fallback from Pro to Free is currently active.
-	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool}
+	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool,fallback_active:bool}
 	 */
 	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id, bool $fallback_active = false ): array {
 		$is_pro       = $has_pro_plugin && 'valid' === $pro_status && ! $fallback_active;


### PR DESCRIPTION
## Summary

- `resolve_license_context()` was updated in a prior commit to return a 5th key `fallback_active`, but both `@return array{...}` shape annotations (on `resolve_license_context` and `get_license_context`) still declared only 4 keys.
- PHPStan at moderate strictness would flag any access to `$context['fallback_active']` as an undefined offset, and IDE autocomplete would not surface the key.
- Updated both `@return` annotations to include `fallback_active:bool`.

## Test plan

- [ ] Confirm PHPStan/static analysis passes with no new offset errors on `fallback_active`
- [ ] No runtime changes — docblock only

🤖 Generated with [Claude Code](https://claude.com/claude-code)