### PR TITLE
Fix WCAG 2.5.3 Label in Name violation on styles toggle button

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -609,7 +609,7 @@ class AccessibilityCheckerHighlight {
                                                                         <li role="none"><button id="edac-highlight-dock" class="edac-highlight-dock" role="menuitem"><span>${ dockLabel }</span>${ dockIcon }</button></li>
                                                                         ${ rescanButton }
                                                                         ${ clearButtonMarkup }
-                                                                        <li role="none"><button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" role="menuitem" aria-live="polite" aria-label="${ __( 'Disable Page Styles', 'accessibility-checker' ) }"><span>${ __( 'Disable Styles', 'accessibility-checker' ) }</span>${ stylesIcon }</button></li>
+                                                                        <li role="none"><button id="edac-highlight-disable-styles" class="edac-highlight-disable-styles" role="menuitem" aria-live="polite"><span>${ __( 'Disable Styles', 'accessibility-checker' ) }</span>${ stylesIcon }</button></li>
                                                                 </ul>
                                                         </div>
                                                         <button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="${ __( 'Close', 'accessibility-checker' ) }">×</button>
@@ -1444,7 +1444,6 @@ class AccessibilityCheckerHighlight {
 
 		this.stylesDisabled = true;
 		this.disableStylesButton.querySelector( 'span' ).textContent = __( 'Enable Styles', 'accessibility-checker' );
-		this.disableStylesButton.setAttribute( 'aria-label', __( 'Enable Page Styles', 'accessibility-checker' ) );
 		this.announce( __( 'Page styles disabled.', 'accessibility-checker' ) );
 	}
 
@@ -1481,7 +1480,6 @@ class AccessibilityCheckerHighlight {
 
 		this.stylesDisabled = false;
 		this.disableStylesButton.querySelector( 'span' ).textContent = __( 'Disable Styles', 'accessibility-checker' );
-		this.disableStylesButton.setAttribute( 'aria-label', __( 'Disable Page Styles', 'accessibility-checker' ) );
 		this.announce( __( 'Page styles re-enabled.', 'accessibility-checker' ) );
 
 		// Re-render the current issue to restore panel state after styles are re-enabled.


### PR DESCRIPTION
## Summary

- The styles toggle button had `aria-label="Disable Page Styles"` / `"Enable Page Styles"` while the visible `<span>` text was `"Disable Styles"` / `"Enable Styles"`. The word `"Page"` inserted in the middle means the visible label is not a contiguous substring of the accessible name, failing WCAG 2.5.3 Label in Name (Level A).
- Speech-recognition users (Dragon, Voice Control) saying "click Disable Styles" could not activate the control because the spoken phrase didn't match the accessible name.
- Removed the `aria-label` from all three locations (initial markup, `disableStyles()`, `enableStyles()`). The visible span text is already descriptive and becomes the accessible name directly, resolving the violation.

## Test plan

- [ ] Confirm "Disable Styles" / "Enable Styles" button is activatable by speech recognition using its visible label
- [ ] Confirm the button still announces state changes via `aria-live="polite"` on toggle
- [ ] Run automated accessibility audit on the highlighter panel — no new WCAG 2.5.3 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)