### PR TITLE
Fix unhandled promise rejections from kickoffScan call sites

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -375,7 +375,7 @@ class AccessibilityCheckerHighlight {
 					} else if ( ! self._scanAttempted && response.data?.[ 0 ]?.code === -3 ) {
 						// Only try kickoffScan once per highlightAjax call
 						self._scanAttempted = true;
-						self.kickoffScan();
+						self.kickoffScan().catch( () => {} );
 						// After kickoffScan, try highlightAjax again, but only once
 						setTimeout( () => {
 							self.highlightAjax().then( resolve ).catch( reject );
@@ -1926,7 +1926,7 @@ class AccessibilityCheckerHighlight {
 			this.panelOpen();
 		} ).finally( () => {
 			this._isRescanning = false;
-		} );
+		} ).catch( () => {} );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `kickoffScan()` was refactored to return a Promise, but two existing callers were not updated to handle rejections:
  - `rescanPage()` — used `.then().finally()`, and `.finally()` re-throws rejections rather than consuming them, leaving the chain's tail unhandled.
  - `highlightAjax()` — called `self.kickoffScan()` with no handler at all (previously safe when kickoffScan returned `undefined`).
- Any scan failure (e.g. scanner bundle 404, missing `runAccessibilityScan`) produces an unhandled rejection that fires `window.onunhandledrejection`, generating console noise and false-positive hits in Sentry/Rollbar. The user-facing error is already displayed via `showScanError`, so a `.catch(() => {})` at each call site is sufficient.

## Test plan

- [ ] Simulate a scanner bundle load failure (e.g. block the bundle URL) — confirm no `Uncaught (in promise)` in console
- [ ] Confirm rescan still works normally on success
- [ ] Confirm `showScanError` still displays correctly on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)