### PR TITLE
feat: add Structure Map panel to frontend highlighter

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -233,6 +233,10 @@ class AccessibilityCheckerHighlight {
 	 * @param {number} index
 	 */
 	switchView( index ) {
+		this.removeSelectedClasses();
+		this.removeHeadingHighlights();
+		this.removeTabOrderHighlights();
+
 		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks, this.tabTabOrder ];
 		const viewPanels = [ this.contentArea, this.panelHeadings, this.panelLandmarks, this.panelTabOrder ];
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -261,6 +261,9 @@ class AccessibilityCheckerHighlight {
 
 		if ( index !== 3 ) {
 			this.removeTabOrderOverlay();
+			document.querySelectorAll( '.edac-highlight-btn' ).forEach( ( b ) => b.style.removeProperty( 'display' ) );
+		} else {
+			document.querySelectorAll( '.edac-highlight-btn' ).forEach( ( b ) => b.style.setProperty( 'display', 'none', 'important' ) );
 		}
 
 		if ( index === 0 ) {

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -67,6 +67,7 @@ class AccessibilityCheckerHighlight {
 		this.panelHeadings = document.querySelector( '#edac-panel-headings' );
 		this.panelLandmarks = document.querySelector( '#edac-panel-landmarks' );
 		this.activeViewIndex = 0;
+		this._activeLandmarkEl = null;
 
 		// Force-hide structure panels from the start — all:unset overrides CSS [hidden].
 		[ this.panelHeadings, this.panelLandmarks ].forEach( ( panel ) => {
@@ -216,7 +217,9 @@ class AccessibilityCheckerHighlight {
 		if ( this.urlParameter ) {
 			this.panelOpen( this.urlParameter );
 		} else if ( this.landmarkParameter ) {
+			this.panelOpen();
 			this.highlightLandmark( this.landmarkParameter );
+			this.switchView( 2 );
 		} else if ( this.isDocked ) {
 			// Docked panel restored on page load — fetch issue data so the panel isn't empty.
 			this.panelOpen();
@@ -254,7 +257,12 @@ class AccessibilityCheckerHighlight {
 		this.panelControls.classList.toggle( 'edac-view--structure', index !== 0 );
 		this.activeViewIndex = index;
 
-		if ( index === 1 ) {
+		if ( index === 0 ) {
+			// If issues loaded while we were on another tab, show them now.
+			if ( this.issues?.length > 0 && this.currentButtonIndex === null ) {
+				this.showIssue( this.issues[ 0 ].id );
+			}
+		} else if ( index === 1 ) {
 			this.buildHeadingsPanel();
 		} else if ( index === 2 ) {
 			this.buildLandmarksPanel();
@@ -268,7 +276,7 @@ class AccessibilityCheckerHighlight {
 
 	buildLandmarksPanel() {
 		this.panelLandmarks.innerHTML = '';
-		renderLandmarksPanel( this.panelLandmarks, ( el ) => this.applyLandmarkHighlight( el ) );
+		renderLandmarksPanel( this.panelLandmarks, ( el ) => this.applyLandmarkHighlight( el ), this._activeLandmarkEl );
 	}
 
 	toggleMenu() {
@@ -1096,10 +1104,15 @@ class AccessibilityCheckerHighlight {
 
 				if ( id !== undefined ) {
 					this.showIssue( id );
-				} else if ( this.currentButtonIndex !== null && this.issues[ this.currentButtonIndex ] ) {
-					this.showIssue( this.issues[ this.currentButtonIndex ].id );
-				} else if ( this.issues.length > 0 ) {
-					this.showIssue( this.issues[ 0 ].id );
+				} else if ( this.activeViewIndex === 0 ) {
+					// Only auto-navigate to an issue when the Issues tab is active.
+					// Skipping this on Headings/Landmarks prevents polluting the URL
+					// with ?edac=<id>, which would reopen the Issues tab on refresh.
+					if ( this.currentButtonIndex !== null && this.issues[ this.currentButtonIndex ] ) {
+						this.showIssue( this.issues[ this.currentButtonIndex ].id );
+					} else if ( this.issues.length > 0 ) {
+						this.showIssue( this.issues[ 0 ].id );
+					}
 				}
 			}
 		).catch( ( err ) => {
@@ -1778,6 +1791,7 @@ class AccessibilityCheckerHighlight {
 	 * @param {HTMLElement} landmarkElement The element to highlight
 	 */
 	applyLandmarkHighlight( landmarkElement ) {
+		this._activeLandmarkEl = landmarkElement;
 		this.removeLandmarkLabels();
 		this.removeHeadingHighlights();
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -8,6 +8,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { saveFixSettings } from '../common/saveFixSettingsRest';
 import { fillFixesModal, fixSettingsModalInit, openFixesModal } from './fixesModal';
 import { getLandmarkType as getLandmarkTypeUtil } from './getLandmarkType';
+import { renderStructureMap } from './structureMap';
 
 class AccessibilityCheckerHighlight {
 	/**
@@ -60,6 +61,16 @@ class AccessibilityCheckerHighlight {
 		this.moveButton = document.querySelector( '#edac-highlight-move' );
 		this.dockButton = document.querySelector( '#edac-highlight-dock' );
 		this.srAnnouncer = document.querySelector( '#edac-highlight-announcer' );
+		this.tabIssues = document.querySelector( '#edac-tab-issues' );
+		this.tabStructure = document.querySelector( '#edac-tab-structure' );
+		this.panelStructure = document.querySelector( '#edac-panel-structure' );
+		this.activeViewIndex = 0;
+
+		// Force-hide the structure panel from the start. CSS alone can't reliably win
+		// against all:unset inside the panel, so we use the highest-priority override possible.
+		if ( this.panelStructure ) {
+			this.panelStructure.style.setProperty( 'display', 'none', 'important' );
+		}
 		this.isDocked = localStorage.getItem( 'edac-panel-docked' ) === '1';
 		this.stylesDisabled = false;
 		this.originalCss = [];
@@ -163,6 +174,29 @@ class AccessibilityCheckerHighlight {
 			} );
 		}
 
+		// View tab switching (Issues / Structure)
+		const viewTabs = [ this.tabIssues, this.tabStructure ];
+		viewTabs.forEach( ( tab, index ) => {
+			tab.addEventListener( 'click', () => this.switchView( index ) );
+			tab.addEventListener( 'keydown', ( e ) => {
+				let next = index;
+				if ( e.key === 'ArrowRight' ) {
+					next = ( index + 1 ) % viewTabs.length;
+				} else if ( e.key === 'ArrowLeft' ) {
+					next = ( index - 1 + viewTabs.length ) % viewTabs.length;
+				} else if ( e.key === 'Home' ) {
+					next = 0;
+				} else if ( e.key === 'End' ) {
+					next = viewTabs.length - 1;
+				} else {
+					return;
+				}
+				e.preventDefault();
+				this.switchView( next );
+				viewTabs[ next ].focus();
+			} );
+		} );
+
 		// Reactivate the focus trap when the user clicks back into the panel.
 		this.panelControls.addEventListener( 'pointerdown', () => {
 			if ( ! this.panelControlsFocusTrap.active ) {
@@ -184,6 +218,51 @@ class AccessibilityCheckerHighlight {
 			// Docked panel restored on page load — fetch issue data so the panel isn't empty.
 			this.panelOpen();
 		}
+	}
+
+	/**
+	 * Switch between Issues (index 0) and Structure (index 1) views.
+	 * @param {number} index
+	 */
+	switchView( index ) {
+		const viewTabs = [ this.tabIssues, this.tabStructure ];
+		const viewPanels = [ this.contentArea, this.panelStructure ];
+
+		viewTabs.forEach( ( tab, i ) => {
+			const active = i === index;
+			tab.setAttribute( 'aria-selected', String( active ) );
+			tab.tabIndex = active ? 0 : -1;
+		} );
+
+		viewPanels.forEach( ( panel, i ) => {
+			const active = i === index;
+			if ( active ) {
+				panel.removeAttribute( 'hidden' );
+				panel.classList.remove( 'edac-view-hidden' );
+				panel.style.removeProperty( 'display' );
+			} else {
+				panel.setAttribute( 'hidden', '' );
+				panel.classList.add( 'edac-view-hidden' );
+				panel.style.setProperty( 'display', 'none', 'important' );
+			}
+		} );
+
+		// Hide prev/next nav in structure view — they only apply to issues.
+		this.panelControls.classList.toggle( 'edac-view--structure', index === 1 );
+		this.activeViewIndex = index;
+
+		if ( index === 1 ) {
+			this.buildStructureMap();
+		}
+	}
+
+	buildStructureMap() {
+		renderStructureMap(
+			this.panelStructure,
+			this.issues || [],
+			( el ) => this.applyLandmarkHighlight( el ),
+			( el ) => this.applyHeadingHighlight( el )
+		);
 	}
 
 	toggleMenu() {
@@ -615,7 +694,11 @@ class AccessibilityCheckerHighlight {
                                                         <button id="edac-highlight-panel-controls-close" class="edac-highlight-panel-controls-close" aria-label="${ __( 'Close', 'accessibility-checker' ) }">×</button>
                                                 </div>
                                         </div>
-                                        <div id="edac-highlight-panel-controls-content" class="edac-highlight-panel-controls-content">
+                                        <div role="tablist" class="edac-highlight-view-tabs" aria-label="${ __( 'Panel view', 'accessibility-checker' ) }">
+                                                <button id="edac-tab-issues" role="tab" aria-selected="true" aria-controls="edac-highlight-panel-controls-content" class="edac-highlight-view-tab" tabindex="0">${ __( 'Issues', 'accessibility-checker' ) }</button>
+                                                <button id="edac-tab-structure" role="tab" aria-selected="false" aria-controls="edac-panel-structure" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Structure', 'accessibility-checker' ) }</button>
+                                        </div>
+                                        <div id="edac-highlight-panel-controls-content" role="tabpanel" aria-labelledby="edac-tab-issues" class="edac-highlight-panel-controls-content">
                                                 <div id="edac-highlight-panel-controls-content-empty" class="edac-highlight-panel-controls-content-empty">
                                                         ${ __( 'No issues found on this page.', 'accessibility-checker' ) }
                                                 </div>
@@ -626,6 +709,7 @@ class AccessibilityCheckerHighlight {
                                                         <div id="edac-highlight-panel-description-fix" class="edac-highlight-panel-description-fix"></div>
                                                 </div>
                                         </div>
+                                        <div id="edac-panel-structure" role="tabpanel" aria-labelledby="edac-tab-structure" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
                                         <div class="edac-highlight-panel-controls-footer">
                                                 <div class="edac-highlight-panel-controls-summary">${ __( 'Loading...', 'accessibility-checker' ) }</div>
                                                 <div class="edac-highlight-panel-controls-buttons">
@@ -1674,69 +1758,66 @@ class AccessibilityCheckerHighlight {
 			}
 
 			if ( landmarkElement ) {
-				// Clean up any existing landmark labels first
-				this.removeLandmarkLabels();
-
-				// Add highlighting styles
-				landmarkElement.classList.add( 'edac-highlight-element-selected' );
-				landmarkElement.classList.add( 'edac-landmark-highlight' );
-
-				// Create and add landmark type label
-				const landmarkType = this.getLandmarkType( landmarkElement );
-				const landmarkLabel = document.createElement( 'div' );
-				landmarkLabel.classList.add( 'edac-landmark-label' );
-				landmarkLabel.textContent = sprintf( __( 'Landmark: %s', 'accessibility-checker' ), landmarkType );
-				landmarkLabel.setAttribute( 'aria-hidden', 'true' );
-				landmarkLabel.style.cssText = `
-					position: absolute;
-					background: #072446;
-					color: white;
-					padding: 4px 8px;
-					font-size: 12px;
-					font-weight: bold;
-					border-radius: 3px;
-					z-index: 99998;
-					pointer-events: none;
-					font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-					line-height: 1;
-					box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-				`;
-
-				// Position the label inside the top-left corner of the landmark
-				const rect = landmarkElement.getBoundingClientRect();
-				landmarkLabel.style.left = ( rect.left + window.scrollX - 0 ) + 'px'; // 15px inside from left edge
-				landmarkLabel.style.top = ( rect.top + window.scrollY - 0 ) + 'px'; // 15px inside from top edge
-
-				// Add label to the page
-				document.body.appendChild( landmarkLabel );
-
-				// Store reference for cleanup
-				landmarkElement.setAttribute( 'data-edac-landmark-label-id', Date.now() );
-				landmarkLabel.setAttribute( 'data-edac-landmark-for', landmarkElement.getAttribute( 'data-edac-landmark-label-id' ) );
-
-				// Adjust for small elements
-				if ( landmarkElement.offsetWidth < 20 ) {
-					landmarkElement.classList.add( 'edac-highlight-element-selected-min-width' );
-				}
-
-				if ( landmarkElement.offsetHeight < 5 ) {
-					landmarkElement.classList.add( 'edac-highlight-element-selected-min-height' );
-				}
-
-				// Scroll to the landmark with 20px offset from start
-				const elementRect = landmarkElement.getBoundingClientRect();
-				const elementTop = elementRect.top + window.scrollY - 75;
-				window.scrollTo( {
-					top: elementTop,
-					behavior: 'smooth',
-				} );
-
-			} else {
-				// Landmark element not found - silently fail
+				this.applyLandmarkHighlight( landmarkElement );
 			}
 		} catch ( error ) {
 			// Error highlighting landmark - silently fail
 		}
+	}
+
+	/**
+	 * Applies the visual landmark highlight (outline, label badge, scroll) to a live element.
+	 * @param {HTMLElement} landmarkElement The element to highlight
+	 */
+	applyLandmarkHighlight( landmarkElement ) {
+		this.removeLandmarkLabels();
+		this.removeHeadingHighlights();
+
+		landmarkElement.classList.add( 'edac-highlight-element-selected' );
+		landmarkElement.classList.add( 'edac-landmark-highlight' );
+
+		const landmarkType = this.getLandmarkType( landmarkElement );
+		const landmarkLabel = document.createElement( 'div' );
+		landmarkLabel.classList.add( 'edac-landmark-label' );
+		landmarkLabel.textContent = sprintf( __( 'Landmark: %s', 'accessibility-checker' ), landmarkType );
+		landmarkLabel.setAttribute( 'aria-hidden', 'true' );
+		landmarkLabel.style.cssText = `
+			position: absolute;
+			background: #072446;
+			color: white;
+			padding: 4px 8px;
+			font-size: 12px;
+			font-weight: bold;
+			border-radius: 3px;
+			z-index: 99998;
+			pointer-events: none;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+			line-height: 1;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+		`;
+
+		const rect = landmarkElement.getBoundingClientRect();
+		landmarkLabel.style.left = ( rect.left + window.scrollX ) + 'px';
+		landmarkLabel.style.top = ( rect.top + window.scrollY ) + 'px';
+
+		document.body.appendChild( landmarkLabel );
+
+		landmarkElement.setAttribute( 'data-edac-landmark-label-id', Date.now() );
+		landmarkLabel.setAttribute( 'data-edac-landmark-for', landmarkElement.getAttribute( 'data-edac-landmark-label-id' ) );
+
+		if ( landmarkElement.offsetWidth < 20 ) {
+			landmarkElement.classList.add( 'edac-highlight-element-selected-min-width' );
+		}
+
+		if ( landmarkElement.offsetHeight < 5 ) {
+			landmarkElement.classList.add( 'edac-highlight-element-selected-min-height' );
+		}
+
+		const elementTop = landmarkElement.getBoundingClientRect().top + window.scrollY - 75;
+		window.scrollTo( {
+			top: elementTop,
+			behavior: 'smooth',
+		} );
 	}
 
 	/**
@@ -1746,6 +1827,69 @@ class AccessibilityCheckerHighlight {
 	 */
 	getLandmarkType( element ) {
 		return getLandmarkTypeUtil( element );
+	}
+
+	/**
+	 * Applies the visual heading highlight (outline, label badge, scroll) to a live element.
+	 * @param {HTMLElement} headingElement The heading element to highlight
+	 */
+	applyHeadingHighlight( headingElement ) {
+		this.removeLandmarkLabels();
+		this.removeHeadingHighlights();
+
+		headingElement.classList.add( 'edac-highlight-element-selected', 'edac-heading-highlight' );
+
+		const level = headingElement.tagName.toUpperCase();
+		const headingLabel = document.createElement( 'div' );
+		headingLabel.classList.add( 'edac-heading-label' );
+		headingLabel.textContent = sprintf( __( 'Heading: %s', 'accessibility-checker' ), level );
+		headingLabel.setAttribute( 'aria-hidden', 'true' );
+		headingLabel.style.cssText = `
+			position: absolute;
+			background: #072446;
+			color: white;
+			padding: 4px 8px;
+			font-size: 12px;
+			font-weight: bold;
+			border-radius: 3px;
+			z-index: 99998;
+			pointer-events: none;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+			line-height: 1;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+		`;
+
+		const rect = headingElement.getBoundingClientRect();
+		headingLabel.style.left = ( rect.left + window.scrollX ) + 'px';
+		headingLabel.style.top = ( rect.top + window.scrollY ) + 'px';
+
+		document.body.appendChild( headingLabel );
+
+		if ( headingElement.offsetWidth < 20 ) {
+			headingElement.classList.add( 'edac-highlight-element-selected-min-width' );
+		}
+
+		if ( headingElement.offsetHeight < 5 ) {
+			headingElement.classList.add( 'edac-highlight-element-selected-min-height' );
+		}
+
+		const elementTop = headingElement.getBoundingClientRect().top + window.scrollY - 75;
+		window.scrollTo( {
+			top: elementTop,
+			behavior: 'smooth',
+		} );
+	}
+
+	removeHeadingHighlights() {
+		document.querySelectorAll( '.edac-heading-label' ).forEach( ( label ) => label.remove() );
+		document.querySelectorAll( '.edac-heading-highlight' ).forEach( ( el ) => {
+			el.classList.remove(
+				'edac-heading-highlight',
+				'edac-highlight-element-selected',
+				'edac-highlight-element-selected-min-width',
+				'edac-highlight-element-selected-min-height'
+			);
+		} );
 	}
 
 	/**
@@ -1760,7 +1904,12 @@ class AccessibilityCheckerHighlight {
 		// Remove landmark highlight classes
 		const landmarkHighlights = document.querySelectorAll( '.edac-landmark-highlight' );
 		landmarkHighlights.forEach( ( element ) => {
-			element.classList.remove( 'edac-landmark-highlight' );
+			element.classList.remove(
+				'edac-landmark-highlight',
+				'edac-highlight-element-selected',
+				'edac-highlight-element-selected-min-width',
+				'edac-highlight-element-selected-min-height'
+			);
 			element.removeAttribute( 'data-edac-landmark-label-id' );
 		} );
 	}

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -261,9 +261,9 @@ class AccessibilityCheckerHighlight {
 
 		if ( index !== 3 ) {
 			this.removeTabOrderOverlay();
-			document.querySelectorAll( '.edac-highlight-btn' ).forEach( ( b ) => b.style.removeProperty( 'display' ) );
+			document.body.classList.remove( 'edac-tab-order-active' );
 		} else {
-			document.querySelectorAll( '.edac-highlight-btn' ).forEach( ( b ) => b.style.setProperty( 'display', 'none', 'important' ) );
+			document.body.classList.add( 'edac-tab-order-active' );
 		}
 
 		if ( index === 0 ) {
@@ -390,6 +390,7 @@ class AccessibilityCheckerHighlight {
 
 	removeTabOrderOverlay() {
 		document.getElementById( 'edac-tab-order-overlay' )?.remove();
+		document.body.classList.remove( 'edac-tab-order-active' );
 		if ( this._tabOrderResizeHandler ) {
 			window.removeEventListener( 'resize', this._tabOrderResizeHandler );
 		}

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -8,7 +8,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { saveFixSettings } from '../common/saveFixSettingsRest';
 import { fillFixesModal, fixSettingsModalInit, openFixesModal } from './fixesModal';
 import { getLandmarkType as getLandmarkTypeUtil } from './getLandmarkType';
-import { renderStructureMap } from './structureMap';
+import { renderHeadingsPanel, renderLandmarksPanel } from './structureMap';
 
 class AccessibilityCheckerHighlight {
 	/**
@@ -62,15 +62,18 @@ class AccessibilityCheckerHighlight {
 		this.dockButton = document.querySelector( '#edac-highlight-dock' );
 		this.srAnnouncer = document.querySelector( '#edac-highlight-announcer' );
 		this.tabIssues = document.querySelector( '#edac-tab-issues' );
-		this.tabStructure = document.querySelector( '#edac-tab-structure' );
-		this.panelStructure = document.querySelector( '#edac-panel-structure' );
+		this.tabHeadings = document.querySelector( '#edac-tab-headings' );
+		this.tabLandmarks = document.querySelector( '#edac-tab-landmarks' );
+		this.panelHeadings = document.querySelector( '#edac-panel-headings' );
+		this.panelLandmarks = document.querySelector( '#edac-panel-landmarks' );
 		this.activeViewIndex = 0;
 
-		// Force-hide the structure panel from the start. CSS alone can't reliably win
-		// against all:unset inside the panel, so we use the highest-priority override possible.
-		if ( this.panelStructure ) {
-			this.panelStructure.style.setProperty( 'display', 'none', 'important' );
-		}
+		// Force-hide structure panels from the start — all:unset overrides CSS [hidden].
+		[ this.panelHeadings, this.panelLandmarks ].forEach( ( panel ) => {
+			if ( panel ) {
+				panel.style.setProperty( 'display', 'none', 'important' );
+			}
+		} );
 		this.isDocked = localStorage.getItem( 'edac-panel-docked' ) === '1';
 		this.stylesDisabled = false;
 		this.originalCss = [];
@@ -174,8 +177,8 @@ class AccessibilityCheckerHighlight {
 			} );
 		}
 
-		// View tab switching (Issues / Structure)
-		const viewTabs = [ this.tabIssues, this.tabStructure ];
+		// View tab switching (Issues / Headings / Landmarks)
+		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks ];
 		viewTabs.forEach( ( tab, index ) => {
 			tab.addEventListener( 'click', () => this.switchView( index ) );
 			tab.addEventListener( 'keydown', ( e ) => {
@@ -221,12 +224,12 @@ class AccessibilityCheckerHighlight {
 	}
 
 	/**
-	 * Switch between Issues (index 0) and Structure (index 1) views.
+	 * Switch between Issues (0), Headings (1), and Landmarks (2) views.
 	 * @param {number} index
 	 */
 	switchView( index ) {
-		const viewTabs = [ this.tabIssues, this.tabStructure ];
-		const viewPanels = [ this.contentArea, this.panelStructure ];
+		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks ];
+		const viewPanels = [ this.contentArea, this.panelHeadings, this.panelLandmarks ];
 
 		viewTabs.forEach( ( tab, i ) => {
 			const active = i === index;
@@ -247,22 +250,25 @@ class AccessibilityCheckerHighlight {
 			}
 		} );
 
-		// Hide prev/next nav in structure view — they only apply to issues.
-		this.panelControls.classList.toggle( 'edac-view--structure', index === 1 );
+		// Hide footer (summary + prev/next) when not on Issues tab.
+		this.panelControls.classList.toggle( 'edac-view--structure', index !== 0 );
 		this.activeViewIndex = index;
 
 		if ( index === 1 ) {
-			this.buildStructureMap();
+			this.buildHeadingsPanel();
+		} else if ( index === 2 ) {
+			this.buildLandmarksPanel();
 		}
 	}
 
-	buildStructureMap() {
-		renderStructureMap(
-			this.panelStructure,
-			this.issues || [],
-			( el ) => this.applyLandmarkHighlight( el ),
-			( el ) => this.applyHeadingHighlight( el )
-		);
+	buildHeadingsPanel() {
+		this.panelHeadings.innerHTML = '';
+		renderHeadingsPanel( this.panelHeadings, this.issues || [], ( el ) => this.applyHeadingHighlight( el ) );
+	}
+
+	buildLandmarksPanel() {
+		this.panelLandmarks.innerHTML = '';
+		renderLandmarksPanel( this.panelLandmarks, ( el ) => this.applyLandmarkHighlight( el ) );
 	}
 
 	toggleMenu() {
@@ -696,7 +702,8 @@ class AccessibilityCheckerHighlight {
                                         </div>
                                         <div role="tablist" class="edac-highlight-view-tabs" aria-label="${ __( 'Panel view', 'accessibility-checker' ) }">
                                                 <button id="edac-tab-issues" role="tab" aria-selected="true" aria-controls="edac-highlight-panel-controls-content" class="edac-highlight-view-tab" tabindex="0">${ __( 'Issues', 'accessibility-checker' ) }</button>
-                                                <button id="edac-tab-structure" role="tab" aria-selected="false" aria-controls="edac-panel-structure" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Structure', 'accessibility-checker' ) }</button>
+                                                <button id="edac-tab-headings" role="tab" aria-selected="false" aria-controls="edac-panel-headings" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Headings', 'accessibility-checker' ) }</button>
+                                                <button id="edac-tab-landmarks" role="tab" aria-selected="false" aria-controls="edac-panel-landmarks" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Landmarks', 'accessibility-checker' ) }</button>
                                         </div>
                                         <div id="edac-highlight-panel-controls-content" role="tabpanel" aria-labelledby="edac-tab-issues" class="edac-highlight-panel-controls-content">
                                                 <div id="edac-highlight-panel-controls-content-empty" class="edac-highlight-panel-controls-content-empty">
@@ -709,7 +716,8 @@ class AccessibilityCheckerHighlight {
                                                         <div id="edac-highlight-panel-description-fix" class="edac-highlight-panel-description-fix"></div>
                                                 </div>
                                         </div>
-                                        <div id="edac-panel-structure" role="tabpanel" aria-labelledby="edac-tab-structure" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
+                                        <div id="edac-panel-headings" role="tabpanel" aria-labelledby="edac-tab-headings" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
+                                        <div id="edac-panel-landmarks" role="tabpanel" aria-labelledby="edac-tab-landmarks" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
                                         <div class="edac-highlight-panel-controls-footer">
                                                 <div class="edac-highlight-panel-controls-summary">${ __( 'Loading...', 'accessibility-checker' ) }</div>
                                                 <div class="edac-highlight-panel-controls-buttons">

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -8,7 +8,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { saveFixSettings } from '../common/saveFixSettingsRest';
 import { fillFixesModal, fixSettingsModalInit, openFixesModal } from './fixesModal';
 import { getLandmarkType as getLandmarkTypeUtil } from './getLandmarkType';
-import { renderHeadingsPanel, renderLandmarksPanel } from './structureMap';
+import { renderHeadingsPanel, renderLandmarksPanel, renderTabOrderPanel, getFocusableElements } from './structureMap';
 
 class AccessibilityCheckerHighlight {
 	/**
@@ -66,11 +66,13 @@ class AccessibilityCheckerHighlight {
 		this.tabLandmarks = document.querySelector( '#edac-tab-landmarks' );
 		this.panelHeadings = document.querySelector( '#edac-panel-headings' );
 		this.panelLandmarks = document.querySelector( '#edac-panel-landmarks' );
+		this.tabTabOrder = document.querySelector( '#edac-tab-taborder' );
+		this.panelTabOrder = document.querySelector( '#edac-panel-taborder' );
 		this.activeViewIndex = 0;
 		this._activeLandmarkEl = null;
 
 		// Force-hide structure panels from the start — all:unset overrides CSS [hidden].
-		[ this.panelHeadings, this.panelLandmarks ].forEach( ( panel ) => {
+		[ this.panelHeadings, this.panelLandmarks, this.panelTabOrder ].forEach( ( panel ) => {
 			if ( panel ) {
 				panel.style.setProperty( 'display', 'none', 'important' );
 			}
@@ -178,8 +180,8 @@ class AccessibilityCheckerHighlight {
 			} );
 		}
 
-		// View tab switching (Issues / Headings / Landmarks)
-		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks ];
+		// View tab switching (Issues / Headings / Landmarks / Tab Order)
+		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks, this.tabTabOrder ];
 		viewTabs.forEach( ( tab, index ) => {
 			tab.addEventListener( 'click', () => this.switchView( index ) );
 			tab.addEventListener( 'keydown', ( e ) => {
@@ -231,8 +233,8 @@ class AccessibilityCheckerHighlight {
 	 * @param {number} index
 	 */
 	switchView( index ) {
-		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks ];
-		const viewPanels = [ this.contentArea, this.panelHeadings, this.panelLandmarks ];
+		const viewTabs = [ this.tabIssues, this.tabHeadings, this.tabLandmarks, this.tabTabOrder ];
+		const viewPanels = [ this.contentArea, this.panelHeadings, this.panelLandmarks, this.panelTabOrder ];
 
 		viewTabs.forEach( ( tab, i ) => {
 			const active = i === index;
@@ -257,6 +259,10 @@ class AccessibilityCheckerHighlight {
 		this.panelControls.classList.toggle( 'edac-view--structure', index !== 0 );
 		this.activeViewIndex = index;
 
+		if ( index !== 3 ) {
+			this.removeTabOrderOverlay();
+		}
+
 		if ( index === 0 ) {
 			// If issues loaded while we were on another tab, show them now.
 			if ( this.issues?.length > 0 && this.currentButtonIndex === null ) {
@@ -266,6 +272,8 @@ class AccessibilityCheckerHighlight {
 			this.buildHeadingsPanel();
 		} else if ( index === 2 ) {
 			this.buildLandmarksPanel();
+		} else if ( index === 3 ) {
+			this.buildTabOrderPanel();
 		}
 	}
 
@@ -277,6 +285,111 @@ class AccessibilityCheckerHighlight {
 	buildLandmarksPanel() {
 		this.panelLandmarks.innerHTML = '';
 		renderLandmarksPanel( this.panelLandmarks, ( el ) => this.applyLandmarkHighlight( el ), this._activeLandmarkEl );
+	}
+
+	buildTabOrderPanel() {
+		this.panelTabOrder.innerHTML = '';
+		renderTabOrderPanel( this.panelTabOrder, ( el, stopNumber, type ) => this.applyTabOrderHighlight( el, stopNumber, type ) );
+		this.overlayTabOrder();
+
+		if ( ! this._tabOrderResizeHandler ) {
+			let resizeTimer;
+			this._tabOrderResizeHandler = () => {
+				clearTimeout( resizeTimer );
+				resizeTimer = setTimeout( () => this.overlayTabOrder(), 150 );
+			};
+		}
+		window.addEventListener( 'resize', this._tabOrderResizeHandler );
+	}
+
+	overlayTabOrder() {
+		// Only remove the DOM element — leave the resize listener intact.
+		document.getElementById( 'edac-tab-order-overlay' )?.remove();
+
+		const focusableEls = getFocusableElements();
+		if ( focusableEls.length === 0 ) {
+			return;
+		}
+
+		const docWidth = document.documentElement.scrollWidth;
+		const docHeight = document.documentElement.scrollHeight;
+
+		const overlay = document.createElement( 'div' );
+		overlay.id = 'edac-tab-order-overlay';
+		overlay.setAttribute( 'aria-hidden', 'true' );
+		overlay.style.cssText = `
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: ${ docWidth }px;
+			height: ${ docHeight }px;
+			pointer-events: none;
+			z-index: 99998;
+		`;
+
+		// Badge centre points for line drawing
+		const badgeSize = 22;
+		const centres = focusableEls.map( ( el ) => {
+			const rect = el.getBoundingClientRect();
+			const x = rect.left + window.scrollX + ( Math.min( rect.width, badgeSize ) / 2 );
+			const y = rect.top + window.scrollY + ( Math.min( rect.height, badgeSize ) / 2 );
+			return { x, y };
+		} );
+
+		// SVG connecting lines
+		const ns = 'http://www.w3.org/2000/svg';
+		const svg = document.createElementNS( ns, 'svg' );
+		svg.setAttribute( 'xmlns', ns );
+		svg.style.cssText = `position:absolute;top:0;left:0;width:${ docWidth }px;height:${ docHeight }px;overflow:visible;`;
+
+		for ( let i = 0; i < centres.length - 1; i++ ) {
+			const line = document.createElementNS( ns, 'line' );
+			line.setAttribute( 'x1', centres[ i ].x );
+			line.setAttribute( 'y1', centres[ i ].y );
+			line.setAttribute( 'x2', centres[ i + 1 ].x );
+			line.setAttribute( 'y2', centres[ i + 1 ].y );
+			line.setAttribute( 'stroke', '#970C0C' );
+			line.setAttribute( 'stroke-width', '1.5' );
+			line.setAttribute( 'opacity', '0.65' );
+			svg.append( line );
+		}
+		overlay.append( svg );
+
+		// Numbered badges
+		focusableEls.forEach( ( el, i ) => {
+			const rect = el.getBoundingClientRect();
+			const badge = document.createElement( 'div' );
+			badge.textContent = i + 1;
+			badge.style.cssText = `
+				position: absolute;
+				left: ${ rect.left + window.scrollX }px;
+				top: ${ rect.top + window.scrollY }px;
+				width: 20px;
+				height: 20px;
+				background: #970C0C;
+				color: #fff;
+				border-radius: 50%;
+				font-size: 10px;
+				font-weight: 700;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+				line-height: 1;
+				box-shadow: 0 1px 3px rgba(0,0,0,0.35);
+				box-sizing: border-box;
+			`;
+			overlay.append( badge );
+		} );
+
+		document.body.append( overlay );
+	}
+
+	removeTabOrderOverlay() {
+		document.getElementById( 'edac-tab-order-overlay' )?.remove();
+		if ( this._tabOrderResizeHandler ) {
+			window.removeEventListener( 'resize', this._tabOrderResizeHandler );
+		}
 	}
 
 	toggleMenu() {
@@ -712,6 +825,7 @@ class AccessibilityCheckerHighlight {
                                                 <button id="edac-tab-issues" role="tab" aria-selected="true" aria-controls="edac-highlight-panel-controls-content" class="edac-highlight-view-tab" tabindex="0">${ __( 'Issues', 'accessibility-checker' ) }</button>
                                                 <button id="edac-tab-headings" role="tab" aria-selected="false" aria-controls="edac-panel-headings" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Headings', 'accessibility-checker' ) }</button>
                                                 <button id="edac-tab-landmarks" role="tab" aria-selected="false" aria-controls="edac-panel-landmarks" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Landmarks', 'accessibility-checker' ) }</button>
+                                                <button id="edac-tab-taborder" role="tab" aria-selected="false" aria-controls="edac-panel-taborder" class="edac-highlight-view-tab" tabindex="-1">${ __( 'Tab Order', 'accessibility-checker' ) }</button>
                                         </div>
                                         <div id="edac-highlight-panel-controls-content" role="tabpanel" aria-labelledby="edac-tab-issues" class="edac-highlight-panel-controls-content">
                                                 <div id="edac-highlight-panel-controls-content-empty" class="edac-highlight-panel-controls-content-empty">
@@ -726,6 +840,7 @@ class AccessibilityCheckerHighlight {
                                         </div>
                                         <div id="edac-panel-headings" role="tabpanel" aria-labelledby="edac-tab-headings" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
                                         <div id="edac-panel-landmarks" role="tabpanel" aria-labelledby="edac-tab-landmarks" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
+                                        <div id="edac-panel-taborder" role="tabpanel" aria-labelledby="edac-tab-taborder" class="edac-highlight-panel-controls-content edac-view-hidden" hidden></div>
                                         <div class="edac-highlight-panel-controls-footer">
                                                 <div class="edac-highlight-panel-controls-summary">${ __( 'Loading...', 'accessibility-checker' ) }</div>
                                                 <div class="edac-highlight-panel-controls-buttons">
@@ -1137,6 +1252,7 @@ class AccessibilityCheckerHighlight {
 		this.panelToggle.style.display = 'block';
 		this.removeSelectedClasses();
 		this.removeHighlightButtons();
+		this.removeTabOrderOverlay();
 
 		this.closePanel.removeEventListener( 'click', this.panelControlsFocusTrap.deactivate );
 
@@ -1794,6 +1910,7 @@ class AccessibilityCheckerHighlight {
 		this._activeLandmarkEl = landmarkElement;
 		this.removeLandmarkLabels();
 		this.removeHeadingHighlights();
+		this.removeTabOrderHighlights();
 
 		landmarkElement.classList.add( 'edac-highlight-element-selected' );
 		landmarkElement.classList.add( 'edac-landmark-highlight' );
@@ -1858,6 +1975,7 @@ class AccessibilityCheckerHighlight {
 	applyHeadingHighlight( headingElement ) {
 		this.removeLandmarkLabels();
 		this.removeHeadingHighlights();
+		this.removeTabOrderHighlights();
 
 		headingElement.classList.add( 'edac-highlight-element-selected', 'edac-heading-highlight' );
 
@@ -1899,6 +2017,65 @@ class AccessibilityCheckerHighlight {
 		window.scrollTo( {
 			top: elementTop,
 			behavior: 'smooth',
+		} );
+	}
+
+	applyTabOrderHighlight( element, stopNumber, type ) {
+		this.removeLandmarkLabels();
+		this.removeHeadingHighlights();
+		this.removeTabOrderHighlights();
+
+		element.classList.add( 'edac-highlight-element-selected', 'edac-tab-order-highlight' );
+
+		const label = document.createElement( 'div' );
+		label.classList.add( 'edac-tab-order-label' );
+		label.textContent = sprintf(
+			/* translators: %1$s is the tab stop number, %2$s is the element type e.g. "Button" */
+			__( 'Tab Stop #%1$s: %2$s', 'accessibility-checker' ),
+			stopNumber,
+			type
+		);
+		label.setAttribute( 'aria-hidden', 'true' );
+		label.style.cssText = `
+			position: absolute;
+			background: #072446;
+			color: white;
+			padding: 4px 8px;
+			font-size: 12px;
+			font-weight: bold;
+			border-radius: 3px;
+			z-index: 99998;
+			pointer-events: none;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+			line-height: 1;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+		`;
+
+		const rect = element.getBoundingClientRect();
+		label.style.left = ( rect.left + window.scrollX ) + 'px';
+		label.style.top = ( rect.top + window.scrollY ) + 'px';
+		document.body.appendChild( label );
+
+		if ( element.offsetWidth < 20 ) {
+			element.classList.add( 'edac-highlight-element-selected-min-width' );
+		}
+		if ( element.offsetHeight < 5 ) {
+			element.classList.add( 'edac-highlight-element-selected-min-height' );
+		}
+
+		const elementTop = element.getBoundingClientRect().top + window.scrollY - 75;
+		window.scrollTo( { top: elementTop, behavior: 'smooth' } );
+	}
+
+	removeTabOrderHighlights() {
+		document.querySelectorAll( '.edac-tab-order-label' ).forEach( ( el ) => el.remove() );
+		document.querySelectorAll( '.edac-tab-order-highlight' ).forEach( ( el ) => {
+			el.classList.remove(
+				'edac-tab-order-highlight',
+				'edac-highlight-element-selected',
+				'edac-highlight-element-selected-min-width',
+				'edac-highlight-element-selected-min-height'
+			);
 		} );
 	}
 

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -824,9 +824,9 @@ body {
 				}
 			}
 
-			// Hide prev/next navigation when structure view is active.
+			// Hide footer (summary + nav) when structure view is active.
 			&.edac-view--structure {
-				.edac-highlight-panel-controls-buttons {
+				.edac-highlight-panel-controls-footer {
 					display: none !important;
 				}
 			}
@@ -875,60 +875,12 @@ body {
 			}
 		}
 
-		// Structure tabpanel — flex column so sub-tabs stay fixed and list scrolls.
-		#edac-panel-structure {
-			display: flex !important;
-			flex-direction: column !important;
-			overflow: hidden !important;
-			padding: 0 !important;
-		}
-
-		// Structure sub-tabs (Headings / Landmarks)
-		.edac-structure-tabs {
-			display: flex !important;
-			flex-shrink: 0 !important;
-			border-bottom: 1px solid variables.$color-gray-light !important;
-			margin: 0 !important;
-			padding: 0 !important;
-		}
-
-		.edac-structure-tab {
-			all: unset !important;
-			flex: 1 !important;
-			padding: 8px 12px !important;
-			font-size: 12px !important;
-			font-weight: 500 !important;
-			color: variables.$color-dark-gray !important;
-			cursor: pointer !important;
-			text-align: center !important;
-			border-bottom: 2px solid transparent !important;
-			box-sizing: border-box !important;
-
-			&:hover {
-				color: variables.$color-blue !important;
-			}
-
-			&:focus-visible {
-				outline: 2px solid variables.$color-blue !important;
-				outline-offset: -2px !important;
-			}
-
-			&[aria-selected="true"] {
-				color: variables.$color-blue !important;
-				border-bottom-color: variables.$color-blue !important;
-				font-weight: 600 !important;
-			}
-		}
-
-		// Structure sub-tabpanels
-		.edac-structure-panel {
-			flex: 1 !important;
+		// Headings and Landmarks tabpanels — scrollable content areas.
+		#edac-panel-headings,
+		#edac-panel-landmarks {
+			display: block !important;
 			overflow-y: auto !important;
 			padding: 6px 0 !important;
-
-			&[hidden] {
-				display: none !important;
-			}
 		}
 
 		// Structure tree list

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -29,6 +29,10 @@ body {
 	&.edac-app-wait * {
 		cursor: wait !important;
 	}
+
+	&.edac-tab-order-active .edac-highlight-btn {
+		display: none !important;
+	}
 }
 
 .edac-highlight {

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -823,6 +823,215 @@ body {
 					}
 				}
 			}
+
+			// Hide prev/next navigation when structure view is active.
+			&.edac-view--structure {
+				.edac-highlight-panel-controls-buttons {
+					display: none !important;
+				}
+			}
+		}
+
+		// Hides a view panel — overrides all:unset which would otherwise reset display to inline.
+		.edac-view-hidden {
+			display: none !important;
+		}
+
+		// View toggle tabs (Issues / Structure)
+		.edac-highlight-view-tabs {
+			display: flex !important;
+			flex-shrink: 0 !important;
+			border-bottom: 1px solid variables.$color-gray-light !important;
+			background-color: variables.$color-white !important;
+			margin: 0 !important;
+			padding: 0 !important;
+		}
+
+		.edac-highlight-view-tab {
+			all: unset !important;
+			flex: 1 !important;
+			padding: 10px 16px !important;
+			font-size: 13px !important;
+			font-weight: 500 !important;
+			color: variables.$color-dark-gray !important;
+			cursor: pointer !important;
+			text-align: center !important;
+			border-bottom: 3px solid transparent !important;
+			box-sizing: border-box !important;
+
+			&:hover {
+				color: variables.$color-blue !important;
+			}
+
+			&:focus-visible {
+				outline: 2px solid variables.$color-blue !important;
+				outline-offset: -2px !important;
+			}
+
+			&[aria-selected="true"] {
+				color: variables.$color-blue !important;
+				border-bottom-color: variables.$color-blue !important;
+				font-weight: 600 !important;
+			}
+		}
+
+		// Structure tabpanel — flex column so sub-tabs stay fixed and list scrolls.
+		#edac-panel-structure {
+			display: flex !important;
+			flex-direction: column !important;
+			overflow: hidden !important;
+			padding: 0 !important;
+		}
+
+		// Structure sub-tabs (Headings / Landmarks)
+		.edac-structure-tabs {
+			display: flex !important;
+			flex-shrink: 0 !important;
+			border-bottom: 1px solid variables.$color-gray-light !important;
+			margin: 0 !important;
+			padding: 0 !important;
+		}
+
+		.edac-structure-tab {
+			all: unset !important;
+			flex: 1 !important;
+			padding: 8px 12px !important;
+			font-size: 12px !important;
+			font-weight: 500 !important;
+			color: variables.$color-dark-gray !important;
+			cursor: pointer !important;
+			text-align: center !important;
+			border-bottom: 2px solid transparent !important;
+			box-sizing: border-box !important;
+
+			&:hover {
+				color: variables.$color-blue !important;
+			}
+
+			&:focus-visible {
+				outline: 2px solid variables.$color-blue !important;
+				outline-offset: -2px !important;
+			}
+
+			&[aria-selected="true"] {
+				color: variables.$color-blue !important;
+				border-bottom-color: variables.$color-blue !important;
+				font-weight: 600 !important;
+			}
+		}
+
+		// Structure sub-tabpanels
+		.edac-structure-panel {
+			flex: 1 !important;
+			overflow-y: auto !important;
+			padding: 6px 0 !important;
+
+			&[hidden] {
+				display: none !important;
+			}
+		}
+
+		// Structure tree list
+		.edac-structure-list {
+			display: block !important;
+			list-style: none !important;
+			margin: 0 !important;
+			padding: 0 !important;
+
+			li {
+				display: block !important;
+				list-style: none !important;
+				padding: 0 !important;
+				margin: 0 !important;
+			}
+
+			// Nested landmark lists indent via padding on the child ul.
+			ul {
+				display: block !important;
+				list-style: none !important;
+				margin: 0 !important;
+				padding: 0 0 0 16px !important;
+			}
+		}
+
+		.edac-structure-item {
+			display: block !important;
+
+			&--error .edac-structure-item-btn {
+				border-left: 3px solid variables.$color-red !important;
+
+				.edac-structure-item-level {
+					background-color: variables.$color-red !important;
+					color: variables.$color-white !important;
+				}
+			}
+		}
+
+		.edac-structure-item-btn {
+			all: unset !important;
+			display: flex !important;
+			align-items: baseline !important;
+			gap: 8px !important;
+			padding: 4px 12px 4px calc(12px + var(--depth, 0) * 16px) !important;
+			width: 100% !important;
+			box-sizing: border-box !important;
+			cursor: pointer !important;
+			font-size: 13px !important;
+			line-height: 1.4 !important;
+			color: #1e1e1e !important;
+
+			&:hover {
+				background-color: color-mix(in srgb, variables.$color-blue 8%, transparent) !important;
+			}
+
+			&:focus-visible {
+				outline: 2px solid variables.$color-blue !important;
+				outline-offset: -2px !important;
+			}
+		}
+
+		.edac-structure-item-level {
+			display: inline-block !important;
+			font-size: 10px !important;
+			font-weight: 700 !important;
+			font-family: monospace !important;
+			letter-spacing: 0 !important;
+			padding: 2px 5px !important;
+			border-radius: 3px !important;
+			background-color: variables.$color-gray-light !important;
+			color: #1e1e1e !important;
+			white-space: nowrap !important;
+			flex-shrink: 0 !important;
+
+			&--landmark {
+				background-color: #e8f0f8 !important;
+				color: variables.$color-blue-dark !important;
+			}
+		}
+
+		.edac-structure-item-text {
+			color: #1e1e1e !important;
+			word-break: break-word !important;
+			flex: 1 !important;
+			text-align: left !important;
+		}
+
+		.edac-structure-item-error-icon {
+			display: inline-block !important;
+			width: 14px !important;
+			height: 14px !important;
+			flex-shrink: 0 !important;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M2.247 13.438C1.526 14.688 2.428 16.25 3.871 16.25H16.13c1.441 0 2.344-1.562 1.622-2.812L11.625 2.815C10.902 1.565 9.097 1.565 8.376 2.815L2.247 13.438ZM10 7.5v3.125M10 13.125h.006' stroke='%23970C0C' stroke-width='1.25' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") !important;
+			background-repeat: no-repeat !important;
+			background-position: center !important;
+			background-size: contain !important;
+		}
+
+		.edac-structure-empty {
+			padding: 16px 15px !important;
+			color: variables.$color-gray !important;
+			font-size: 13px !important;
+			font-style: italic !important;
 		}
 	}
 

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -940,6 +940,15 @@ body {
 				outline: 2px solid variables.$color-blue !important;
 				outline-offset: -2px !important;
 			}
+
+			&--active {
+				background-color: rgba(50, 115, 170, 0.12) !important;
+
+				.edac-structure-item-level {
+					background-color: variables.$color-blue-dark !important;
+					color: variables.$color-white !important;
+				}
+			}
 		}
 
 		.edac-structure-item-level {

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -875,9 +875,10 @@ body {
 			}
 		}
 
-		// Headings and Landmarks tabpanels — scrollable content areas.
+		// Structure tabpanels — scrollable content areas.
 		#edac-panel-headings,
-		#edac-panel-landmarks {
+		#edac-panel-landmarks,
+		#edac-panel-taborder {
 			display: block !important;
 			overflow-y: auto !important;
 			padding: 6px 0 !important;
@@ -967,6 +968,28 @@ body {
 			&--landmark {
 				background-color: #e8f0f8 !important;
 				color: variables.$color-blue-dark !important;
+			}
+
+			&--tabstop {
+				background-color: #ede8f8 !important;
+				color: #3d1f8a !important;
+			}
+		}
+
+		.edac-structure-item-taborder-type {
+			font-size: 11px !important;
+			font-weight: 600 !important;
+			color: variables.$color-gray !important;
+			white-space: nowrap !important;
+			flex-shrink: 0 !important;
+		}
+
+		.edac-structure-item--warning .edac-structure-item-btn {
+			border-left: 3px solid variables.$color-orange !important;
+
+			.edac-structure-item-level--tabstop {
+				background-color: variables.$color-orange !important;
+				color: variables.$color-white !important;
 			}
 		}
 

--- a/src/frontendHighlighterApp/structureMap.js
+++ b/src/frontendHighlighterApp/structureMap.js
@@ -82,9 +82,9 @@ function makeItemButton( levelText, labelText, isLandmark, hasError ) {
 	return btn;
 }
 
-function renderHeadingsPanel( panel, issues, onHeadingClick ) {
+export function renderHeadingsPanel( panel, issues, onHeadingClick ) {
 	const headingEls = Array.from( document.querySelectorAll( 'h1, h2, h3, h4, h5, h6' ) ).filter(
-		( el ) => ! el.closest( '#edac-highlight-panel' )
+		( el ) => ! el.closest( '#edac-highlight-panel' ) && ! el.closest( '#edac-fixes-modal' )
 	);
 
 	if ( headingEls.length === 0 ) {
@@ -188,7 +188,7 @@ function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick ) {
 	}
 }
 
-function renderLandmarksPanel( panel, onLandmarkClick ) {
+export function renderLandmarksPanel( panel, onLandmarkClick ) {
 	const landmarkEls = Array.from( document.querySelectorAll( LANDMARK_SELECTOR ) ).filter(
 		( el ) => ! el.closest( '#edac-highlight-panel' )
 	);
@@ -207,86 +207,4 @@ function renderLandmarksPanel( panel, onLandmarkClick ) {
 	list.setAttribute( 'role', 'list' );
 	appendLandmarkNodes( nodes, list, onLandmarkClick );
 	panel.append( list );
-}
-
-export function renderStructureMap( container, issues, onLandmarkClick, onHeadingClick ) {
-	container.innerHTML = '';
-
-	const tablist = document.createElement( 'div' );
-	tablist.setAttribute( 'role', 'tablist' );
-	tablist.setAttribute( 'aria-label', __( 'Structure type', 'accessibility-checker' ) );
-	tablist.className = 'edac-structure-tabs';
-
-	const headingsTab = document.createElement( 'button' );
-	headingsTab.id = 'edac-tab-headings';
-	headingsTab.setAttribute( 'role', 'tab' );
-	headingsTab.setAttribute( 'aria-selected', 'true' );
-	headingsTab.setAttribute( 'aria-controls', 'edac-structure-headings' );
-	headingsTab.className = 'edac-structure-tab';
-	headingsTab.tabIndex = 0;
-	headingsTab.textContent = __( 'Headings', 'accessibility-checker' );
-
-	const landmarksTab = document.createElement( 'button' );
-	landmarksTab.id = 'edac-tab-landmarks';
-	landmarksTab.setAttribute( 'role', 'tab' );
-	landmarksTab.setAttribute( 'aria-selected', 'false' );
-	landmarksTab.setAttribute( 'aria-controls', 'edac-structure-landmarks' );
-	landmarksTab.className = 'edac-structure-tab';
-	landmarksTab.tabIndex = -1;
-	landmarksTab.textContent = __( 'Landmarks', 'accessibility-checker' );
-
-	tablist.append( headingsTab, landmarksTab );
-
-	const headingsPanel = document.createElement( 'div' );
-	headingsPanel.id = 'edac-structure-headings';
-	headingsPanel.setAttribute( 'role', 'tabpanel' );
-	headingsPanel.setAttribute( 'aria-labelledby', 'edac-tab-headings' );
-	headingsPanel.className = 'edac-structure-panel';
-	headingsPanel.tabIndex = 0;
-
-	const landmarksPanel = document.createElement( 'div' );
-	landmarksPanel.id = 'edac-structure-landmarks';
-	landmarksPanel.setAttribute( 'role', 'tabpanel' );
-	landmarksPanel.setAttribute( 'aria-labelledby', 'edac-tab-landmarks' );
-	landmarksPanel.className = 'edac-structure-panel';
-	landmarksPanel.tabIndex = 0;
-	landmarksPanel.hidden = true;
-
-	const tabs = [ headingsTab, landmarksTab ];
-	const panels = [ headingsPanel, landmarksPanel ];
-
-	const activateSubTab = ( index ) => {
-		tabs.forEach( ( tab, i ) => {
-			const active = i === index;
-			tab.setAttribute( 'aria-selected', String( active ) );
-			tab.tabIndex = active ? 0 : -1;
-			panels[ i ].hidden = ! active;
-		} );
-	};
-
-	tabs.forEach( ( tab, index ) => {
-		tab.addEventListener( 'click', () => activateSubTab( index ) );
-		tab.addEventListener( 'keydown', ( e ) => {
-			let next = index;
-			if ( e.key === 'ArrowRight' || e.key === 'ArrowDown' ) {
-				next = ( index + 1 ) % tabs.length;
-			} else if ( e.key === 'ArrowLeft' || e.key === 'ArrowUp' ) {
-				next = ( index - 1 + tabs.length ) % tabs.length;
-			} else if ( e.key === 'Home' ) {
-				next = 0;
-			} else if ( e.key === 'End' ) {
-				next = tabs.length - 1;
-			} else {
-				return;
-			}
-			e.preventDefault();
-			activateSubTab( next );
-			tabs[ next ].focus();
-		} );
-	} );
-
-	renderHeadingsPanel( headingsPanel, issues, onHeadingClick );
-	renderLandmarksPanel( landmarksPanel, onLandmarkClick );
-
-	container.append( tablist, headingsPanel, landmarksPanel );
 }

--- a/src/frontendHighlighterApp/structureMap.js
+++ b/src/frontendHighlighterApp/structureMap.js
@@ -133,6 +133,10 @@ export function renderHeadingsPanel( panel, issues, onHeadingClick ) {
 		) );
 
 		btn.addEventListener( 'click', () => {
+			panel.querySelectorAll( '.edac-structure-item-btn--active' ).forEach(
+				( b ) => b.classList.remove( 'edac-structure-item-btn--active' )
+			);
+			btn.classList.add( 'edac-structure-item-btn--active' );
 			if ( onHeadingClick ) {
 				onHeadingClick( el );
 			} else {
@@ -148,7 +152,7 @@ export function renderHeadingsPanel( panel, issues, onHeadingClick ) {
 	panel.append( list );
 }
 
-function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick ) {
+function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick, activeElement ) {
 	for ( const node of nodeList ) {
 		const type = getLandmarkType( node.el );
 		const label = getLandmarkLabel( node.el );
@@ -166,7 +170,15 @@ function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick ) {
 			label ? `${ type }: ${ label }` : type
 		) );
 
+		if ( node.el === activeElement ) {
+			btn.classList.add( 'edac-structure-item-btn--active' );
+		}
+
 		btn.addEventListener( 'click', () => {
+			ulEl.closest( '[role="tabpanel"]' ).querySelectorAll( '.edac-structure-item-btn--active' ).forEach(
+				( b ) => b.classList.remove( 'edac-structure-item-btn--active' )
+			);
+			btn.classList.add( 'edac-structure-item-btn--active' );
 			if ( onLandmarkClick ) {
 				onLandmarkClick( node.el );
 			} else {
@@ -180,7 +192,7 @@ function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick ) {
 		if ( node.children.length ) {
 			const childUl = document.createElement( 'ul' );
 			childUl.setAttribute( 'role', 'list' );
-			appendLandmarkNodes( node.children, childUl, onLandmarkClick );
+			appendLandmarkNodes( node.children, childUl, onLandmarkClick, activeElement );
 			li.append( childUl );
 		}
 
@@ -188,7 +200,7 @@ function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick ) {
 	}
 }
 
-export function renderLandmarksPanel( panel, onLandmarkClick ) {
+export function renderLandmarksPanel( panel, onLandmarkClick, activeElement ) {
 	const landmarkEls = Array.from( document.querySelectorAll( LANDMARK_SELECTOR ) ).filter(
 		( el ) => ! el.closest( '#edac-highlight-panel' )
 	);
@@ -205,6 +217,6 @@ export function renderLandmarksPanel( panel, onLandmarkClick ) {
 	const list = document.createElement( 'ul' );
 	list.className = 'edac-structure-list';
 	list.setAttribute( 'role', 'list' );
-	appendLandmarkNodes( nodes, list, onLandmarkClick );
+	appendLandmarkNodes( nodes, list, onLandmarkClick, activeElement );
 	panel.append( list );
 }

--- a/src/frontendHighlighterApp/structureMap.js
+++ b/src/frontendHighlighterApp/structureMap.js
@@ -220,3 +220,228 @@ export function renderLandmarksPanel( panel, onLandmarkClick, activeElement ) {
 	appendLandmarkNodes( nodes, list, onLandmarkClick, activeElement );
 	panel.append( list );
 }
+
+const FOCUSABLE_SELECTOR = [
+	'a[href]',
+	'button:not([disabled])',
+	'input:not([disabled])',
+	'select:not([disabled])',
+	'textarea:not([disabled])',
+	'details > summary',
+	'audio[controls]',
+	'video[controls]',
+	'[tabindex]:not([tabindex="-1"])',
+].join( ', ' );
+
+function getElementType( el ) {
+	const role = el.getAttribute( 'role' )?.toLowerCase();
+	if ( role ) {
+		return role.charAt( 0 ).toUpperCase() + role.slice( 1 );
+	}
+	const tag = el.tagName.toLowerCase();
+	const type = el.getAttribute( 'type' )?.toLowerCase();
+	switch ( tag ) {
+		case 'a': return 'Link';
+		case 'button': return 'Button';
+		case 'select': return 'Select';
+		case 'textarea': return 'Textarea';
+		case 'summary': return 'Summary';
+		case 'audio': return 'Audio';
+		case 'video': return 'Video';
+		case 'input':
+			switch ( type ) {
+				case 'checkbox': return 'Checkbox';
+				case 'radio': return 'Radio';
+				case 'submit': return 'Submit';
+				case 'reset': return 'Reset';
+				case 'button': return 'Button';
+				case 'image': return 'Image button';
+				case 'file': return 'File';
+				case 'search': return 'Search';
+				case 'email': return 'Email';
+				case 'url': return 'URL';
+				case 'tel': return 'Phone';
+				case 'number': return 'Number';
+				case 'password': return 'Password';
+				case 'date': return 'Date';
+				case 'time': return 'Time';
+				case 'color': return 'Color';
+				case 'range': return 'Range';
+				default: return 'Input';
+			}
+		default:
+			return el.hasAttribute( 'tabindex' ) ? 'Interactive' : tag;
+	}
+}
+
+function getAccessibleName( el ) {
+	const labelledby = el.getAttribute( 'aria-labelledby' );
+	if ( labelledby ) {
+		const text = labelledby.split( /\s+/ )
+			.map( ( id ) => document.getElementById( id )?.textContent.trim() )
+			.filter( Boolean )
+			.join( ' ' );
+		if ( text ) {
+			return text;
+		}
+	}
+	const ariaLabel = el.getAttribute( 'aria-label' )?.trim();
+	if ( ariaLabel ) {
+		return ariaLabel;
+	}
+	if ( el.id ) {
+		const label = document.querySelector( `label[for="${ el.id }"]` );
+		if ( label ) {
+			return label.textContent.trim();
+		}
+	}
+	const wrappingLabel = el.closest( 'label' );
+	if ( wrappingLabel ) {
+		const clone = wrappingLabel.cloneNode( true );
+		clone.querySelectorAll( 'input, select, textarea' ).forEach( ( i ) => i.remove() );
+		const text = clone.textContent.trim();
+		if ( text ) {
+			return text;
+		}
+	}
+	const title = el.getAttribute( 'title' )?.trim();
+	if ( title ) {
+		return title;
+	}
+	const textContent = el.textContent.trim();
+	if ( textContent ) {
+		return textContent;
+	}
+	const imgAlt = el.querySelector( 'img[alt]' )?.getAttribute( 'alt' )?.trim();
+	if ( imgAlt ) {
+		return imgAlt;
+	}
+	const placeholder = el.getAttribute( 'placeholder' )?.trim();
+	if ( placeholder ) {
+		return placeholder;
+	}
+	const value = el.getAttribute( 'value' )?.trim();
+	if ( value ) {
+		return value;
+	}
+	return '';
+}
+
+function isVisible( el ) {
+	const style = getComputedStyle( el );
+	if ( style.display === 'none' || style.visibility === 'hidden' ) {
+		return false;
+	}
+	if ( el.closest( '[hidden]' ) ) {
+		return false;
+	}
+	if ( el.closest( '[aria-hidden="true"]' ) ) {
+		return false;
+	}
+	return true;
+}
+
+export function getFocusableElements() {
+	const els = Array.from( document.querySelectorAll( FOCUSABLE_SELECTOR ) ).filter(
+		( el ) =>
+			! el.closest( '#edac-highlight-panel' ) &&
+			! el.closest( '#edac-fixes-modal' ) &&
+			! el.closest( '#edac-tab-order-overlay' ) &&
+			! el.closest( '#wpadminbar' ) &&
+			! el.classList.contains( 'edac-highlight-btn' ) &&
+			isVisible( el )
+	);
+	els.sort( ( a, b ) => {
+		const tabA = parseInt( a.getAttribute( 'tabindex' ) ?? '0', 10 );
+		const tabB = parseInt( b.getAttribute( 'tabindex' ) ?? '0', 10 );
+		const posA = tabA > 0 ? tabA : Infinity;
+		const posB = tabB > 0 ? tabB : Infinity;
+		if ( posA !== posB ) {
+			return posA - posB;
+		}
+		// eslint-disable-next-line no-bitwise
+		return a.compareDocumentPosition( b ) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+	} );
+	return els;
+}
+
+export function renderTabOrderPanel( panel, onTabOrderClick ) {
+	const focusableEls = getFocusableElements();
+
+	if ( focusableEls.length === 0 ) {
+		const empty = document.createElement( 'p' );
+		empty.className = 'edac-structure-empty';
+		empty.textContent = __( 'No focusable elements found on this page.', 'accessibility-checker' );
+		panel.append( empty );
+		return;
+	}
+
+	const list = document.createElement( 'ul' );
+	list.className = 'edac-structure-list';
+	list.setAttribute( 'role', 'list' );
+
+	focusableEls.forEach( ( el, i ) => {
+		const stopNumber = i + 1;
+		const type = getElementType( el );
+		const name = getAccessibleName( el );
+		const hasPositiveTabindex = parseInt( el.getAttribute( 'tabindex' ) ?? '0', 10 ) > 0;
+
+		const li = document.createElement( 'li' );
+		li.setAttribute( 'role', 'listitem' );
+
+		const item = document.createElement( 'div' );
+		item.className = 'edac-structure-item' + ( hasPositiveTabindex ? ' edac-structure-item--warning' : '' );
+
+		const btn = document.createElement( 'button' );
+		btn.className = 'edac-structure-item-btn';
+		btn.setAttribute( 'aria-label', sprintf(
+			/* translators: %1$s is the tab stop number, %2$s is the element type and name */
+			__( 'Navigate to tab stop %1$s: %2$s', 'accessibility-checker' ),
+			stopNumber,
+			name ? `${ type } - ${ name }` : type
+		) );
+
+		const numberSpan = document.createElement( 'span' );
+		numberSpan.className = 'edac-structure-item-level edac-structure-item-level--tabstop';
+		numberSpan.textContent = `#${ stopNumber }`;
+		numberSpan.setAttribute( 'aria-hidden', 'true' );
+		btn.append( numberSpan );
+
+		const typeSpan = document.createElement( 'span' );
+		typeSpan.className = 'edac-structure-item-taborder-type';
+		typeSpan.textContent = type;
+		btn.append( typeSpan );
+
+		if ( name ) {
+			const nameSpan = document.createElement( 'span' );
+			nameSpan.className = 'edac-structure-item-text';
+			nameSpan.textContent = name;
+			btn.append( nameSpan );
+		}
+
+		if ( hasPositiveTabindex ) {
+			const warnSpan = document.createElement( 'span' );
+			warnSpan.className = 'edac-structure-item-error-icon';
+			warnSpan.setAttribute( 'aria-hidden', 'true' );
+			btn.append( warnSpan );
+		}
+
+		btn.addEventListener( 'click', () => {
+			panel.querySelectorAll( '.edac-structure-item-btn--active' ).forEach(
+				( b ) => b.classList.remove( 'edac-structure-item-btn--active' )
+			);
+			btn.classList.add( 'edac-structure-item-btn--active' );
+			if ( onTabOrderClick ) {
+				onTabOrderClick( el, stopNumber, type );
+			} else {
+				el.scrollIntoView( { block: 'center' } );
+			}
+		} );
+
+		item.append( btn );
+		li.append( item );
+		list.append( li );
+	} );
+
+	panel.append( list );
+}

--- a/src/frontendHighlighterApp/structureMap.js
+++ b/src/frontendHighlighterApp/structureMap.js
@@ -1,0 +1,292 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { getLandmarkType } from './getLandmarkType';
+
+const LANDMARK_SELECTOR = [
+	'header:not([role])',
+	'nav:not([role])',
+	'main:not([role])',
+	'aside:not([role])',
+	'footer:not([role])',
+	'section[aria-label], section[aria-labelledby]',
+	'form[aria-label], form[aria-labelledby]',
+	'[role="banner"]',
+	'[role="navigation"]',
+	'[role="main"]',
+	'[role="complementary"]',
+	'[role="contentinfo"]',
+	'[role="search"]',
+	'[role="form"]',
+	'[role="region"]',
+].join( ', ' );
+
+function getLandmarkLabel( el ) {
+	const labelledby = el.getAttribute( 'aria-labelledby' );
+	if ( labelledby ) {
+		const labelEl = document.getElementById( labelledby );
+		if ( labelEl ) {
+			return labelEl.textContent.trim();
+		}
+	}
+	const ariaLabel = el.getAttribute( 'aria-label' );
+	if ( ariaLabel ) {
+		return ariaLabel.trim();
+	}
+	return '';
+}
+
+function buildLandmarkNodes( elements ) {
+	const sorted = [ ...elements ].sort( ( a, b ) => {
+		// eslint-disable-next-line no-bitwise
+		return a.compareDocumentPosition( b ) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+	} );
+
+	const root = { el: null, children: [] };
+	const stack = [ root ];
+
+	for ( const el of sorted ) {
+		const node = { el, children: [] };
+		while ( stack.length > 1 && ! stack[ stack.length - 1 ].el.contains( el ) ) {
+			stack.pop();
+		}
+		stack[ stack.length - 1 ].children.push( node );
+		stack.push( node );
+	}
+
+	return root.children;
+}
+
+function makeItemButton( levelText, labelText, isLandmark, hasError ) {
+	const btn = document.createElement( 'button' );
+	btn.className = 'edac-structure-item-btn';
+
+	const levelSpan = document.createElement( 'span' );
+	levelSpan.className = 'edac-structure-item-level' + ( isLandmark ? ' edac-structure-item-level--landmark' : '' );
+	levelSpan.textContent = levelText;
+	levelSpan.setAttribute( 'aria-hidden', 'true' );
+	btn.append( levelSpan );
+
+	if ( labelText ) {
+		const textSpan = document.createElement( 'span' );
+		textSpan.className = 'edac-structure-item-text';
+		textSpan.textContent = labelText;
+		btn.append( textSpan );
+	}
+
+	if ( hasError ) {
+		const errorSpan = document.createElement( 'span' );
+		errorSpan.className = 'edac-structure-item-error-icon';
+		errorSpan.setAttribute( 'aria-hidden', 'true' );
+		btn.append( errorSpan );
+	}
+
+	return btn;
+}
+
+function renderHeadingsPanel( panel, issues, onHeadingClick ) {
+	const headingEls = Array.from( document.querySelectorAll( 'h1, h2, h3, h4, h5, h6' ) ).filter(
+		( el ) => ! el.closest( '#edac-highlight-panel' )
+	);
+
+	if ( headingEls.length === 0 ) {
+		const empty = document.createElement( 'p' );
+		empty.className = 'edac-structure-empty';
+		empty.textContent = __( 'No headings found on this page.', 'accessibility-checker' );
+		panel.append( empty );
+		return;
+	}
+
+	const list = document.createElement( 'ul' );
+	list.className = 'edac-structure-list';
+	list.setAttribute( 'role', 'list' );
+
+	let prevLevel = 0;
+
+	for ( const el of headingEls ) {
+		const level = parseInt( el.tagName[ 1 ] );
+		const hasDbIssue = issues?.some( ( i ) => i.element === el ) ?? false;
+		const isSkip = prevLevel > 0 && level > prevLevel + 1;
+		prevLevel = level;
+
+		const hasError = hasDbIssue || isSkip;
+		const text = el.textContent.trim();
+		const levelTag = `H${ level }`;
+
+		let srSuffix = '';
+		if ( isSkip ) {
+			srSuffix = ', ' + __( 'heading level skipped', 'accessibility-checker' );
+		} else if ( hasDbIssue ) {
+			srSuffix = ', ' + __( 'has accessibility issue', 'accessibility-checker' );
+		}
+
+		const li = document.createElement( 'li' );
+		li.setAttribute( 'role', 'listitem' );
+
+		const item = document.createElement( 'div' );
+		item.className = 'edac-structure-item' + ( hasError ? ' edac-structure-item--error' : '' );
+		item.style.setProperty( '--depth', level - 1 );
+
+		const btn = makeItemButton( levelTag, text, false, hasError );
+		btn.setAttribute( 'aria-label', sprintf(
+			/* translators: %s is the heading level and text, e.g. "H2: Section Title, heading level skipped" */
+			__( 'Navigate to %s', 'accessibility-checker' ),
+			`${ levelTag }: ${ text }${ srSuffix }`
+		) );
+
+		btn.addEventListener( 'click', () => {
+			if ( onHeadingClick ) {
+				onHeadingClick( el );
+			} else {
+				el.scrollIntoView( { block: 'center' } );
+			}
+		} );
+
+		item.append( btn );
+		li.append( item );
+		list.append( li );
+	}
+
+	panel.append( list );
+}
+
+function appendLandmarkNodes( nodeList, ulEl, onLandmarkClick ) {
+	for ( const node of nodeList ) {
+		const type = getLandmarkType( node.el );
+		const label = getLandmarkLabel( node.el );
+
+		const li = document.createElement( 'li' );
+		li.setAttribute( 'role', 'listitem' );
+
+		const item = document.createElement( 'div' );
+		item.className = 'edac-structure-item';
+
+		const btn = makeItemButton( type, label, true, false );
+		btn.setAttribute( 'aria-label', sprintf(
+			/* translators: %s is the landmark type and label, e.g. "Navigation: Main menu" */
+			__( 'Navigate to %s', 'accessibility-checker' ),
+			label ? `${ type }: ${ label }` : type
+		) );
+
+		btn.addEventListener( 'click', () => {
+			if ( onLandmarkClick ) {
+				onLandmarkClick( node.el );
+			} else {
+				node.el.scrollIntoView( { block: 'center' } );
+			}
+		} );
+
+		item.append( btn );
+		li.append( item );
+
+		if ( node.children.length ) {
+			const childUl = document.createElement( 'ul' );
+			childUl.setAttribute( 'role', 'list' );
+			appendLandmarkNodes( node.children, childUl, onLandmarkClick );
+			li.append( childUl );
+		}
+
+		ulEl.append( li );
+	}
+}
+
+function renderLandmarksPanel( panel, onLandmarkClick ) {
+	const landmarkEls = Array.from( document.querySelectorAll( LANDMARK_SELECTOR ) ).filter(
+		( el ) => ! el.closest( '#edac-highlight-panel' )
+	);
+
+	if ( landmarkEls.length === 0 ) {
+		const empty = document.createElement( 'p' );
+		empty.className = 'edac-structure-empty';
+		empty.textContent = __( 'No landmarks found on this page.', 'accessibility-checker' );
+		panel.append( empty );
+		return;
+	}
+
+	const nodes = buildLandmarkNodes( landmarkEls );
+	const list = document.createElement( 'ul' );
+	list.className = 'edac-structure-list';
+	list.setAttribute( 'role', 'list' );
+	appendLandmarkNodes( nodes, list, onLandmarkClick );
+	panel.append( list );
+}
+
+export function renderStructureMap( container, issues, onLandmarkClick, onHeadingClick ) {
+	container.innerHTML = '';
+
+	const tablist = document.createElement( 'div' );
+	tablist.setAttribute( 'role', 'tablist' );
+	tablist.setAttribute( 'aria-label', __( 'Structure type', 'accessibility-checker' ) );
+	tablist.className = 'edac-structure-tabs';
+
+	const headingsTab = document.createElement( 'button' );
+	headingsTab.id = 'edac-tab-headings';
+	headingsTab.setAttribute( 'role', 'tab' );
+	headingsTab.setAttribute( 'aria-selected', 'true' );
+	headingsTab.setAttribute( 'aria-controls', 'edac-structure-headings' );
+	headingsTab.className = 'edac-structure-tab';
+	headingsTab.tabIndex = 0;
+	headingsTab.textContent = __( 'Headings', 'accessibility-checker' );
+
+	const landmarksTab = document.createElement( 'button' );
+	landmarksTab.id = 'edac-tab-landmarks';
+	landmarksTab.setAttribute( 'role', 'tab' );
+	landmarksTab.setAttribute( 'aria-selected', 'false' );
+	landmarksTab.setAttribute( 'aria-controls', 'edac-structure-landmarks' );
+	landmarksTab.className = 'edac-structure-tab';
+	landmarksTab.tabIndex = -1;
+	landmarksTab.textContent = __( 'Landmarks', 'accessibility-checker' );
+
+	tablist.append( headingsTab, landmarksTab );
+
+	const headingsPanel = document.createElement( 'div' );
+	headingsPanel.id = 'edac-structure-headings';
+	headingsPanel.setAttribute( 'role', 'tabpanel' );
+	headingsPanel.setAttribute( 'aria-labelledby', 'edac-tab-headings' );
+	headingsPanel.className = 'edac-structure-panel';
+	headingsPanel.tabIndex = 0;
+
+	const landmarksPanel = document.createElement( 'div' );
+	landmarksPanel.id = 'edac-structure-landmarks';
+	landmarksPanel.setAttribute( 'role', 'tabpanel' );
+	landmarksPanel.setAttribute( 'aria-labelledby', 'edac-tab-landmarks' );
+	landmarksPanel.className = 'edac-structure-panel';
+	landmarksPanel.tabIndex = 0;
+	landmarksPanel.hidden = true;
+
+	const tabs = [ headingsTab, landmarksTab ];
+	const panels = [ headingsPanel, landmarksPanel ];
+
+	const activateSubTab = ( index ) => {
+		tabs.forEach( ( tab, i ) => {
+			const active = i === index;
+			tab.setAttribute( 'aria-selected', String( active ) );
+			tab.tabIndex = active ? 0 : -1;
+			panels[ i ].hidden = ! active;
+		} );
+	};
+
+	tabs.forEach( ( tab, index ) => {
+		tab.addEventListener( 'click', () => activateSubTab( index ) );
+		tab.addEventListener( 'keydown', ( e ) => {
+			let next = index;
+			if ( e.key === 'ArrowRight' || e.key === 'ArrowDown' ) {
+				next = ( index + 1 ) % tabs.length;
+			} else if ( e.key === 'ArrowLeft' || e.key === 'ArrowUp' ) {
+				next = ( index - 1 + tabs.length ) % tabs.length;
+			} else if ( e.key === 'Home' ) {
+				next = 0;
+			} else if ( e.key === 'End' ) {
+				next = tabs.length - 1;
+			} else {
+				return;
+			}
+			e.preventDefault();
+			activateSubTab( next );
+			tabs[ next ].focus();
+		} );
+	} );
+
+	renderHeadingsPanel( headingsPanel, issues, onHeadingClick );
+	renderLandmarksPanel( landmarksPanel, onLandmarkClick );
+
+	container.append( tablist, headingsPanel, landmarksPanel );
+}


### PR DESCRIPTION
Adds a new Structure view tab alongside Issues in the frontend highlighter panel, providing a HeadingsMap-style overview of the page's heading hierarchy and landmark regions.

- Headings tab: flat list with H1–H6 level badges, indentation via CSS custom property, live level-skip detection, and cross-reference against DB issues
- Landmarks tab: nested tree reflecting DOM containment, built with compareDocumentPosition
- Full ARIA tablist/tab/tabpanel pattern with roving tabindex and keyboard navigation (ArrowLeft/Right/Home/End) for both the view tabs and structure sub-tabs
- Clicking a heading or landmark applies the existing visual highlight (outline + dark-blue label badge + smooth scroll) and clears any previously highlighted element
- Fixed all: unset display regression on ul/li by adding display: block !important to structure list rules

<!-- Always provide a short description -->

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Structure view with tabs for Headings, Landmarks, and a new Tab Order panel.
  * Tab Order overlay shows numbered focus order and connecting lines; supports click and keyboard navigation.

* **Usability**
  * Improved keyboard/tab roles and focus handling for tabbed navigation between views.
  * Panel auto-navigation now only triggers when Issues tab is active.

* **Style**
  * New Structure view styles, hidden/footer behavior, and responsive handling for overlay sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->