### PR TITLE
Add a SystemInfo class for getting theme, plugin and env type

### DIFF
--- a/includes/classes/Admin/SystemInfo.php
+++ b/includes/classes/Admin/SystemInfo.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * System information helpers.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Admin;
+
+use WP_Theme;
+
+/**
+ * Collects active plugin and theme information.
+ */
+class SystemInfo {
+
+	/**
+	 * Returns active plugins with name, slug, and version.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	public static function get_active_plugins() {
+		$active_plugins = [];
+
+		foreach ( wp_get_active_and_valid_plugins() as $plugin_path ) {
+			$plugin_data      = get_plugin_data( $plugin_path );
+			$active_plugins[] = [
+				'name'    => $plugin_data['Name'] ?? '',
+				'slug'    => self::get_plugin_slug_from_path( $plugin_path ),
+				'version' => $plugin_data['Version'] ?? '',
+			];
+		}
+
+		return $active_plugins;
+	}
+
+	/**
+	 * Gets the plugin slug from a plugin file path.
+	 *
+	 * @param string $plugin_path Path to a plugin file.
+	 * @return string
+	 */
+	public static function get_plugin_slug_from_path( $plugin_path ) {
+		if ( ! is_string( $plugin_path ) || '' === $plugin_path ) {
+			return '';
+		}
+
+		$relative = plugin_basename( $plugin_path );
+		$dir      = dirname( $relative );
+
+		if ( '.' !== $dir ) {
+			return $dir;
+		}
+
+		return basename( $relative, '.php' );
+	}
+
+	/**
+	 * Returns active theme information, including parent data for child themes.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_active_theme() {
+		$theme_data = wp_get_theme();
+
+		$active_theme = self::get_theme_data_collection( $theme_data );
+
+		$active_theme['accessibility_ready'] = self::is_theme_accessibility_ready( $theme_data );
+
+		$active_theme['parent_theme'] = [];
+		if ( $theme_data->parent() ) {
+			$active_theme['parent_theme'] = self::get_theme_data_collection( $theme_data->parent() );
+		}
+
+		return $active_theme;
+	}
+
+	/**
+	 * Gets theme details as a normalized collection.
+	 *
+	 * @param mixed $theme Theme object.
+	 * @return array<string, mixed>
+	 */
+	public static function get_theme_data_collection( $theme ) {
+		if ( ! is_a( $theme, '\\WP_Theme' ) ) {
+			return [];
+		}
+
+		return [
+			'name'    => $theme->get( 'Name' ) ?? '',
+			'slug'    => $theme->get_stylesheet() ?? '',
+			'version' => $theme->get( 'Version' ) ?? '',
+			'tags'    => $theme->get( 'Tags' ) ?? [],
+		];
+	}
+
+	/**
+	 * Checks whether theme or parent theme is tagged accessibility-ready.
+	 *
+	 * @param WP_Theme $theme_data Theme object to check.
+	 * @return bool
+	 */
+	public static function is_theme_accessibility_ready( WP_Theme $theme_data ) {
+		$tags = is_array( $theme_data->get( 'Tags' ) ) ? $theme_data->get( 'Tags' ) : [];
+
+		if ( $theme_data->parent() ) {
+			$parent_tags = $theme_data->parent()->get( 'Tags' );
+			$tags        = array_merge( $tags, is_array( $parent_tags ) ? $parent_tags : [] );
+		}
+
+		return in_array( 'accessibility-ready', $tags, true );
+	}
+
+	/**
+	 * Gets the current WordPress environment type.
+	 *
+	 * @return string
+	 */
+	public static function get_environment_type() {
+		return function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production';
+	}
+
+	/**
+	 * Gets the current WordPress version.
+	 *
+	 * @return string
+	 */
+	public static function get_wordpress_version() {
+		return (string) get_bloginfo( 'version' );
+	}
+
+	/**
+	 * Gets the current PHP version.
+	 *
+	 * @return string
+	 */
+	public static function get_php_version() {
+		return (string) phpversion();
+	}
+
+	/**
+	 * Gets a payload-ready set of system fields for license API requests.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_license_request_context() {
+		return [
+			'environment'    => self::get_environment_type(),
+			'wp_version'     => self::get_wordpress_version(),
+			'php_version'    => self::get_php_version(),
+			'active_plugins' => wp_json_encode( self::get_active_plugins() ),
+			'active_theme'   => wp_json_encode( self::get_active_theme() ),
+		];
+	}
+}

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -11,7 +11,7 @@
 namespace EqualizeDigital\AccessibilityChecker\MyDot;
 
 use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\ConnectedServicesPage;
-use EqualizeDigital\AccessibilityChecker\Admin\SystemInfo;
+use EqualizeDigital\AccessibilityChecker\SystemInfo\SystemInfo;
 
 /**
  * Class Connector

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -11,6 +11,7 @@
 namespace EqualizeDigital\AccessibilityChecker\MyDot;
 
 use EqualizeDigital\AccessibilityChecker\Admin\AdminPage\ConnectedServicesPage;
+use EqualizeDigital\AccessibilityChecker\Admin\SystemInfo;
 
 /**
  * Class Connector
@@ -246,14 +247,13 @@ class Connector {
 		}
 
 		$api_params = [
-			'edd_action'  => 'activate_license',
-			'license'     => $license,
-			'item_id'     => self::PRODUCT_ID,
-			'url'         => home_url(),
-			'environment' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
-			'wp_version'  => get_bloginfo( 'version' ),
-			'php_version' => phpversion(),
+			'edd_action' => 'activate_license',
+			'license'    => $license,
+			'item_id'    => self::PRODUCT_ID,
+			'url'        => home_url(),
 		];
+
+		$api_params = array_merge( $api_params, SystemInfo::get_license_request_context() );
 
 		$response = wp_remote_post(
 			self::get_api_endpoint(),
@@ -421,11 +421,10 @@ class Connector {
 			'item_id'      => self::PRODUCT_ID,
 			'item_name'    => rawurlencode( self::PRODUCT_NAME ),
 			'url'          => home_url(),
-			'environment'  => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
 			'edac_version' => defined( 'EDAC_VERSION' ) ? EDAC_VERSION : '0.0.0',
-			'wp_version'   => get_bloginfo( 'version' ),
-			'php_version'  => phpversion(),
 		];
+
+		$api_params = array_merge( $api_params, SystemInfo::get_license_request_context() );
 
 		// Call the custom API.
 		$response = wp_remote_post(

--- a/includes/classes/SystemInfo/SystemInfo.php
+++ b/includes/classes/SystemInfo/SystemInfo.php
@@ -23,7 +23,7 @@ class SystemInfo {
 		$active_plugins = [];
 
 		foreach ( wp_get_active_and_valid_plugins() as $plugin_path ) {
-			$plugin_data      = get_plugin_data( $plugin_path );
+			$plugin_data      = get_plugin_data( $plugin_path, false, false );
 			$active_plugins[] = [
 				'name'    => $plugin_data['Name'] ?? '',
 				'slug'    => self::get_plugin_slug_from_path( $plugin_path ),
@@ -151,8 +151,8 @@ class SystemInfo {
 			'environment'    => self::get_environment_type(),
 			'wp_version'     => self::get_wordpress_version(),
 			'php_version'    => self::get_php_version(),
-			'active_plugins' => false !== $active_plugins ? $active_plugins : [],
-			'active_theme'   => false !== $active_theme ? $active_theme : [],
+			'active_plugins' => false !== $active_plugins ? $active_plugins : '[]',
+			'active_theme'   => false !== $active_theme ? $active_theme : '{}',
 		];
 	}
 }

--- a/includes/classes/SystemInfo/SystemInfo.php
+++ b/includes/classes/SystemInfo/SystemInfo.php
@@ -5,7 +5,7 @@
  * @package Accessibility_Checker
  */
 
-namespace EqualizeDigital\AccessibilityChecker\Admin;
+namespace EqualizeDigital\AccessibilityChecker\SystemInfo;
 
 use WP_Theme;
 

--- a/includes/classes/SystemInfo/SystemInfo.php
+++ b/includes/classes/SystemInfo/SystemInfo.php
@@ -144,12 +144,15 @@ class SystemInfo {
 	 * @return array<string, mixed>
 	 */
 	public static function get_license_request_context() {
+		$active_plugins = wp_json_encode( self::get_active_plugins() );
+		$active_theme   = wp_json_encode( self::get_active_theme() );
+
 		return [
 			'environment'    => self::get_environment_type(),
 			'wp_version'     => self::get_wordpress_version(),
 			'php_version'    => self::get_php_version(),
-			'active_plugins' => wp_json_encode( self::get_active_plugins() ),
-			'active_theme'   => wp_json_encode( self::get_active_theme() ),
+			'active_plugins' => false !== $active_plugins ? $active_plugins : [],
+			'active_theme'   => false !== $active_theme ? $active_theme : [],
 		];
 	}
 }

--- a/tests/phpunit/Admin/SystemInfoTest.php
+++ b/tests/phpunit/Admin/SystemInfoTest.php
@@ -1,0 +1,461 @@
+<?php
+/**
+ * Test cases for the SystemInfo class.
+ *
+ * @package accessibility-checker
+ */
+
+use EqualizeDigital\AccessibilityChecker\Admin\SystemInfo;
+
+/**
+ * Tests for SystemInfo static helper methods.
+ */
+class SystemInfoTest extends WP_UnitTestCase {
+
+	/**
+	 * A plugin living in its own directory should return the directory name.
+	 *
+	 * @return void
+	 */
+	public function testGetPluginSlugFromPathReturnsDirectoryNameForStandardPlugin() {
+		$path   = WP_PLUGIN_DIR . '/my-plugin/my-plugin.php';
+		$result = SystemInfo::get_plugin_slug_from_path( $path );
+
+		$this->assertSame( 'my-plugin', $result );
+	}
+
+	/**
+	 * A single-file plugin (directly in the plugins root) returns the filename without extension.
+	 *
+	 * @return void
+	 */
+	public function testGetPluginSlugFromPathReturnsBareFilenameForSingleFilePlugin() {
+		$path   = WP_PLUGIN_DIR . '/hello.php';
+		$result = SystemInfo::get_plugin_slug_from_path( $path );
+
+		$this->assertSame( 'hello', $result );
+	}
+
+	/**
+	 * An empty string returns an empty string without error.
+	 *
+	 * @return void
+	 */
+	public function testGetPluginSlugFromPathReturnsEmptyStringForEmptyInput() {
+		$result = SystemInfo::get_plugin_slug_from_path( '' );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * A non-string value returns an empty string without error.
+	 *
+	 * @return void
+	 */
+	public function testGetPluginSlugFromPathReturnsEmptyStringForNonStringInput() {
+		// @phpstan-ignore-next-line
+		$result = SystemInfo::get_plugin_slug_from_path( null );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * The return value is always an array.
+	 *
+	 * @return void
+	 */
+	public function testGetActivePluginsReturnsArray() {
+		$result = SystemInfo::get_active_plugins();
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Every entry must contain name, slug, and version keys.
+	 *
+	 * @return void
+	 */
+	public function testGetActivePluginsEntriesHaveRequiredKeys() {
+		$result = SystemInfo::get_active_plugins();
+
+		foreach ( $result as $plugin ) {
+			$this->assertArrayHasKey( 'name', $plugin );
+			$this->assertArrayHasKey( 'slug', $plugin );
+			$this->assertArrayHasKey( 'version', $plugin );
+		}
+	}
+
+	/**
+	 * Every entry must have string values for name, slug, and version.
+	 *
+	 * @return void
+	 */
+	public function testGetActivePluginsEntriesAreAllStrings() {
+		$result = SystemInfo::get_active_plugins();
+
+		foreach ( $result as $plugin ) {
+			$this->assertIsString( $plugin['name'] );
+			$this->assertIsString( $plugin['slug'] );
+			$this->assertIsString( $plugin['version'] );
+		}
+	}
+
+	/**
+	 * A non-WP_Theme value returns an empty array.
+	 *
+	 * @return void
+	 */
+	public function testGetThemeDataCollectionReturnsEmptyArrayForNonThemeObject() {
+		// @phpstan-ignore-next-line
+		$this->assertSame( [], SystemInfo::get_theme_data_collection( null ) );
+		// @phpstan-ignore-next-line
+		$this->assertSame( [], SystemInfo::get_theme_data_collection( 'twentytwentyfour' ) );
+		// @phpstan-ignore-next-line
+		$this->assertSame( [], SystemInfo::get_theme_data_collection( [] ) );
+	}
+
+	/**
+	 * A valid WP_Theme object produces the four expected keys.
+	 *
+	 * @return void
+	 */
+	public function testGetThemeDataCollectionReturnsStructuredArrayForValidTheme() {
+		$theme  = wp_get_theme();
+		$result = SystemInfo::get_theme_data_collection( $theme );
+
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'slug', $result );
+		$this->assertArrayHasKey( 'version', $result );
+		$this->assertArrayHasKey( 'tags', $result );
+	}
+
+	/**
+	 * The slug value matches the theme's stylesheet directory name.
+	 *
+	 * @return void
+	 */
+	public function testGetThemeDataCollectionSlugMatchesStylesheet() {
+		$theme  = wp_get_theme();
+		$result = SystemInfo::get_theme_data_collection( $theme );
+
+		$this->assertSame( $theme->get_stylesheet(), $result['slug'] );
+	}
+
+	/**
+	 * The name value matches the theme's Name header.
+	 *
+	 * @return void
+	 */
+	public function testGetThemeDataCollectionNameMatchesThemeName() {
+		$theme  = wp_get_theme();
+		$result = SystemInfo::get_theme_data_collection( $theme );
+
+		$this->assertSame( $theme->get( 'Name' ), $result['name'] );
+	}
+
+	/**
+	 * A theme with the accessibility-ready tag returns true.
+	 *
+	 * @return void
+	 */
+	public function testIsThemeAccessibilityReadyReturnsTrueWhenTagPresent() {
+		$theme = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$theme->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [ 'accessibility-ready', 'blog' ] ],
+			]
+		);
+		$theme->method( 'parent' )->willReturn( false );
+
+		$this->assertTrue( SystemInfo::is_theme_accessibility_ready( $theme ) );
+	}
+
+	/**
+	 * A theme without the accessibility-ready tag returns false.
+	 *
+	 * @return void
+	 */
+	public function testIsThemeAccessibilityReadyReturnsFalseWhenTagMissing() {
+		$theme = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$theme->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [ 'blog', 'e-commerce' ] ],
+			]
+		);
+		$theme->method( 'parent' )->willReturn( false );
+
+		$this->assertFalse( SystemInfo::is_theme_accessibility_ready( $theme ) );
+	}
+
+	/**
+	 * A child theme without the tag but whose parent has it returns true.
+	 *
+	 * @return void
+	 */
+	public function testIsThemeAccessibilityReadyReturnsTrueWhenParentThemeHasTag() {
+		$parent = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$parent->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [ 'accessibility-ready' ] ],
+			]
+		);
+
+		$theme = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$theme->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [ 'blog' ] ],
+			]
+		);
+		$theme->method( 'parent' )->willReturn( $parent );
+
+		$this->assertTrue( SystemInfo::is_theme_accessibility_ready( $theme ) );
+	}
+
+	/**
+	 * Both child and parent missing the tag returns false.
+	 *
+	 * @return void
+	 */
+	public function testIsThemeAccessibilityReadyReturnsFalseWhenNeitherChildNorParentHasTag() {
+		$parent = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$parent->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [ 'blog' ] ],
+			]
+		);
+
+		$theme = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$theme->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [ 'blog' ] ],
+			]
+		);
+		$theme->method( 'parent' )->willReturn( $parent );
+
+		$this->assertFalse( SystemInfo::is_theme_accessibility_ready( $theme ) );
+	}
+
+	/**
+	 * An empty tag list returns false without errors.
+	 *
+	 * @return void
+	 */
+	public function testIsThemeAccessibilityReadyReturnsFalseForEmptyTags() {
+		$theme = $this->getMockBuilder( WP_Theme::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$theme->method( 'get' )->willReturnMap(
+			[
+				[ 'Tags', [] ],
+			]
+		);
+		$theme->method( 'parent' )->willReturn( false );
+
+		$this->assertFalse( SystemInfo::is_theme_accessibility_ready( $theme ) );
+	}
+
+	/**
+	 * The active theme array contains all required top-level keys.
+	 *
+	 * @return void
+	 */
+	public function testGetActiveThemeReturnsExpectedKeys() {
+		$result = SystemInfo::get_active_theme();
+
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'slug', $result );
+		$this->assertArrayHasKey( 'version', $result );
+		$this->assertArrayHasKey( 'tags', $result );
+		$this->assertArrayHasKey( 'accessibility_ready', $result );
+		$this->assertArrayHasKey( 'parent_theme', $result );
+	}
+
+	/**
+	 * The accessibility_ready key is a boolean.
+	 *
+	 * @return void
+	 */
+	public function testGetActiveThemeAccessibilityReadyIsBool() {
+		$result = SystemInfo::get_active_theme();
+
+		$this->assertIsBool( $result['accessibility_ready'] );
+	}
+
+	/**
+	 * The parent_theme key is an array (empty for non-child themes).
+	 *
+	 * @return void
+	 */
+	public function testGetActiveThemeParentThemeIsArray() {
+		$result = SystemInfo::get_active_theme();
+
+		$this->assertIsArray( $result['parent_theme'] );
+	}
+
+	/**
+	 * Returns a non-empty string.
+	 *
+	 * @return void
+	 */
+	public function testGetEnvironmentTypeReturnsNonEmptyString() {
+		$result = SystemInfo::get_environment_type();
+
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Return value is one of WordPress's recognised environment types.
+	 *
+	 * @return void
+	 */
+	public function testGetEnvironmentTypeReturnsRecognisedValue() {
+		$allowed = [ 'local', 'development', 'staging', 'production' ];
+
+		$this->assertContains( SystemInfo::get_environment_type(), $allowed );
+	}
+
+	/**
+	 * Returns a non-empty string.
+	 *
+	 * @return void
+	 */
+	public function testGetWordpressVersionReturnsNonEmptyString() {
+		$result = SystemInfo::get_wordpress_version();
+
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Matches the value returned by get_bloginfo( 'version' ).
+	 *
+	 * @return void
+	 */
+	public function testGetWordpressVersionMatchesBloginfo() {
+		$this->assertSame( get_bloginfo( 'version' ), SystemInfo::get_wordpress_version() );
+	}
+
+	/**
+	 * Returns a non-empty string.
+	 *
+	 * @return void
+	 */
+	public function testGetPhpVersionReturnsNonEmptyString() {
+		$result = SystemInfo::get_php_version();
+
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Matches phpversion().
+	 *
+	 * @return void
+	 */
+	public function testGetPhpVersionMatchesPhpversion() {
+		$this->assertSame( phpversion(), SystemInfo::get_php_version() );
+	}
+
+	/**
+	 * Returns an array with all five expected keys.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextReturnsExpectedKeys() {
+		$result = SystemInfo::get_license_request_context();
+
+		$this->assertArrayHasKey( 'environment', $result );
+		$this->assertArrayHasKey( 'wp_version', $result );
+		$this->assertArrayHasKey( 'php_version', $result );
+		$this->assertArrayHasKey( 'active_plugins', $result );
+		$this->assertArrayHasKey( 'active_theme', $result );
+	}
+
+	/**
+	 * An active_plugins is a valid JSON string decoding to an array.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextActivePluginsIsJsonString() {
+		$result  = SystemInfo::get_license_request_context();
+		$decoded = json_decode( $result['active_plugins'], true );
+
+		$this->assertIsString( $result['active_plugins'] );
+		$this->assertNotNull( $decoded );
+		$this->assertIsArray( $decoded );
+	}
+
+	/**
+	 * An active_theme is a valid JSON string decoding to an array.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextActiveThemeIsJsonString() {
+		$result  = SystemInfo::get_license_request_context();
+		$decoded = json_decode( $result['active_theme'], true );
+
+		$this->assertIsString( $result['active_theme'] );
+		$this->assertNotNull( $decoded );
+		$this->assertIsArray( $decoded );
+	}
+
+	/**
+	 * An environment key matches get_environment_type() called directly.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextEnvironmentMatchesDirectCall() {
+		$result = SystemInfo::get_license_request_context();
+
+		$this->assertSame( SystemInfo::get_environment_type(), $result['environment'] );
+	}
+
+	/**
+	 * A wp_version key matches get_wordpress_version() called directly.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextWpVersionMatchesDirectCall() {
+		$result = SystemInfo::get_license_request_context();
+
+		$this->assertSame( SystemInfo::get_wordpress_version(), $result['wp_version'] );
+	}
+
+	/**
+	 * A php_version key matches get_php_version() called directly.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextPhpVersionMatchesDirectCall() {
+		$result = SystemInfo::get_license_request_context();
+
+		$this->assertSame( SystemInfo::get_php_version(), $result['php_version'] );
+	}
+
+	/**
+	 * The full context array contains exactly five keys and no extras.
+	 *
+	 * @return void
+	 */
+	public function testGetLicenseRequestContextHasExactlyFiveKeys() {
+		$result = SystemInfo::get_license_request_context();
+
+		$this->assertCount( 5, $result );
+	}
+}

--- a/tests/phpunit/Admin/SystemInfoTest.php
+++ b/tests/phpunit/Admin/SystemInfoTest.php
@@ -11,6 +11,46 @@ use EqualizeDigital\AccessibilityChecker\Admin\SystemInfo;
  * Tests for SystemInfo static helper methods.
  */
 class SystemInfoTest extends WP_UnitTestCase {
+	/**
+	 * Returns normalized tags for a theme.
+	 *
+	 * @param WP_Theme $theme Theme object.
+	 * @return array<int, string>
+	 */
+	private function get_theme_tags( WP_Theme $theme ) {
+		$tags = $theme->get( 'Tags' );
+		return is_array( $tags ) ? $tags : [];
+	}
+	/**
+	 * Computes expected accessibility-ready status from theme and parent tags.
+	 *
+	 * @param WP_Theme $theme Theme object.
+	 * @return bool
+	 */
+	private function compute_expected_accessibility_ready( WP_Theme $theme ) {
+		$tags = $this->get_theme_tags( $theme );
+		if ( $theme->parent() ) {
+			$tags = array_merge( $tags, $this->get_theme_tags( $theme->parent() ) );
+		}
+		return in_array( 'accessibility-ready', $tags, true );
+	}
+	/**
+	 * Finds the first installed theme matching the given predicate.
+	 *
+	 * @param callable $predicate Matcher callback.
+	 * @return WP_Theme|null
+	 */
+	private function find_installed_theme( $predicate ) {
+		foreach ( wp_get_themes() as $theme ) {
+			if ( ! $theme instanceof WP_Theme || ! $theme->exists() ) {
+				continue;
+			}
+			if ( call_user_func( $predicate, $theme ) ) {
+				return $theme;
+			}
+		}
+		return null;
+	}
 
 	/**
 	 * A plugin living in its own directory should return the directory name.
@@ -77,6 +117,12 @@ class SystemInfoTest extends WP_UnitTestCase {
 	 */
 	public function testGetActivePluginsEntriesHaveRequiredKeys() {
 		$result = SystemInfo::get_active_plugins();
+		$this->assertIsArray( $result );
+
+		if ( [] === $result ) {
+			$this->assertEmpty( $result );
+			return;
+		}
 
 		foreach ( $result as $plugin ) {
 			$this->assertArrayHasKey( 'name', $plugin );
@@ -92,6 +138,12 @@ class SystemInfoTest extends WP_UnitTestCase {
 	 */
 	public function testGetActivePluginsEntriesAreAllStrings() {
 		$result = SystemInfo::get_active_plugins();
+		$this->assertIsArray( $result );
+
+		if ( [] === $result ) {
+			$this->assertEmpty( $result );
+			return;
+		}
 
 		foreach ( $result as $plugin ) {
 			$this->assertIsString( $plugin['name'] );
@@ -154,119 +206,74 @@ class SystemInfoTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A theme with the accessibility-ready tag returns true.
+	 * That is_theme_accessibility_ready() matches expected tag evaluation on the active theme.
 	 *
 	 * @return void
 	 */
-	public function testIsThemeAccessibilityReadyReturnsTrueWhenTagPresent() {
-		$theme = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$theme->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [ 'accessibility-ready', 'blog' ] ],
-			]
+	public function testIsThemeAccessibilityReadyMatchesComputedExpectationForActiveTheme() {
+		$theme    = wp_get_theme();
+		$expected = $this->compute_expected_accessibility_ready( $theme );
+		$actual   = SystemInfo::is_theme_accessibility_ready( $theme );
+		$this->assertSame( $expected, $actual );
+	}
+	/**
+	 * A theme tagged accessibility-ready returns true.
+	 *
+	 * @return void
+	 */
+	public function testIsThemeAccessibilityReadyReturnsTrueForInstalledAccessibilityReadyTheme() {
+		$theme = $this->find_installed_theme(
+			function ( $candidate ) {
+				return in_array( 'accessibility-ready', $this->get_theme_tags( $candidate ), true );
+			}
 		);
-		$theme->method( 'parent' )->willReturn( false );
-
+		if ( ! $theme ) {
+			$this->markTestSkipped( 'No installed theme with accessibility-ready tag found.' );
+		}
 		$this->assertTrue( SystemInfo::is_theme_accessibility_ready( $theme ) );
 	}
-
 	/**
-	 * A theme without the accessibility-ready tag returns false.
+	 * A theme and parent without accessibility-ready tags return false.
 	 *
 	 * @return void
 	 */
-	public function testIsThemeAccessibilityReadyReturnsFalseWhenTagMissing() {
-		$theme = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$theme->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [ 'blog', 'e-commerce' ] ],
-			]
+	public function testIsThemeAccessibilityReadyReturnsFalseForInstalledThemeWithoutAnyReadyTag() {
+		$theme = $this->find_installed_theme(
+			function ( $candidate ) {
+				if ( in_array( 'accessibility-ready', $this->get_theme_tags( $candidate ), true ) ) {
+					return false;
+				}
+				if ( ! $candidate->parent() ) {
+					return true;
+				}
+				return ! in_array( 'accessibility-ready', $this->get_theme_tags( $candidate->parent() ), true );
+			}
 		);
-		$theme->method( 'parent' )->willReturn( false );
-
+		if ( ! $theme ) {
+			$this->markTestSkipped( 'No installed theme found where both child and parent lack accessibility-ready tag.' );
+		}
 		$this->assertFalse( SystemInfo::is_theme_accessibility_ready( $theme ) );
 	}
-
 	/**
-	 * A child theme without the tag but whose parent has it returns true.
+	 * A child theme without the tag returns true when parent has accessibility-ready tag.
 	 *
 	 * @return void
 	 */
-	public function testIsThemeAccessibilityReadyReturnsTrueWhenParentThemeHasTag() {
-		$parent = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$parent->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [ 'accessibility-ready' ] ],
-			]
+	public function testIsThemeAccessibilityReadyReturnsTrueWhenInstalledParentThemeHasTag() {
+		$theme = $this->find_installed_theme(
+			function ( $candidate ) {
+				if ( ! $candidate->parent() ) {
+					return false;
+				}
+				$child_has_tag  = in_array( 'accessibility-ready', $this->get_theme_tags( $candidate ), true );
+				$parent_has_tag = in_array( 'accessibility-ready', $this->get_theme_tags( $candidate->parent() ), true );
+				return ! $child_has_tag && $parent_has_tag;
+			}
 		);
-
-		$theme = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$theme->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [ 'blog' ] ],
-			]
-		);
-		$theme->method( 'parent' )->willReturn( $parent );
-
+		if ( ! $theme ) {
+			$this->markTestSkipped( 'No installed child theme found where only parent is accessibility-ready.' );
+		}
 		$this->assertTrue( SystemInfo::is_theme_accessibility_ready( $theme ) );
-	}
-
-	/**
-	 * Both child and parent missing the tag returns false.
-	 *
-	 * @return void
-	 */
-	public function testIsThemeAccessibilityReadyReturnsFalseWhenNeitherChildNorParentHasTag() {
-		$parent = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$parent->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [ 'blog' ] ],
-			]
-		);
-
-		$theme = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$theme->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [ 'blog' ] ],
-			]
-		);
-		$theme->method( 'parent' )->willReturn( $parent );
-
-		$this->assertFalse( SystemInfo::is_theme_accessibility_ready( $theme ) );
-	}
-
-	/**
-	 * An empty tag list returns false without errors.
-	 *
-	 * @return void
-	 */
-	public function testIsThemeAccessibilityReadyReturnsFalseForEmptyTags() {
-		$theme = $this->getMockBuilder( WP_Theme::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$theme->method( 'get' )->willReturnMap(
-			[
-				[ 'Tags', [] ],
-			]
-		);
-		$theme->method( 'parent' )->willReturn( false );
-
-		$this->assertFalse( SystemInfo::is_theme_accessibility_ready( $theme ) );
 	}
 
 	/**

--- a/tests/phpunit/Admin/SystemInfoTest.php
+++ b/tests/phpunit/Admin/SystemInfoTest.php
@@ -5,7 +5,7 @@
  * @package accessibility-checker
  */
 
-use EqualizeDigital\AccessibilityChecker\Admin\SystemInfo;
+use EqualizeDigital\AccessibilityChecker\SystemInfo\SystemInfo;
 
 /**
  * Tests for SystemInfo static helper methods.


### PR DESCRIPTION
This pull request introduces a new `SystemInfo` helper class to centralize and standardize the collection of WordPress environment details, including active plugins, theme information, and system versions. The license activation and periodic license check processes are refactored to use this new class, ensuring consistent and extensible system data is sent to the license API.

**System information collection and API integration:**

* Added a new `SystemInfo` class (`includes/classes/Admin/SystemInfo.php`) to provide helper methods for retrieving active plugins, active theme (with parent and accessibility-ready check), WordPress environment type, WordPress version, and PHP version. It also provides a method to return a payload-ready set of system fields for license API requests.
* Updated the `Connector` class to use `SystemInfo::get_license_request_context()` when building API parameters for both license activation and periodic license checks, replacing previous in-line system info gathering with a single, extensible call. [[1]](diffhunk://#diff-8a81f4ea9f793b2ccd6e028fe162a565bc61509b1df4829e92d838b6e70e4ee2R14) [[2]](diffhunk://#diff-8a81f4ea9f793b2ccd6e028fe162a565bc61509b1df4829e92d838b6e70e4ee2L253-R257) [[3]](diffhunk://#diff-8a81f4ea9f793b2ccd6e028fe162a565bc61509b1df4829e92d838b6e70e4ee2L424-R428)

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License requests now include packaged environment, PHP/WordPress versions, active plugins, and active theme info.
  * System now centrally collects environment, active plugin, and active theme information.

* **Tests**
  * Added comprehensive tests for plugin slug extraction, active plugins/theme data, accessibility readiness, environment detection, version reporting, and license request context.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1679)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->