### PR TITLE
Add versioning to scanner bundle URL for frontend scans

### DIFF
--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -161,7 +161,7 @@ class Enqueue_Frontend {
 					'appCssUrl'        => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,
 					'widgetPosition'   => get_option( 'edac_frontend_highlighter_position', 'right' ),
 					'editorLink'       => get_edit_post_link( $post_id ),
-					'scannerBundleUrl' => plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/pageScanner.bundle.js',
+					'scannerBundleUrl' => plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/pageScanner.bundle.js?ver=' . EDAC_VERSION,
 					'adminThemeColor'  => self::get_admin_theme_color(),
 				]
 			);

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -161,7 +161,7 @@ class Enqueue_Frontend {
 					'appCssUrl'        => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,
 					'widgetPosition'   => get_option( 'edac_frontend_highlighter_position', 'right' ),
 					'editorLink'       => get_edit_post_link( $post_id ),
-					'scannerBundleUrl' => plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/pageScanner.bundle.js?ver=' . EDAC_VERSION,
+					'scannerBundleUrl' => esc_url_raw( add_query_arg( 'ver', EDAC_VERSION, plugin_dir_url( __FILE__ ) . 'build/pageScanner.bundle.js' ) ),
 					'adminThemeColor'  => self::get_admin_theme_color(),
 				]
 			);

--- a/tests/phpunit/includes/classes/EnqueueFrontendTest.php
+++ b/tests/phpunit/includes/classes/EnqueueFrontendTest.php
@@ -52,6 +52,28 @@ class EnqueueFrontendTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the localized scannerBundleUrl includes the plugin version as a query string parameter.
+	 */
+	public function testScannerBundleUrlIncludesVersionQueryString(): void {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$created_post = $this->factory()->post->create_and_get( [ 'post_type' => 'post' ] );
+
+		global $post;
+		$post = $created_post;
+
+		Enqueue_Frontend::maybe_enqueue_frontend_highlighter();
+
+		global $wp_scripts;
+		$localized_data = $wp_scripts->get_data( 'edac-frontend-highlighter-app', 'data' );
+
+		$this->assertNotEmpty( $localized_data );
+		$this->assertStringContainsString( 'scannerBundleUrl', $localized_data );
+		$this->assertStringContainsString( 'ver=' . EDAC_VERSION, $localized_data );
+	}
+
+	/**
 	 * Ensure the highlighter uses the filtered post ID when determining scannable post types.
 	 */
 	public function testFrontendHighlighterUsesFilteredPostIdForScannableType(): void {


### PR DESCRIPTION
Updated the scannerBundleUrl to include the version parameter for better cache management.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Frontend scanner script URL now includes a cache‑busting version query parameter so browsers fetch updated scanner assets reliably.
* **Tests**
  * Added a unit test to verify the localized frontend data includes the scanner URL with the version query parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->