### PR TITLE
Make pro always authoritive for license checking

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -154,9 +154,9 @@ class AccessibilityReportsPage implements PageInterface {
 									</a>
 								</p>
 								<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-									<input type="hidden" name="action" value="edac_license" />
-									<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
-									<button type="submit" class="button edac-reports-page__button" name="edac_license_deactivate">
+									<input type="hidden" name="action" value="edac_jwt_unregister" />
+									<?php wp_nonce_field( 'edac_jwt_unregister', 'edac_jwt_unregister_nonce' ); ?>
+									<button type="submit" class="button edac-reports-page__button" name="edac_jwt_unregister">
 										<?php esc_html_e( 'Disable Email Reports', 'accessibility-checker' ); ?>
 									</button>
 								</form>

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -349,7 +349,7 @@ class AccessibilityReportsPage implements PageInterface {
 	 * @param string $free_status     Current free license status.
 	 * @param string $site_id         Current connected site ID.
 	 * @param bool   $fallback_active Whether a fallback from Pro to Free is currently active.
-	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool,fallback_active:bool}
+	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool,is_registered:bool,fallback_active:bool}
 	 */
 	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id, bool $fallback_active = false ): array {
 		$is_pro = $has_pro_plugin && 'valid' === $pro_status && ! $fallback_active;

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -84,6 +84,8 @@ class AccessibilityReportsPage implements PageInterface {
 		$is_pro          = $license_context['is_pro'];
 		$license_key     = (string) get_option( 'edacp_license_key', '' );
 		$is_connected    = $license_context['is_connected'];
+		$is_registered   = $license_context['is_registered'];
+		$status          = $license_context['status'];
 		$next_send_date  = $this->get_next_send_estimate_date();
 		$scans_stats     = new Scans_Stats();
 		$summary         = $scans_stats->summary();
@@ -137,74 +139,97 @@ class AccessibilityReportsPage implements PageInterface {
 				<section class="edac-reports-page__panel">
 					<h2><?php esc_html_e( 'Accessibility Reports', 'accessibility-checker' ); ?></h2>
 
-				<?php if ( ! $is_connected ) : ?>
-						<p class="edac-reports-page__intro">
-							<?php
-							if ( $is_pro ) {
-								esc_html_e( 'Get recurring email reports with a snapshot of your site’s accessibility, including total issues, trends over time, most problematic pages, and the most severe issues to fix first.', 'accessibility-checker' );
-							} else {
-								esc_html_e( 'Get recurring email reports with a snapshot of your site’s accessibility, including total issues, trends over time, most problematic pages, and the most severe issues to fix first. Some details, like full-site coverage and issue breakdowns, are available in Pro.', 'accessibility-checker' );
-							}
-							?>
-						</p>
-
-						<?php if ( $is_pro ) : ?>
-							<div class="edac-reports-page__single-action">
+					<?php if ( ! $is_connected && 'expired' === $status && $is_registered ) : ?>
+						<div class="edac-reports-grid edac-reports-grid--two">
+							<div class="edac-reports-card">
+								<div class="edac-reports-card__header">
+									<h3><?php esc_html_e( 'License Expired', 'accessibility-checker' ); ?></h3>
+								</div>
+								<p>
+									<?php esc_html_e( 'Your license has expired. This site is still connected but reports may stop until your license is renewed.', 'accessibility-checker' ); ?>
+								</p>
+								<p>
+									<a href="<?php echo esc_url( edac_link_wrapper( 'https://my.equalizedigital.com/', 'accessibility-reports', 'renew', false ) ); ?>" target="_blank" rel="noopener noreferrer">
+										<?php esc_html_e( 'Renew your license', 'accessibility-checker' ); ?>
+									</a>
+								</p>
 								<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-									<input type="hidden" name="action" value="edac_jwt_register" />
-									<?php wp_nonce_field( 'edac_jwt_register', 'edac_jwt_register_nonce' ); ?>
-									<button type="submit" class="button button-primary edac-reports-page__button">
+									<input type="hidden" name="action" value="edac_license" />
+									<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
+									<button type="submit" class="button edac-reports-page__button" name="edac_license_deactivate">
+										<?php esc_html_e( 'Disable Email Reports', 'accessibility-checker' ); ?>
+									</button>
+								</form>
+							</div>
+						</div>
+				<?php elseif ( ! $is_connected ) : ?>
+					<p class="edac-reports-page__intro">
+						<?php
+						if ( $is_pro ) {
+							esc_html_e( 'Get recurring email reports with a snapshot of your site’s accessibility, including total issues, trends over time, most problematic pages, and the most severe issues to fix first.', 'accessibility-checker' );
+						} else {
+							esc_html_e( 'Get recurring email reports with a snapshot of your site’s accessibility, including total issues, trends over time, most problematic pages, and the most severe issues to fix first. Some details, like full-site coverage and issue breakdowns, are available in Pro.', 'accessibility-checker' );
+						}
+						?>
+					</p>
+
+					<?php if ( $is_pro ) : ?>
+						<div class="edac-reports-page__single-action">
+							<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+								<input type="hidden" name="action" value="edac_jwt_register" />
+								<?php wp_nonce_field( 'edac_jwt_register', 'edac_jwt_register_nonce' ); ?>
+								<button type="submit" class="button button-primary edac-reports-page__button">
+									<?php esc_html_e( 'Enable Email Reports', 'accessibility-checker' ); ?>
+								</button>
+							</form>
+						</div>
+					<?php else : ?>
+						<div class="edac-reports-grid edac-reports-grid--two">
+							<div class="edac-reports-card">
+								<h3><?php esc_html_e( 'Free License Key', 'accessibility-checker' ); ?></h3>
+								<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+									<input type="hidden" name="action" value="edac_license" />
+									<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
+									<label class="screen-reader-text" for="edac-reports-license-key"><?php esc_html_e( 'Free License Key', 'accessibility-checker' ); ?></label>
+									<input id="edac-reports-license-key" name="edacp_license_key" type="text" class="regular-text edac-reports-page__license-input" value="<?php echo esc_attr( $license_key ); ?>" />
+									<button type="submit" class="button button-primary edac-reports-page__button" name="edac_license_activate">
 										<?php esc_html_e( 'Enable Email Reports', 'accessibility-checker' ); ?>
 									</button>
 								</form>
 							</div>
-						<?php else : ?>
-							<div class="edac-reports-grid edac-reports-grid--two">
-								<div class="edac-reports-card">
-									<h3><?php esc_html_e( 'Free License Key', 'accessibility-checker' ); ?></h3>
-									<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-										<input type="hidden" name="action" value="edac_license" />
-										<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
-										<label class="screen-reader-text" for="edac-reports-license-key"><?php esc_html_e( 'Free License Key', 'accessibility-checker' ); ?></label>
-										<input id="edac-reports-license-key" name="edacp_license_key" type="text" class="regular-text edac-reports-page__license-input" value="<?php echo esc_attr( $license_key ); ?>" />
-										<button type="submit" class="button button-primary edac-reports-page__button" name="edac_license_activate">
-											<?php esc_html_e( 'Enable Email Reports', 'accessibility-checker' ); ?>
-										</button>
-									</form>
-								</div>
 
-								<div class="edac-reports-card">
-									<h3><?php esc_html_e( 'Get a Free License Key', 'accessibility-checker' ); ?></h3>
-									<p>
-										<?php
-										printf(
-											/* translators: %s: dashboard URL. */
-											wp_kses_post( __( 'Got the plugin from Equalize Digital? Your key is in your <a href="%s" target="_blank" rel="noopener noreferrer">dashboard</a>.', 'accessibility-checker' ) ),
-											esc_url( $dashboard_url )
-										);
-										?>
-									</p>
-									<p>
-										<?php
-										printf(
-											/* translators: %s: signup URL. */
-											wp_kses_post( __( 'Installed from WordPress.org? <a href="%s" target="_blank" rel="noopener noreferrer">Create a free account</a> to get one.', 'accessibility-checker' ) ),
-											esc_url( $signup_url )
-										);
-										?>
-									</p>
-									<p>
-										<?php
-										printf(
-											/* translators: %s: signup URL. */
-											wp_kses_post( __( 'Not sure? Just <a href="%s" target="_blank" rel="noopener noreferrer">create a free account</a>. It only takes a minute.', 'accessibility-checker' ) ),
-											esc_url( $signup_url )
-										);
-										?>
-									</p>
-								</div>
+							<div class="edac-reports-card">
+								<h3><?php esc_html_e( 'Get a Free License Key', 'accessibility-checker' ); ?></h3>
+								<p>
+									<?php
+									printf(
+										/* translators: %s: dashboard URL. */
+										wp_kses_post( __( 'Got the plugin from Equalize Digital? Your key is in your <a href="%s" target="_blank" rel="noopener noreferrer">dashboard</a>.', 'accessibility-checker' ) ),
+										esc_url( $dashboard_url )
+									);
+									?>
+								</p>
+								<p>
+									<?php
+									printf(
+										/* translators: %s: signup URL. */
+										wp_kses_post( __( 'Installed from WordPress.org? <a href="%s" target="_blank" rel="noopener noreferrer">Create a free account</a> to get one.', 'accessibility-checker' ) ),
+										esc_url( $signup_url )
+									);
+									?>
+								</p>
+								<p>
+									<?php
+									printf(
+										/* translators: %s: signup URL. */
+										wp_kses_post( __( 'Not sure? Just <a href="%s" target="_blank" rel="noopener noreferrer">create a free account</a>. It only takes a minute.', 'accessibility-checker' ) ),
+										esc_url( $signup_url )
+									);
+									?>
+								</p>
 							</div>
-						<?php endif; ?>
+						</div>
+					<?php endif; ?>
 				<?php else : ?>
 						<div class="edac-reports-grid edac-reports-grid--two">
 							<div class="edac-reports-card">
@@ -327,16 +352,20 @@ class AccessibilityReportsPage implements PageInterface {
 	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool,fallback_active:bool}
 	 */
 	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id, bool $fallback_active = false ): array {
-		$is_pro       = $has_pro_plugin && 'valid' === $pro_status && ! $fallback_active;
-		$status       = $is_pro ? $pro_status : $free_status;
-		$is_connected = 'valid' === $status && '' !== $site_id;
-
+		$is_pro = $has_pro_plugin && 'valid' === $pro_status && ! $fallback_active;
+		$status = $is_pro ? $pro_status : $free_status;
+		// is_connected is true when:
+		// 1. License status is valid AND site_id exists, OR
+		// 2. Pro exists but is expired/degraded (fallback_active), AND site_id exists (reports still flowing).
+		$is_connected  = ( 'valid' === $status && '' !== $site_id ) || ( $has_pro_plugin && $fallback_active && '' !== $site_id );
+		$is_registered = '' !== $site_id;
 
 		return [
 			'has_pro_plugin'  => $has_pro_plugin,
 			'is_pro'          => $is_pro,
 			'status'          => $status,
 			'is_connected'    => $is_connected,
+			'is_registered'   => $is_registered,
 			'fallback_active' => $fallback_active,
 		];
 	}

--- a/admin/AdminPage/ConnectedServicesPage.php
+++ b/admin/AdminPage/ConnectedServicesPage.php
@@ -131,6 +131,7 @@ class ConnectedServicesPage implements PageInterface {
 		$status              = $license_context['status'];
 		$license             = get_option( 'edacp_license_key' );
 		$is_connected        = $license_context['is_connected'];
+		$is_registered       = $license_context['is_registered'];
 		$degraded_context    = $this->get_degraded_notice_context( $license_context );
 		$degraded_notice     = $this->get_degraded_notice_message( $license_context );
 		$dashboard_link      = '<a href="' . esc_url( \edac_link_wrapper( 'https://my.equalizedigital.com/', 'connected-services', 'account', false ) ) . '" target="_blank" rel="noopener noreferrer">my.equalizedigital.com</a>';
@@ -174,48 +175,66 @@ class ConnectedServicesPage implements PageInterface {
 				<tr valign="top">
 					<th scope="row" valign="top"></th>
 					<td>
-						<input type="hidden" name="action" value="edac_license" />
-						<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
-						<?php if ( $is_connected ) : ?>
-							<input
-								type="submit"
-								class="button-primary"
-								name="edac_license_deactivate"
-								value="<?php esc_attr_e( 'Disconnect Site', 'accessibility-checker' ); ?>"
-							>
-						<?php else : ?>
-							<input
-								type="submit"
-								class="button-primary"
-								name="edac_license_activate"
-								value="<?php esc_attr_e( 'Connect Site', 'accessibility-checker' ); ?>"
-							/>
-						<?php endif; ?>
+					<input type="hidden" name="action" value="edac_license" />
+					<?php wp_nonce_field( 'edac_license_nonce', 'edac_license_nonce' ); ?>
+					<?php if ( $is_connected ) : ?>
+						<input
+							type="submit"
+							class="button-primary"
+							name="edac_license_deactivate"
+							value="<?php esc_attr_e( 'Disconnect Site', 'accessibility-checker' ); ?>"
+						>
+					<?php elseif ( ! $is_connected && 'expired' === $status && $is_registered ) : ?>
+						<input
+							type="submit"
+							class="button-primary"
+							name="edac_license_deactivate"
+							value="<?php esc_attr_e( 'Disconnect Site', 'accessibility-checker' ); ?>"
+						>
+					<?php else : ?>
+						<input
+							type="submit"
+							class="button-primary"
+							name="edac_license_activate"
+							value="<?php esc_attr_e( 'Connect Site', 'accessibility-checker' ); ?>"
+						/>
+					<?php endif; ?>
 					</td>
 					</tr>
 					</tbody>
 				</table>
 			</form>
-			<?php if ( ! $is_connected ) : ?>
-				<p>
-					<?php
-					printf(
-						/* translators: %s: link to my.equalizedigital.com dashboard */
-						esc_html__( 'If you downloaded the free plugin from Equalize Digital, you already have a free license key in your %s dashboard.', 'accessibility-checker' ),
-						wp_kses_post( $dashboard_link )
-					);
-					?>
-				</p>
-				<p>
-					<?php
-					printf(
-						/* translators: %s: link to create a free account */
-						esc_html__( 'If not, %s to generate a license key and connect this site.', 'accessibility-checker' ),
-						wp_kses_post( $create_account_link )
-					);
-					?>
-				</p>
-			<?php endif; ?>
+			<?php if ( ! $is_connected && ! $is_registered ) : ?>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: link to my.equalizedigital.com dashboard */
+					esc_html__( 'If you downloaded the free plugin from Equalize Digital, you already have a free license key in your %s dashboard.', 'accessibility-checker' ),
+					wp_kses_post( $dashboard_link )
+				);
+				?>
+			</p>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: link to create a free account */
+					esc_html__( 'If not, %s to generate a license key and connect this site.', 'accessibility-checker' ),
+					wp_kses_post( $create_account_link )
+				);
+				?>
+			</p>
+		<?php elseif ( ! $is_connected && 'expired' === $status && $is_registered ) : ?>
+			<p>
+				<?php
+				$renew_link = '<a href="' . esc_url( \edac_link_wrapper( 'https://my.equalizedigital.com/', 'connected-services', 'renew', false ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Renew your license', 'accessibility-checker' ) . '</a>';
+				printf(
+					/* translators: %s: renew license link */
+					wp_kses_post( __( 'Your license has expired and this site is still connected. %s to restore full access, or disconnect the site above.', 'accessibility-checker' ) ),
+					wp_kses_post( $renew_link )
+				);
+				?>
+			</p>
+		<?php endif; ?>
 
 		<?php endif; ?>
 		<?php
@@ -308,22 +327,29 @@ class ConnectedServicesPage implements PageInterface {
 	/**
 	 * Resolve effective license context from current status values.
 	 *
-	 * @param bool   $has_pro_plugin Whether the Pro plugin is installed.
-	 * @param string $pro_status     Current Pro license status.
-	 * @param string $free_status    Current free license status.
-	 * @param string $site_id        Current connected site ID.
-	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool}
+	 * @param bool   $has_pro_plugin  Whether the Pro plugin is installed.
+	 * @param string $pro_status      Current Pro license status.
+	 * @param string $free_status     Current free license status.
+	 * @param string $site_id         Current connected site ID.
+	 * @param bool   $fallback_active Whether a fallback from Pro to Free is currently active.
+	 * @return array{has_pro_plugin:bool,is_pro:bool,status:string,is_connected:bool,is_registered:bool,fallback_active:bool}
 	 */
-	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id ): array {
-		$is_pro       = $has_pro_plugin && 'valid' === $pro_status;
-		$status       = $is_pro ? $pro_status : $free_status;
-		$is_connected = 'valid' === $status && '' !== $site_id;
+	private static function resolve_license_context( bool $has_pro_plugin, string $pro_status, string $free_status, string $site_id, bool $fallback_active = false ): array {
+		$is_pro = $has_pro_plugin && 'valid' === $pro_status && ! $fallback_active;
+		$status = $is_pro ? $pro_status : $free_status;
+		// is_connected is true when:
+		// 1. License status is valid AND site_id exists, OR
+		// 2. Pro exists but is expired/degraded (fallback_active), AND site_id exists (reports still flowing).
+		$is_connected  = ( 'valid' === $status && '' !== $site_id ) || ( $has_pro_plugin && $fallback_active && '' !== $site_id );
+		$is_registered = '' !== $site_id;
 
 		return [
-			'has_pro_plugin' => $has_pro_plugin,
-			'is_pro'         => $is_pro,
-			'status'         => $status,
-			'is_connected'   => $is_connected,
+			'has_pro_plugin'  => $has_pro_plugin,
+			'is_pro'          => $is_pro,
+			'status'          => $status,
+			'is_connected'    => $is_connected,
+			'is_registered'   => $is_registered,
+			'fallback_active' => $fallback_active,
 		];
 	}
 
@@ -359,14 +385,20 @@ class ConnectedServicesPage implements PageInterface {
 	 * @param string $pro_status        Current Pro status option.
 	 * @param string $effective_status  Effective authority status.
 	 * @param bool   $is_connected      Whether UI currently considers site connected.
+	 * @param bool   $fallback_active   Whether Pro has degraded to fallback mode.
 	 * @return array{show:bool,mode:string}
 	 */
-	private static function resolve_degraded_notice_context( bool $has_pro_plugin, bool $is_pro, string $pro_status, string $effective_status, bool $is_connected ): array {
+	private static function resolve_degraded_notice_context( bool $has_pro_plugin, bool $is_pro, string $pro_status, string $effective_status, bool $is_connected, bool $fallback_active = false ): array {
+		// Show degraded notice when:
+		// - Pro plugin exists AND
+		// - Pro is not currently active as authority AND
+		// - Pro status is set but not valid AND
+		// - Either: Free is valid OR Pro fallback mode is active.
 		$show = $has_pro_plugin
 			&& ! $is_pro
-			&& 'valid' === $effective_status
 			&& '' !== $pro_status
-			&& 'valid' !== $pro_status;
+			&& 'valid' !== $pro_status
+			&& ( 'valid' === $effective_status || $fallback_active );
 
 		if ( ! $show ) {
 			return [
@@ -377,7 +409,7 @@ class ConnectedServicesPage implements PageInterface {
 
 		return [
 			'show' => true,
-			'mode' => ! $is_connected ? 'reconnect' : 'connected',
+			'mode' => $is_connected ? 'connected' : 'reconnect',
 		];
 	}
 
@@ -395,7 +427,7 @@ class ConnectedServicesPage implements PageInterface {
 		}
 
 		if ( 'connected' === $notice_context['mode'] ) {
-			return __( 'Your Pro license is no longer valid. This site is using a valid Free license, and email reports remain connected as Free email reports. Renew your Pro license to restore Pro-only features.', 'accessibility-checker' );
+			return __( 'Your Pro license is no longer valid. Email reports remain connected as Free email reports. Renew your Pro license to restore Pro-only features.', 'accessibility-checker' );
 		}
 
 		return __( 'Your Pro license is no longer valid. This site is using a valid Free license, but email reports are not currently connected. Connect this site from the Free License section to resume Free email reports.', 'accessibility-checker' );

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -104,8 +104,11 @@ class Connector {
 	/**
 	 * Determine whether Pro should be the sole authority for license checks.
 	 *
-	 * Pro is considered authoritative when the Pro plugin is loaded and a
-	 * non-empty license key exists, which indicates Pro's check flow is in use.
+	 * Pro is authoritative whenever the Pro plugin is loaded and a non-empty
+	 * license key is present. Free license checks are fully suppressed in this
+	 * state so that both plugins cannot write conflicting status values to the
+	 * database simultaneously. Pro's own cron handles all revalidation; Free
+	 * never needs to re-run alongside it.
 	 *
 	 * @return bool
 	 */

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -483,6 +483,11 @@ class Connector {
 	 * @return void
 	 */
 	public function check_license_cron() {
+		if ( self::is_pro_license_check_active() ) {
+			wp_clear_scheduled_hook( 'edac_check_license_hook' );
+			return;
+		}
+
 		if ( ! wp_next_scheduled( 'edac_check_license_hook' ) ) {
 			wp_schedule_event( time(), 'daily', 'edac_check_license_hook' );
 		}

--- a/includes/classes/MyDot/Connector.php
+++ b/includes/classes/MyDot/Connector.php
@@ -102,6 +102,22 @@ class Connector {
 	}
 
 	/**
+	 * Determine whether Pro should be the sole authority for license checks.
+	 *
+	 * Pro is considered authoritative when the Pro plugin is loaded and a
+	 * non-empty license key exists, which indicates Pro's check flow is in use.
+	 *
+	 * @return bool
+	 */
+	private static function is_pro_license_check_active(): bool {
+		if ( ! defined( 'EDACP_VERSION' ) ) {
+			return false;
+		}
+
+		return '' !== trim( (string) get_option( 'edacp_license_key', '' ) );
+	}
+
+	/**
 	 * Expose the free product ID via a filter so other plugins (e.g. Pro) can
 	 * read it when inferring license type from API response product IDs.
 	 *
@@ -232,10 +248,9 @@ class Connector {
 	 * @return void
 	 */
 	private function activate_license() {
-		// If pro plugin is enabled with a valid license, it takes precedence.
-		// Do not allow free license activation to overwrite pro state.
-		if ( defined( 'EDACP_VERSION' ) && 'valid' === get_option( 'edacp_license_status' ) ) {
-			update_option( 'edac_license_error', __( 'Pro license is active. Please deactivate the Pro license first if you want to use a free license.', 'accessibility-checker' ) );
+		// Pro is authoritative whenever its license check flow is active.
+		if ( self::is_pro_license_check_active() ) {
+			update_option( 'edac_license_error', __( 'Pro license management is active. Please manage your license from Accessibility Checker Pro.', 'accessibility-checker' ) );
 			return;
 		}
 
@@ -398,15 +413,8 @@ class Connector {
 	 * @return void
 	 */
 	public function periodic_check_license() {
-		// Guard: Only bail if Pro is active with VALID license.
-		// This allows fallback when Pro license becomes invalid (expired, disabled, etc).
-		//
-		// Safe from race conditions:
-		// - Once Pro's license status changes from 'valid' to anything else, this guard
-		// stops bailing and free plugin resumes checking.
-		// - Both plugins check the same 'edacp_license_status' option atomically
-		// - Concurrent reads of the same option value are thread-safe in WordPress.
-		if ( defined( 'EDACP_VERSION' ) && self::LICENSE_STATUS_VALID === get_option( 'edacp_license_status' ) ) {
+		// Pro is authoritative whenever its own license check flow is active.
+		if ( self::is_pro_license_check_active() ) {
 			return;
 		}
 
@@ -458,6 +466,9 @@ class Connector {
 				// Free revalidated successfully after fallback; remove the temporary
 				// fallback marker so UI can reflect connected state again.
 				delete_option( 'edac_fallback_active' );
+			} elseif ( 'expired' === $license_data->license ) {
+				// License expired: set the error option so admin notices fire on the next page load.
+				update_option( 'edac_license_error', 'expired' );
 			}
 		}
 

--- a/tests/phpunit/Admin/ConnectedServicesPageTest.php
+++ b/tests/phpunit/Admin/ConnectedServicesPageTest.php
@@ -354,7 +354,7 @@ class ConnectedServicesPageTest extends WP_UnitTestCase {
 		$this->page->render_page();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'email reports remain connected as Free email reports', $output );
+		$this->assertStringContainsString( 'this site remains connected for Free email reports', $output );
 		$this->assertStringContainsString( 'Connected as Free', $output );
 		$this->assertStringNotContainsString( 'Free License Key', $output );
 	}

--- a/tests/phpunit/Admin/ConnectedServicesPageTest.php
+++ b/tests/phpunit/Admin/ConnectedServicesPageTest.php
@@ -249,6 +249,32 @@ class ConnectedServicesPageTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures degraded notice message still appears when Pro is expired, fallback is active,
+	 * and the free status is blank but the site remains connected.
+	 *
+	 * @throws ReflectionException If reflection fails.
+	 */
+	public function test_get_degraded_notice_message_connected_mode_during_fallback_with_blank_free_status() {
+		update_option( 'edacp_license_status', 'expired' );
+		update_option( 'edac_fallback_active', true );
+
+		$message = $this->invoke_private_method(
+			'get_degraded_notice_message',
+			[
+				[
+					'has_pro_plugin' => true,
+					'is_pro'         => false,
+					'status'         => '',
+					'is_connected'   => true,
+				],
+			]
+		);
+
+		$this->assertIsString( $message );
+		$this->assertStringContainsString( 'Free email reports', $message );
+	}
+
+	/**
 	 * Ensures degraded notice message explains reconnect mode during fallback.
 	 *
 	 * @throws ReflectionException If reflection fails.
@@ -286,6 +312,9 @@ class ConnectedServicesPageTest extends WP_UnitTestCase {
 
 	/**
 	 * Ensures degraded-state notice can be injected into the Pro license page hook.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_render_pro_license_degraded_notice_outputs_when_pro_is_invalid_and_free_is_valid() {
 		if ( ! defined( 'EDACP_VERSION' ) ) {
@@ -307,6 +336,9 @@ class ConnectedServicesPageTest extends WP_UnitTestCase {
 
 	/**
 	 * Ensures connected services shows a connected-as-free state instead of the free license key form during degraded fallback.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_render_page_shows_connected_as_free_in_degraded_connected_state() {
 		if ( ! defined( 'EDACP_VERSION' ) ) {
@@ -314,7 +346,7 @@ class ConnectedServicesPageTest extends WP_UnitTestCase {
 		}
 
 		update_option( 'edacp_license_status', 'expired' );
-		update_option( 'edac_license_status', 'valid' );
+		delete_option( 'edac_license_status' );
 		update_option( 'edac_site_id', 'site-123' );
 		update_option( 'edac_fallback_active', true );
 
@@ -322,6 +354,7 @@ class ConnectedServicesPageTest extends WP_UnitTestCase {
 		$this->page->render_page();
 		$output = ob_get_clean();
 
+		$this->assertStringContainsString( 'email reports remain connected as Free email reports', $output );
 		$this->assertStringContainsString( 'Connected as Free', $output );
 		$this->assertStringNotContainsString( 'Free License Key', $output );
 	}

--- a/tests/phpunit/Admin/SiteHealth/ChecksTest.php
+++ b/tests/phpunit/Admin/SiteHealth/ChecksTest.php
@@ -92,13 +92,13 @@ class ChecksTest extends WP_UnitTestCase {
 		$mock_stats = $this->getMockBuilder( Scans_Stats::class )
 			->disableOriginalConstructor()
 			->getMock();
-		
+
 		$mock_stats->method( 'summary' )
 			->willReturn(
 				[
 					'errors'   => 0,
 					'warnings' => 0,
-				] 
+				]
 			);
 
 		// Use reflection to set the private stats property.
@@ -110,7 +110,7 @@ class ChecksTest extends WP_UnitTestCase {
 			[
 				'errors'   => 0,
 				'warnings' => 0,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_for_issues();
@@ -137,7 +137,7 @@ class ChecksTest extends WP_UnitTestCase {
 			[
 				'errors'   => 5,
 				'warnings' => 3,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_for_issues();
@@ -152,11 +152,14 @@ class ChecksTest extends WP_UnitTestCase {
 
 	/**
 	 * Test test_for_issues with Pro version available.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_test_for_issues_with_pro_version() {
 		// Only run if constants aren't already defined.
 		$skip_test = defined( 'EDACP_VERSION' ) || defined( 'EDAC_KEY_VALID' );
-		
+
 		if ( ! $skip_test ) {
 			if ( ! defined( 'EDACP_VERSION' ) ) {
 				define( 'EDACP_VERSION', '1.0.0' );
@@ -175,7 +178,7 @@ class ChecksTest extends WP_UnitTestCase {
 			[
 				'errors'   => 2,
 				'warnings' => 1,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_for_issues();
@@ -203,7 +206,7 @@ class ChecksTest extends WP_UnitTestCase {
 			$this->checks,
 			[
 				'posts_scanned' => 0,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_content_scanned();
@@ -228,7 +231,7 @@ class ChecksTest extends WP_UnitTestCase {
 			$this->checks,
 			[
 				'posts_scanned' => 1,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_content_scanned();
@@ -251,7 +254,7 @@ class ChecksTest extends WP_UnitTestCase {
 			$this->checks,
 			[
 				'posts_scanned' => 150,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_content_scanned();
@@ -367,7 +370,7 @@ class ChecksTest extends WP_UnitTestCase {
 			[
 				'errors'   => 1234,
 				'warnings' => 5678,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_for_issues();
@@ -389,7 +392,7 @@ class ChecksTest extends WP_UnitTestCase {
 			$this->checks,
 			[
 				'posts_scanned' => 12345,
-			] 
+			]
 		);
 
 		$result = $this->checks->test_content_scanned();
@@ -412,7 +415,7 @@ class ChecksTest extends WP_UnitTestCase {
 				'errors'        => 1,
 				'warnings'      => 1,
 				'posts_scanned' => 1,
-			] 
+			]
 		);
 
 		// Set up post types option.

--- a/tests/phpunit/includes/classes/MyDot/ConnectorTest.php
+++ b/tests/phpunit/includes/classes/MyDot/ConnectorTest.php
@@ -559,6 +559,45 @@ class ConnectorTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures fallback marker remains untouched when Free checks bail due to active Pro checks.
+	 *
+	 * Pro is fully authoritative when installed with a key — Free never re-runs,
+	 * even when edac_fallback_active is set. Pro's own cron handles all revalidation.
+	 */
+	public function test_periodic_check_license_keeps_fallback_marker_when_pro_license_check_is_active() {
+		if ( ! defined( 'EDACP_VERSION' ) ) {
+			define( 'EDACP_VERSION', '1.19.0' );
+		}
+
+		update_option( 'edac_fallback_active', 1 );
+		update_option( 'edacp_license_key', 'free-license-key' );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode( [ 'license' => 'valid' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+			},
+			10,
+			3
+		);
+
+		$connector = new Connector();
+		$connector->periodic_check_license();
+
+		$this->assertFalse( $http_request_made, 'Free periodic check must bail even when edac_fallback_active=1.' );
+		$this->assertSame( 1, (int) get_option( 'edac_fallback_active' ) );
+	}
+
+	/**
 	 * Ensures free plugin's deactivate_license clears all expected options.
 	 *
 	 * @throws ReflectionException If the method cannot be reflected.
@@ -637,35 +676,6 @@ class ConnectorTest extends WP_UnitTestCase {
 		$this->assertFalse( $site_id, 'Site should not be auto-registered during fallback' );
 	}
 
-	/**
-	 * Ensures fallback marker remains when free checks bail due to active Pro checks.
-	 */
-	public function test_periodic_check_license_keeps_fallback_marker_when_pro_license_check_is_active() {
-		if ( ! defined( 'EDACP_VERSION' ) ) {
-			define( 'EDACP_VERSION', '1.19.0' );
-		}
-
-		update_option( 'edac_fallback_active', 1 );
-		update_option( 'edacp_license_key', 'free-license-key' );
-
-		$filter = $this->mock_http_response(
-			[
-				'license'          => 'valid',
-				'item_id'          => 1666,
-				'item_name'        => 'Accessibility Checker Free',
-				'license_limit'    => '1',
-				'expires'          => '2026-12-31 00:00:00',
-				'site_count'       => '1',
-				'activations_left' => '0',
-			]
-		);
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-
-		$connector = new Connector();
-		$connector->periodic_check_license();
-
-		$this->assertSame( 1, (int) get_option( 'edac_fallback_active' ) );
-	}
 
 	/**
 	 * Ensures Pro activation hook refreshes existing registration context.

--- a/tests/phpunit/includes/classes/MyDot/ConnectorTest.php
+++ b/tests/phpunit/includes/classes/MyDot/ConnectorTest.php
@@ -29,6 +29,8 @@ class ConnectorTest extends WP_UnitTestCase {
 		delete_option( 'edac_collection_interval_days' );
 		delete_option( 'edac_next_collection' );
 		delete_option( 'edac_fallback_active' );
+		wp_clear_scheduled_hook( 'edac_check_license_hook' );
+		wp_clear_scheduled_hook( 'edacp_check_license_hook' );
 	}
 
 	/**
@@ -46,6 +48,8 @@ class ConnectorTest extends WP_UnitTestCase {
 		delete_option( 'edac_collection_interval_days' );
 		delete_option( 'edac_next_collection' );
 		delete_option( 'edac_fallback_active' );
+		wp_clear_scheduled_hook( 'edac_check_license_hook' );
+		wp_clear_scheduled_hook( 'edacp_check_license_hook' );
 		remove_all_filters( 'edac_pro_product_id' );
 		remove_all_filters( 'pre_http_request' );
 
@@ -265,18 +269,220 @@ class ConnectorTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures free plugin's activate_license() does not run when Pro is installed with valid license.
+	 * Flow matrix for free-only periodic checks.
+	 *
+	 * @return array<string,array{0:string,1:bool,2:string|false}>
+	 */
+	public function free_only_periodic_license_flow_provider() {
+		return [
+			'free no key'   => [ '', false, false ],
+			'free with key' => [ 'free-license-key', true, 'valid' ],
+		];
+	}
+
+	/**
+	 * Covers free-only flows: no key vs key present.
+	 *
+	 * @dataProvider free_only_periodic_license_flow_provider
+	 *
+	 * @param string       $license_key          Shared license key value.
+	 * @param bool         $expects_http_request Whether free check should call remote API.
+	 * @param string|false $expected_status      Expected free status value or false when untouched.
+	 */
+	public function test_periodic_check_license_free_only_flow_matrix( $license_key, $expects_http_request, $expected_status ) {
+		if ( '' === $license_key ) {
+			delete_option( 'edacp_license_key' );
+		} else {
+			update_option( 'edacp_license_key', $license_key );
+		}
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode(
+						[
+							'license'          => 'valid',
+							'item_id'          => 1666,
+							'item_name'        => 'Accessibility Checker Free',
+							'license_limit'    => '1',
+							'expires'          => '2026-12-31 00:00:00',
+							'site_count'       => '1',
+							'activations_left' => '0',
+						]
+					),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+			},
+			10,
+			3
+		);
+
+		$connector = new Connector();
+		$connector->periodic_check_license();
+
+		$this->assertSame( $expects_http_request, $http_request_made );
+		if ( false === $expected_status ) {
+			$this->assertFalse( get_option( 'edac_license_status', false ) );
+			$this->assertFalse( get_option( 'edac_license_metadata', false ) );
+		} else {
+			$this->assertSame( $expected_status, get_option( 'edac_license_status' ) );
+			$this->assertIsArray( get_option( 'edac_license_metadata' ) );
+		}
+	}
+
+	/**
+	 * Flow matrix for periodic checks when Pro is installed.
+	 *
+	 * @return array<string,array{0:string,1:string|false,2:bool}>
+	 */
+	public function pro_installed_periodic_license_flow_provider() {
+		return [
+			'pro installed, no key'      => [ '', false, false ],
+			'pro installed, key set'     => [ 'free-license-key', false, false ],
+			'pro installed, key valid'   => [ 'pro-license-key', 'valid', false ],
+			'pro installed, key expired' => [ 'pro-license-key', 'expired', false ],
+		];
+	}
+
+	/**
+	 * Covers flows where Pro is installed; free periodic check should stand down once key is present.
+	 *
+	 * @dataProvider pro_installed_periodic_license_flow_provider
+	 *
+	 * @param string       $license_key          Shared license key value.
+	 * @param string|false $pro_status           Pro license status option value.
+	 * @param bool         $expects_http_request Whether free check should call remote API.
+	 */
+	public function test_periodic_check_license_pro_installed_flow_matrix( $license_key, $pro_status, $expects_http_request ) {
+		if ( ! defined( 'EDACP_VERSION' ) ) {
+			define( 'EDACP_VERSION', '1.19.0' );
+		}
+
+		if ( '' === $license_key ) {
+			delete_option( 'edacp_license_key' );
+		} else {
+			update_option( 'edacp_license_key', $license_key );
+		}
+
+		if ( false === $pro_status ) {
+			delete_option( 'edacp_license_status' );
+		} else {
+			update_option( 'edacp_license_status', $pro_status );
+		}
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode( [ 'license' => 'valid' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+			},
+			10,
+			3
+		);
+
+		$connector = new Connector();
+		$connector->periodic_check_license();
+
+		$this->assertSame( $expects_http_request, $http_request_made );
+		$this->assertFalse( get_option( 'edac_license_metadata', false ) );
+	}
+
+	/**
+	 * Pro-status matrix for activate_license guard behavior.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function pro_status_for_activation_guard_provider() {
+		return [
+			'pro key valid'   => [ 'valid' ],
+			'pro key expired' => [ 'expired' ],
+		];
+	}
+
+	/**
+	 * Ensures free activation is blocked whenever Pro check flow is active.
+	 *
+	 * @dataProvider pro_status_for_activation_guard_provider
+	 *
+	 * @param string $pro_status Pro license status value.
+	 * @throws ReflectionException If the method cannot be reflected.
+	 */
+	public function test_activate_license_pro_installed_with_key_flow_matrix( $pro_status ) {
+		if ( ! defined( 'EDACP_VERSION' ) ) {
+			define( 'EDACP_VERSION', '1.19.0' );
+		}
+
+		update_option( 'edacp_license_status', $pro_status );
+		update_option( 'edacp_license_key', 'pro-license-key' );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode( [ 'license' => 'valid' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+			},
+			10,
+			3
+		);
+
+		$connector  = new Connector();
+		$reflection = new ReflectionClass( Connector::class );
+		$method     = $reflection->getMethod( 'activate_license' );
+		$method->setAccessible( true );
+		$method->invoke( $connector );
+
+		$this->assertFalse( $http_request_made );
+		$this->assertStringContainsString( 'Pro license management is active', (string) get_option( 'edac_license_error' ) );
+	}
+
+	/**
+	 * Ensures free cron is still scheduled in free-only mode.
+	 */
+	public function test_check_license_cron_schedules_hook_in_free_only_mode() {
+		delete_option( 'edacp_license_key' );
+
+		$connector = new Connector();
+		$connector->check_license_cron();
+
+		$this->assertNotFalse( wp_next_scheduled( 'edac_check_license_hook' ) );
+	}
+
+	/**
+	 * Ensures free plugin's activate_license() does not run when Pro license checks are active.
 	 *
 	 * This prevents the free activation form from overwriting Pro license state.
 	 *
 	 * @throws ReflectionException If the method cannot be reflected.
 	 */
-	public function test_activate_license_bails_when_pro_is_active_with_valid_license() {
-		// Simulate Pro plugin installed with valid license.
+	public function test_activate_license_bails_when_pro_license_check_is_active() {
+		// Simulate Pro plugin installed with a stored key (Pro manages checks).
 		if ( ! defined( 'EDACP_VERSION' ) ) {
 			define( 'EDACP_VERSION', '1.19.0' );
 		}
-		update_option( 'edacp_license_status', 'valid' );
+		update_option( 'edacp_license_status', 'expired' );
 		update_option( 'edacp_license_key', 'free-license-key' );
 
 		// Create a new Connector instance and call activate_license via reflection.
@@ -291,50 +497,65 @@ class ConnectorTest extends WP_UnitTestCase {
 		// Verify error was set and no HTTP request was attempted.
 		$error = get_option( 'edac_license_error' );
 		$this->assertNotEmpty( $error );
-		$this->assertStringContainsString( 'Pro license is active', $error );
+		$this->assertStringContainsString( 'Pro license management is active', $error );
 
 		// Verify metadata was NOT updated (no HTTP call happened).
 		$this->assertFalse( get_option( 'edac_license_metadata', false ) );
 	}
 
 	/**
-	 * Ensures free plugin's periodic_check_license resumes when Pro is defined but license is not valid.
-	 *
-	 * This enables automatic fallback from Pro to free when Pro's license expires or is disabled.
+	 * Ensures free periodic checks bail whenever Pro license checks are active.
 	 */
-	public function test_periodic_check_license_resumes_when_pro_license_becomes_invalid() {
-		// Simulate Pro plugin installed but with expired license.
+	public function test_periodic_check_license_bails_when_pro_license_check_is_active() {
+		// Simulate Pro plugin installed with a stored key.
 		if ( ! defined( 'EDACP_VERSION' ) ) {
 			define( 'EDACP_VERSION', '1.19.0' );
 		}
-		update_option( 'edacp_license_status', 'expired' ); // Pro license is no longer valid.
+		update_option( 'edacp_license_status', 'expired' );
 		update_option( 'edacp_license_key', 'free-license-key' );
 
-		$connector = new Connector();
-		$filter    = $this->mock_http_response(
-			[
-				'license'          => 'valid',
-				'item_id'          => 1666,
-				'item_name'        => 'Accessibility Checker Free',
-				'license_limit'    => 1,
-				'expires'          => '2026-12-31 00:00:00',
-				'site_count'       => '1',
-				'activations_left' => '0',
-			]
+		$connector         = new Connector();
+		$http_request_made = false;
+
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode( [ 'license' => 'valid' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+			},
+			10,
+			3
 		);
 
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-
-		// Call periodic_check_license — it should NOT bail even though Pro is defined.
 		$connector->periodic_check_license();
 
-		$metadata = get_option( 'edac_license_metadata' );
+		$this->assertFalse( $http_request_made, 'Expected free periodic check to bail while Pro check is active.' );
+		$this->assertFalse( get_option( 'edac_license_metadata', false ) );
+		$this->assertFalse( get_option( 'edac_license_status', false ) );
+	}
 
-		// Verify free plugin checked and stored metadata (type: 'free', not Pro).
-		$this->assertIsArray( $metadata );
-		$this->assertSame( 'free', $metadata['type'] );
-		$this->assertSame( 1666, $metadata['item_id'] );
-		$this->assertSame( 'valid', get_option( 'edac_license_status' ) );
+	/**
+	 * Ensures free cron checks are unscheduled while Pro license checks are active.
+	 */
+	public function test_check_license_cron_unschedules_free_hook_when_pro_license_check_is_active() {
+		if ( ! defined( 'EDACP_VERSION' ) ) {
+			define( 'EDACP_VERSION', '1.19.0' );
+		}
+
+		update_option( 'edacp_license_key', 'pro-license-key' );
+		wp_schedule_event( time(), 'daily', 'edac_check_license_hook' );
+
+		$connector = new Connector();
+		$connector->check_license_cron();
+
+		$this->assertFalse( wp_next_scheduled( 'edac_check_license_hook' ) );
 	}
 
 	/**
@@ -378,13 +599,10 @@ class ConnectorTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures that when Pro license expires and free resumes, no automatic enrollment occurs.
-	 *
-	 * The free plugin should resume checking the license, but NOT automatically
-	 * register the site for email reports without explicit user action.
+	 * Ensures free periodic checks stay inactive while Pro check is active and cannot auto-enroll.
 	 */
-	public function test_periodic_check_license_fallback_does_not_auto_enroll() {
-		// Simulate Pro installed but expired.
+	public function test_periodic_check_license_with_active_pro_does_not_auto_enroll() {
+		// Simulate Pro installed with a stored key.
 		if ( ! defined( 'EDACP_VERSION' ) ) {
 			define( 'EDACP_VERSION', '1.19.0' );
 		}
@@ -411,10 +629,8 @@ class ConnectorTest extends WP_UnitTestCase {
 
 		$connector->periodic_check_license();
 
-		// Verify metadata was stored (license check succeeded).
-		$metadata = get_option( 'edac_license_metadata' );
-		$this->assertIsArray( $metadata );
-		$this->assertSame( 'free', $metadata['type'] );
+		// Verify metadata was not updated because free checks bail.
+		$this->assertFalse( get_option( 'edac_license_metadata', false ) );
 
 		// Verify that site ID is still empty (no enrollment happened).
 		$site_id = get_option( 'edac_site_id', false );
@@ -422,9 +638,13 @@ class ConnectorTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures fallback marker is cleared when free periodic check validates successfully.
+	 * Ensures fallback marker remains when free checks bail due to active Pro checks.
 	 */
-	public function test_periodic_check_license_clears_fallback_marker_when_free_becomes_valid() {
+	public function test_periodic_check_license_keeps_fallback_marker_when_pro_license_check_is_active() {
+		if ( ! defined( 'EDACP_VERSION' ) ) {
+			define( 'EDACP_VERSION', '1.19.0' );
+		}
+
 		update_option( 'edac_fallback_active', 1 );
 		update_option( 'edacp_license_key', 'free-license-key' );
 
@@ -444,7 +664,7 @@ class ConnectorTest extends WP_UnitTestCase {
 		$connector = new Connector();
 		$connector->periodic_check_license();
 
-		$this->assertFalse( get_option( 'edac_fallback_active', false ) );
+		$this->assertSame( 1, (int) get_option( 'edac_fallback_active' ) );
 	}
 
 	/**


### PR DESCRIPTION
Refactor license check logic to ensure that the Pro plugin's license management takes precedence when active. Introduced a new method to determine if Pro's license check flow is in use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "License Expired" UI card for registered sites when the license is expired and reports are not connected.

* **Improvements**
  * More precise license-state handling so connected / registered / expired scenarios show clearer, context-aware guidance.
  * Free plugin defers license checks and scheduling to Pro when Pro’s license flow is active to avoid duplicate processing.

* **Tests**
  * Expanded and isolated tests covering Free vs Pro flows, scheduling behavior, degraded-state messaging, and fallback scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1689)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->