### PR TITLE
Fix false positive: skip screen-reader-only elements in text_size_too_small check

### DIFF
--- a/src/pageScanner/checks/text-size-too-small.js
+++ b/src/pageScanner/checks/text-size-too-small.js
@@ -17,17 +17,16 @@ export default {
 			return false;
 		}
 
-		// Screen-reader-only elements are visually hidden intentionally — font size
-		// is irrelevant for text that sighted users never see.
-		if ( isScreenReaderOnly( node ) ) {
-			return false;
-		}
-
 		// Check if the node has any direct text nodes as children. For a node with no
 		// children, or with TEXT_NODE children, evaluate the nodes font size. This
 		// handles both leaf nodes and container elements with mixed content.
 		const hasTextChild = Array.from( node.childNodes ).some( ( child ) => child.nodeType === Node.TEXT_NODE );
 		if ( ! node.childNodes.length || hasTextChild ) {
+			// Screen-reader-only elements are visually hidden intentionally — font size
+			// is irrelevant for text that sighted users never see.
+			if ( isScreenReaderOnly( node ) ) {
+				return false;
+			}
 			return fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD;
 		}
 

--- a/src/pageScanner/checks/text-size-too-small.js
+++ b/src/pageScanner/checks/text-size-too-small.js
@@ -27,7 +27,16 @@ export default {
 			if ( isScreenReaderOnly( node ) ) {
 				return false;
 			}
-			return fontSizeInPx( node ) <= SMALL_FONT_SIZE_THRESHOLD;
+
+			const fontSize = fontSizeInPx( node );
+
+			// font-size: 0 means the text isn't rendering at all (commonly used as a
+			// layout technique on icon widget containers). That's not "too small to read".
+			if ( fontSize === 0 ) {
+				return false;
+			}
+
+			return fontSize <= SMALL_FONT_SIZE_THRESHOLD;
 		}
 
 		// No text nodes were found in direct children, and this is not a leaf node,

--- a/src/pageScanner/checks/text-size-too-small.js
+++ b/src/pageScanner/checks/text-size-too-small.js
@@ -5,7 +5,7 @@
  * @return {boolean} True if the text size is equal to or below the minimum size. False otherwise.
  */
 
-import { fontSizeInPx } from '../helpers/helpers';
+import { fontSizeInPx, isScreenReaderOnly } from '../helpers/helpers';
 
 const SMALL_FONT_SIZE_THRESHOLD = 10;
 
@@ -14,6 +14,12 @@ export default {
 	evaluate: ( node ) => {
 		// If the node has no text content then it can't have text that's too small.
 		if ( ! node.textContent.trim().length ) {
+			return false;
+		}
+
+		// Screen-reader-only elements are visually hidden intentionally — font size
+		// is irrelevant for text that sighted users never see.
+		if ( isScreenReaderOnly( node ) ) {
 			return false;
 		}
 

--- a/src/pageScanner/helpers/helpers.js
+++ b/src/pageScanner/helpers/helpers.js
@@ -68,6 +68,12 @@ export const isScreenReaderOnly = ( element ) => {
 		if ( ( isPositional && style.clip === 'rect(0px, 0px, 0px, 0px)' ) || style.clipPath === 'inset(50%)' ) {
 			return true;
 		}
+		// Catch sr-only patterns that rely on 1px dimensions rather than clip values
+		// (e.g. Elementor's .elementor-screen-only uses width/height:1px + overflow:hidden).
+		if ( isPositional && style.overflow === 'hidden' &&
+				parseFloat( style.width ) <= 1 && parseFloat( style.height ) <= 1 ) {
+			return true;
+		}
 		el = el.parentElement;
 	}
 	return false;

--- a/src/pageScanner/helpers/helpers.js
+++ b/src/pageScanner/helpers/helpers.js
@@ -53,6 +53,26 @@ export const isElementVisible = ( element ) => {
 };
 
 /**
+ * Check if an element (or any ancestor) is hidden using the screen-reader-only
+ * technique — visually clipped to nothing but still in the accessibility tree.
+ * Font-size checks are irrelevant for such elements.
+ *
+ * @param {HTMLElement} element The element to check.
+ * @return {boolean} True if the element is screen-reader-only.
+ */
+export const isScreenReaderOnly = ( element ) => {
+	let el = element;
+	while ( el && el.nodeType === Node.ELEMENT_NODE ) {
+		const style = window.getComputedStyle( el );
+		if ( style.clip === 'rect(0px, 0px, 0px, 0px)' || style.clipPath === 'inset(50%)' ) {
+			return true;
+		}
+		el = el.parentElement;
+	}
+	return false;
+};
+
+/**
  * A Map that normalizes all keys to lowercase
  */
 export class NormalizedMap extends Map {

--- a/src/pageScanner/helpers/helpers.js
+++ b/src/pageScanner/helpers/helpers.js
@@ -64,7 +64,8 @@ export const isScreenReaderOnly = ( element ) => {
 	let el = element;
 	while ( el && el.nodeType === Node.ELEMENT_NODE ) {
 		const style = window.getComputedStyle( el );
-		if ( style.clip === 'rect(0px, 0px, 0px, 0px)' || style.clipPath === 'inset(50%)' ) {
+		const isPositional = style.position === 'absolute' || style.position === 'fixed';
+		if ( ( isPositional && style.clip === 'rect(0px, 0px, 0px, 0px)' ) || style.clipPath === 'inset(50%)' ) {
 			return true;
 		}
 		el = el.parentElement;

--- a/tests/jest/rules/textSmall.test.js
+++ b/tests/jest/rules/textSmall.test.js
@@ -1,0 +1,107 @@
+import axe from 'axe-core';
+
+beforeAll( async () => {
+	const textSmallRuleModule = await import( '../../../src/pageScanner/rules/text-small.js' );
+	const textSizeTooSmallCheckModule = await import( '../../../src/pageScanner/checks/text-size-too-small.js' );
+	const textSmallRule = textSmallRuleModule.default;
+	const textSizeTooSmallCheck = textSizeTooSmallCheckModule.default;
+
+	axe.configure( {
+		rules: [ textSmallRule ],
+		checks: [ textSizeTooSmallCheck ],
+	} );
+} );
+
+beforeEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'Text Small Validation', () => {
+	const testCases = [
+		// PASSING CASES
+		{
+			name: 'should pass for text above the size threshold',
+			html: '<p style="font-size: 14px;">Normal sized text</p>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for text exactly above the threshold',
+			html: '<span style="font-size: 11px;">Slightly above threshold</span>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for element with no text content',
+			html: '<p style="font-size: 8px;"></p>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for container element with no direct text children',
+			html: '<div style="font-size: 8px;"><span>Child text</span></div>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for screen-reader-only text using classic clip pattern',
+			html: '<span style="position: absolute; width: 1px; height: 1px; clip: rect(0px, 0px, 0px, 0px); overflow: hidden; font-size: 8px;">Screen reader only</span>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for screen-reader-only text using clip-path pattern',
+			html: '<span style="clip-path: inset(50%); font-size: 8px;">Screen reader only</span>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for screen-reader-only text nested inside a visible element (Elementor social icon pattern)',
+			html: '<a href="#" style="font-size: 8px;"><span style="position: absolute; clip: rect(0px, 0px, 0px, 0px);">Facebook</span><svg aria-hidden="true"></svg></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for clip without absolute/fixed position (clip has no visual effect)',
+			html: '<span style="position: static; clip: rect(0px, 0px, 0px, 0px); font-size: 8px;">Clip but not positioned</span>',
+			shouldPass: false, // clip is ineffective without positioning, so this should still flag
+		},
+
+		// FAILING CASES
+		{
+			name: 'should fail for text at the threshold boundary (10px)',
+			html: '<span style="font-size: 10px;">Threshold text</span>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for text below the threshold',
+			html: '<p style="font-size: 8px;">Small text</p>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for small text in a heading',
+			html: '<h2 style="font-size: 9px;">Small heading</h2>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for small text in a link',
+			html: '<a href="#" style="font-size: 7px;">Tiny link</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for small text in a list item',
+			html: '<ul><li style="font-size: 8px;">Small list item</li></ul>',
+			shouldPass: false,
+		},
+	];
+
+	testCases.forEach( ( testCase ) => {
+		it( testCase.name, async () => {
+			document.body.innerHTML = testCase.html;
+
+			const results = await axe.run( document, {
+				runOnly: [ 'text_small' ],
+			} );
+
+			if ( testCase.shouldPass ) {
+				expect( results.violations.length ).toBe( 0 );
+			} else {
+				expect( results.violations.length ).toBeGreaterThan( 0 );
+				expect( results.violations[ 0 ].id ).toBe( 'text_small' );
+			}
+		} );
+	} );
+} );

--- a/tests/jest/rules/textSmall.test.js
+++ b/tests/jest/rules/textSmall.test.js
@@ -59,6 +59,12 @@ describe( 'Text Small Validation', () => {
 			html: '<a href="#" style="font-size: 8px;"><span style="position: absolute; width: 1px; height: 1px; overflow: hidden;">Facebook</span><svg aria-hidden="true"></svg></a>',
 			shouldPass: true,
 		},
+		{
+			name: 'should pass for text with font-size: 0 inherited from a layout container (Elementor social icons pattern)',
+			html: '<div style="font-size: 0;"><span>Screen reader label</span></div>',
+			shouldPass: true,
+		},
+
 		// FAILING CASES
 		{
 			name: 'should fail for clip without absolute/fixed position (clip has no visual effect)',

--- a/tests/jest/rules/textSmall.test.js
+++ b/tests/jest/rules/textSmall.test.js
@@ -54,13 +54,12 @@ describe( 'Text Small Validation', () => {
 			html: '<a href="#" style="font-size: 8px;"><span style="position: absolute; clip: rect(0px, 0px, 0px, 0px);">Facebook</span><svg aria-hidden="true"></svg></a>',
 			shouldPass: true,
 		},
-		{
-			name: 'should pass for clip without absolute/fixed position (clip has no visual effect)',
-			html: '<span style="position: static; clip: rect(0px, 0px, 0px, 0px); font-size: 8px;">Clip but not positioned</span>',
-			shouldPass: false, // clip is ineffective without positioning, so this should still flag
-		},
-
 		// FAILING CASES
+		{
+			name: 'should fail for clip without absolute/fixed position (clip has no visual effect)',
+			html: '<span style="position: static; clip: rect(0px, 0px, 0px, 0px); font-size: 8px;">Clip but not positioned</span>',
+			shouldPass: false,
+		},
 		{
 			name: 'should fail for text at the threshold boundary (10px)',
 			html: '<span style="font-size: 10px;">Threshold text</span>',

--- a/tests/jest/rules/textSmall.test.js
+++ b/tests/jest/rules/textSmall.test.js
@@ -50,8 +50,13 @@ describe( 'Text Small Validation', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'should pass for screen-reader-only text using dimension-based pattern (no clip)',
+			html: '<span style="position: absolute; width: 1px; height: 1px; overflow: hidden; font-size: 8px;">Screen reader only</span>',
+			shouldPass: true,
+		},
+		{
 			name: 'should pass for screen-reader-only text nested inside a visible element (Elementor social icon pattern)',
-			html: '<a href="#" style="font-size: 8px;"><span style="position: absolute; clip: rect(0px, 0px, 0px, 0px);">Facebook</span><svg aria-hidden="true"></svg></a>',
+			html: '<a href="#" style="font-size: 8px;"><span style="position: absolute; width: 1px; height: 1px; overflow: hidden;">Facebook</span><svg aria-hidden="true"></svg></a>',
 			shouldPass: true,
 		},
 		// FAILING CASES


### PR DESCRIPTION
## Summary

- Adds `isScreenReaderOnly()` helper to `helpers.js` that detects the sr-only CSS technique (classic `clip: rect(0px, 0px, 0px, 0px)` and modern `clip-path: inset(50%)`) by walking the element and its ancestors
- Updates `text-size-too-small.js` to bail out early when the node is screen-reader-only, preventing false positives on visually-hidden accessible labels
- Fixes a false positive triggered by Elementor's social icon widget, where `<span class="elementor-screen-only">` labels were being flagged for small font size

## Context

Elementor (and other builders) use a visually-hidden pattern to provide accessible text labels for icon-only elements. These spans inherit a small computed font size from the icon container but are never visible to sighted users — enforcing a minimum font size on them is meaningless and incorrect.

Axe-core has internal `_isVisibleOnScreen` / `_isVisibleToScreenReaders` functions that could theoretically address this, but they are undocumented internal APIs not exposed via `axe.commons`, operate on virtual nodes rather than DOM nodes, and could change without notice. A thin custom helper over `getComputedStyle` is the safer approach.

## Test plan

- [ ] Verify an Elementor social icons widget no longer triggers Text Too Small
- [ ] Verify genuinely small visible text still triggers the check
- [ ] Verify `display: none` / `visibility: hidden` elements are unaffected (handled upstream by axe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Text-size validation now excludes screen-reader-only (visually hidden) elements from font-size checks, preventing false positives for hidden content.

* **New Features**
  * Added helper to reliably detect screen-reader-only clipping patterns so accessibility checks focus on visible text.

* **Tests**
  * Added comprehensive tests validating the text-size accessibility rule across visible, hidden, and edge-case scenarios.

Fixes: #1688

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1690)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->