### PR TITLE
Replaced inline permission callback with a named method for get_scan_stats

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -108,14 +108,7 @@ class REST_Api {
 					[
 						'methods'             => 'GET',
 						'callback'            => [ $this, 'get_scans_stats' ],
-						'permission_callback' => function ( $request ) {
-							if ( Connector::validate_jwt_token_in_request_with_fallback( $request ) ) {
-								// Only allow if the site is still registered (site_id present).
-								$site_id = (string) get_option( 'edac_site_id', '' );
-								return '' !== $site_id;
-							}
-							return current_user_can( 'edit_posts' );
-						},
+						'permission_callback' => [ $this, 'can_get_scans_stats' ],
 					]
 				);
 			}
@@ -363,6 +356,23 @@ class REST_Api {
 				);
 			}
 		);
+	}
+
+	/**
+	 * Determine whether the current request may access the scans stats endpoint.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 *
+	 * @return bool
+	 */
+	public function can_get_scans_stats( \WP_REST_Request $request ): bool {
+		if ( Connector::validate_jwt_token_in_request_with_fallback( $request ) ) {
+			// Only allow if the site is still registered (site_id present).
+			$site_id = (string) get_option( 'edac_site_id', '' );
+			return '' !== $site_id;
+		}
+
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**


### PR DESCRIPTION
Static analysis in the woo upload process was flagging (falsely in my view) this callback was not returning a bool or a WP_Error object. From my perspective it couldn't ever return anything other than a bool.

Moving it to a named method with a return type hint of bool satisfied the static analysis.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authorization handling for the scans statistics endpoint with enhanced authentication support and role-based access controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1697)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->