### PR TITLE
Add: support for named anchors as jump targets in link validation

### DIFF
--- a/src/pageScanner/checks/link-has-valid-href-or-role.js
+++ b/src/pageScanner/checks/link-has-valid-href-or-role.js
@@ -33,7 +33,9 @@ export default {
 		// Allow named anchors used as jump targets: no href, has id, no visible content.
 		// Per the HTML spec, <a> without href has role="generic" and is not keyboard focusable,
 		// so it does not create a false link for AT or keyboard users.
-		if ( ! href && node.hasAttribute( 'id' ) && node.textContent.trim() === '' ) {
+		// Use hasAttribute instead of !href to exclude href="" which is keyboard focusable.
+		// Check children.length to exclude anchors wrapping images or other elements.
+		if ( ! node.hasAttribute( 'href' ) && node.hasAttribute( 'id' ) && node.children.length === 0 && node.textContent.trim() === '' ) {
 			return true;
 		}
 

--- a/src/pageScanner/checks/link-has-valid-href-or-role.js
+++ b/src/pageScanner/checks/link-has-valid-href-or-role.js
@@ -30,12 +30,22 @@ export default {
 			return true;
 		}
 
-		// Allow named anchors used as jump targets: no href, has id, no visible content.
+		// Allow named anchors used as jump targets: no href, has id/name, no visible content,
+		// and not keyboard-focusable.
 		// Per the HTML spec, <a> without href has role="generic" and is not keyboard focusable,
 		// so it does not create a false link for AT or keyboard users.
 		// Use hasAttribute instead of !href to exclude href="" which is keyboard focusable.
 		// Check children.length to exclude anchors wrapping images or other elements.
-		if ( ! node.hasAttribute( 'href' ) && node.hasAttribute( 'id' ) && node.children.length === 0 && node.textContent.trim() === '' ) {
+		const id = node.getAttribute( 'id' ) || '';
+		const name = node.getAttribute( 'name' ) || '';
+		const hasAnchorTargetName = id.trim() !== '' || name.trim() !== '';
+
+		const tabindex = node.getAttribute( 'tabindex' );
+		const parsedTabindex = null === tabindex ? null : Number.parseInt( tabindex, 10 );
+		const isKeyboardFocusable =
+			null !== tabindex && ( Number.isNaN( parsedTabindex ) || parsedTabindex >= 0 );
+
+		if ( ! node.hasAttribute( 'href' ) && hasAnchorTargetName && ! isKeyboardFocusable && node.children.length === 0 && node.textContent.trim() === '' ) {
 			return true;
 		}
 

--- a/src/pageScanner/checks/link-has-valid-href-or-role.js
+++ b/src/pageScanner/checks/link-has-valid-href-or-role.js
@@ -30,6 +30,13 @@ export default {
 			return true;
 		}
 
+		// Allow named anchors used as jump targets: no href, has id, no visible content.
+		// Per the HTML spec, <a> without href has role="generic" and is not keyboard focusable,
+		// so it does not create a false link for AT or keyboard users.
+		if ( ! href && node.hasAttribute( 'id' ) && node.textContent.trim() === '' ) {
+			return true;
+		}
+
 		const trimmedHref = href ? href.trim() : '';
 
 		// Fail if href is missing, just '#', or contains invalid protocols

--- a/tests/jest/rules/linkImproper.test.js
+++ b/tests/jest/rules/linkImproper.test.js
@@ -153,6 +153,11 @@ describe( 'Link Improper Rule', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'Passes when legacy name-only anchor is used as a jump target',
+			html: '<a name="section-top"></a>',
+			shouldPass: true,
+		},
+		{
 			name: 'Fails when anchor has id and text content but no href',
 			html: '<a id="meet-the-team">Meet the Team</a>',
 			shouldPass: false,
@@ -166,6 +171,16 @@ describe( 'Link Improper Rule', () => {
 			name: 'Fails when anchor has id and child image but no href',
 			html: '<a id="logo"><img src="logo.png" alt="Home"/></a>',
 			shouldPass: false,
+		},
+		{
+			name: 'Fails when anchor is keyboard focusable via tabindex and has no href',
+			html: '<a id="meet-the-team" tabindex="0"></a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Passes when anchor has tabindex of -1 and no href',
+			html: '<a id="meet-the-team" tabindex="-1"></a>',
+			shouldPass: true,
 		},
 	] )( '$name', async ( { html, shouldPass, setup } ) => {
 		document.body.innerHTML = html;

--- a/tests/jest/rules/linkImproper.test.js
+++ b/tests/jest/rules/linkImproper.test.js
@@ -157,6 +157,16 @@ describe( 'Link Improper Rule', () => {
 			html: '<a id="meet-the-team">Meet the Team</a>',
 			shouldPass: false,
 		},
+		{
+			name: 'Fails when anchor has id and empty href',
+			html: '<a id="top" href=""></a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Fails when anchor has id and child image but no href',
+			html: '<a id="logo"><img src="logo.png" alt="Home"/></a>',
+			shouldPass: false,
+		},
 	] )( '$name', async ( { html, shouldPass, setup } ) => {
 		document.body.innerHTML = html;
 

--- a/tests/jest/rules/linkImproper.test.js
+++ b/tests/jest/rules/linkImproper.test.js
@@ -140,6 +140,23 @@ describe( 'Link Improper Rule', () => {
 			html: '<a href="#" role="menuitem">Menu without aria-expanded</a>',
 			shouldPass: false,
 		},
+
+		// Named anchor (jump target) cases
+		{
+			name: 'Passes when empty anchor is used as a named jump target',
+			html: '<a id="meet-the-team"></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes when whitespace-only anchor is used as a named jump target',
+			html: '<a id="section-top">   </a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Fails when anchor has id and text content but no href',
+			html: '<a id="meet-the-team">Meet the Team</a>',
+			shouldPass: false,
+		},
 	] )( '$name', async ( { html, shouldPass, setup } ) => {
 		document.body.innerHTML = html;
 

--- a/tests/jest/rules/linkImproper.test.js
+++ b/tests/jest/rules/linkImproper.test.js
@@ -158,6 +158,11 @@ describe( 'Link Improper Rule', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'Fails when legacy name-only anchor has text',
+			html: '<a name="section-top">Text</a>',
+			shouldPass: false,
+		},
+		{
 			name: 'Fails when anchor has id and text content but no href',
 			html: '<a id="meet-the-team">Meet the Team</a>',
 			shouldPass: false,


### PR DESCRIPTION
This pull request improves the handling of named anchors (jump targets) in the link validation logic, ensuring that empty or whitespace-only anchors with an `id` but no `href` are correctly considered valid per HTML specifications. It also adds comprehensive test coverage for these cases.

Validation logic improvements:

* Updated the link validation in `link-has-valid-href-or-role.js` to allow `<a>` elements without an `href` but with an `id` and no visible content, aligning with HTML spec for named anchors.

Test enhancements:

* Added tests in `linkImproper.test.js` to verify that empty or whitespace-only anchors with an `id` and no `href` pass validation, and that anchors with both an `id` and visible text but no `href` fail as expected.

Fixes: #1694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Link validation updated to accept named anchors used as jump targets (anchors with an id or name and no visible content). Anchors that are keyboard-focusable without an href still fail; non-focusable ones pass. Existing href/role checks remain unchanged.

* **Tests**
  * Added test cases for named-anchor and tabindex scenarios to verify pass/fail behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->