### PR TITLE
Add tests for rest api callbacks

### DIFF
--- a/phpunit.dev.xml
+++ b/phpunit.dev.xml
@@ -22,6 +22,7 @@
 			<directory>./vendor/</directory>
 			<directory>./node_modules/</directory>
 			<directory>./dist/</directory>
+			<directory>./tools/</directory>
 			<file>./includes/wcag.php</file>
 		</exclude>
 	</coverage>

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -215,4 +215,105 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'success', $data2 );
 		$this->assertTrue( $data2['success'] );
 	}
+
+	/**
+	 * Verify permissions and payload shape for scans stats endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_scans_stats_permissions_and_payload() {
+		$this->assertNotNull( $this->server );
+
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats' );
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'Admin should be allowed to access scans stats.' );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'stats', $data );
+
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$request2  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats' );
+		$response2 = $this->server->dispatch( $request2 );
+		$this->assertSame( 403, $response2->get_status(), 'Subscriber without edit_posts should be denied scans stats access.' );
+	}
+
+	/**
+	 * Verify permissions and payload shape for clear cached scans stats endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_clear_cached_scans_stats_permissions_and_payload() {
+		$this->assertNotNull( $this->server );
+
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'POST', '/accessibility-checker/v1/clear-cached-scans-stats' );
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'Admin should be allowed to clear cached scans stats.' );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$request2  = new WP_REST_Request( 'POST', '/accessibility-checker/v1/clear-cached-scans-stats' );
+		$response2 = $this->server->dispatch( $request2 );
+		$this->assertSame( 403, $response2->get_status(), 'Subscriber without publish_posts should be denied cache clear.' );
+	}
+
+	/**
+	 * Verify scans stats by post type endpoint handles allowed and disallowed post types.
+	 *
+	 * @return void
+	 */
+	public function test_scans_stats_by_post_type_status_codes() {
+		$this->assertNotNull( $this->server );
+
+		wp_set_current_user( self::$admin_id );
+
+		$disallowed_request  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats-by-post-type/page' );
+		$disallowed_response = $this->server->dispatch( $disallowed_request );
+		$this->assertSame( 400, $disallowed_response->get_status(), 'Non-scannable post type should return 400.' );
+		$disallowed_data = $disallowed_response->get_data();
+		$this->assertIsArray( $disallowed_data );
+		$this->assertArrayHasKey( 'message', $disallowed_data );
+
+		$allowed_request  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats-by-post-type/post' );
+		$allowed_response = $this->server->dispatch( $allowed_request );
+		$this->assertSame( 200, $allowed_response->get_status(), 'Scannable post type should return 200.' );
+		$allowed_data = $allowed_response->get_data();
+		$this->assertIsArray( $allowed_data );
+		$this->assertArrayHasKey( 'success', $allowed_data );
+		$this->assertTrue( $allowed_data['success'] );
+		$this->assertArrayHasKey( 'stats', $allowed_data );
+	}
+
+	/**
+	 * Verify scans stats by post types endpoint permissions and payload shape.
+	 *
+	 * @return void
+	 */
+	public function test_scans_stats_by_post_types_permissions_and_payload() {
+		$this->assertNotNull( $this->server );
+
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats-by-post-types' );
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'Admin should be allowed to access scans stats by post types.' );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'stats', $data );
+
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$request2  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats-by-post-types' );
+		$response2 = $this->server->dispatch( $request2 );
+		$this->assertSame( 403, $response2->get_status(), 'Subscriber without edit_posts should be denied scans stats by post types.' );
+	}
 }

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -26,6 +26,13 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 	protected static $limited_id;
 
 	/**
+	 * Subscriber user ID (no edit_posts capability).
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
 	 * Post ID used for tests.
 	 *
 	 * @var int
@@ -76,8 +83,9 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		// Ensure plugin DB table exists for tests (normally created via admin_init).
 		( new \EDAC\Admin\Update_Database() )->edac_update_database();
 
-		self::$admin_id   = $factory->user->create( [ 'role' => 'administrator' ] );
-		self::$limited_id = $factory->user->create( [ 'role' => 'subscriber' ] );
+		self::$admin_id      = $factory->user->create( [ 'role' => 'administrator' ] );
+		self::$limited_id    = $factory->user->create( [ 'role' => 'subscriber' ] );
+		self::$subscriber_id = $factory->user->create( [ 'role' => 'subscriber' ] );
 		// Give limited user edit_posts but not edit_others_posts so they cannot edit this post.
 		$user = new WP_User( self::$limited_id );
 		$user->add_cap( 'edit_posts' );
@@ -233,9 +241,13 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'success', $data );
 		$this->assertTrue( $data['success'] );
 		$this->assertArrayHasKey( 'stats', $data );
+		// Verify stats structure is an array with expected keys.
+		$this->assertIsArray( $data['stats'] );
+		if ( ! empty( $data['stats'] ) ) {
+			$this->assertArrayHasKey( 'total_issues', $data['stats'] );
+		}
 
-		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
-		wp_set_current_user( $subscriber_id );
+		wp_set_current_user( self::$subscriber_id );
 		$request2  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats' );
 		$response2 = $this->server->dispatch( $request2 );
 		$this->assertSame( 403, $response2->get_status(), 'Subscriber without edit_posts should be denied scans stats access.' );
@@ -258,8 +270,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'success', $data );
 		$this->assertTrue( $data['success'] );
 
-		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
-		wp_set_current_user( $subscriber_id );
+		wp_set_current_user( self::$subscriber_id );
 		$request2  = new WP_REST_Request( 'POST', '/accessibility-checker/v1/clear-cached-scans-stats' );
 		$response2 = $this->server->dispatch( $request2 );
 		$this->assertSame( 403, $response2->get_status(), 'Subscriber without publish_posts should be denied cache clear.' );
@@ -309,9 +320,17 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'success', $data );
 		$this->assertTrue( $data['success'] );
 		$this->assertArrayHasKey( 'stats', $data );
+		// Verify stats structure is an array with expected keys per post type.
+		$this->assertIsArray( $data['stats'] );
+		if ( ! empty( $data['stats'] ) ) {
+			foreach ( $data['stats'] as $stat ) {
+				$this->assertIsArray( $stat );
+				// Each stat should have post_type key.
+				$this->assertArrayHasKey( 'post_type', $stat );
+			}
+		}
 
-		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
-		wp_set_current_user( $subscriber_id );
+		wp_set_current_user( self::$subscriber_id );
 		$request2  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats-by-post-types' );
 		$response2 = $this->server->dispatch( $request2 );
 		$this->assertSame( 403, $response2->get_status(), 'Subscriber without edit_posts should be denied scans stats by post types.' );

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -322,7 +322,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		if ( ! empty( $data['stats'] ) ) {
 			foreach ( $data['stats'] as $post_type => $stat ) {
 				$this->assertIsString( $post_type );
-				$this->assertTrue( false === $stat || is_array( $stat ) );
+				$this->assertTrue( $stat === false || is_array( $stat ) );
 			}
 		}
 

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -241,11 +241,8 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'success', $data );
 		$this->assertTrue( $data['success'] );
 		$this->assertArrayHasKey( 'stats', $data );
-		// Verify stats structure is an array with expected keys.
+		// Verify stats structure is an array.
 		$this->assertIsArray( $data['stats'] );
-		if ( ! empty( $data['stats'] ) ) {
-			$this->assertArrayHasKey( 'total_issues', $data['stats'] );
-		}
 
 		wp_set_current_user( self::$subscriber_id );
 		$request2  = new WP_REST_Request( 'GET', '/accessibility-checker/v1/scans-stats' );
@@ -320,13 +317,12 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'success', $data );
 		$this->assertTrue( $data['success'] );
 		$this->assertArrayHasKey( 'stats', $data );
-		// Verify stats structure is an array with expected keys per post type.
+		// Verify stats structure is an array keyed by post type.
 		$this->assertIsArray( $data['stats'] );
 		if ( ! empty( $data['stats'] ) ) {
-			foreach ( $data['stats'] as $stat ) {
-				$this->assertIsArray( $stat );
-				// Each stat should have post_type key.
-				$this->assertArrayHasKey( 'post_type', $stat );
+			foreach ( $data['stats'] as $post_type => $stat ) {
+				$this->assertIsString( $post_type );
+				$this->assertTrue( false === $stat || is_array( $stat ) );
 			}
 		}
 


### PR DESCRIPTION
This pull request adds comprehensive tests for several new REST API endpoints related to scan statistics, focusing on permissions, response payloads, and status codes. Additionally, it updates the PHPUnit configuration to include the `tools` directory in code coverage analysis.

**REST API Endpoint Tests:**

* Added tests for the `/scans-stats`, `/clear-cached-scans-stats`, `/scans-stats-by-post-type/{type}`, and `/scans-stats-by-post-types` endpoints, verifying:
  * Correct permissions enforcement for admin and subscriber roles.
  * Proper response payload structure and status codes for both allowed and disallowed actions and post types.

**Testing Configuration:**

* Updated `phpunit.dev.xml` to include the `tools` directory in code coverage exclusions, ensuring more accurate coverage reporting.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added REST API tests for scan statistics endpoints, including a subscriber fixture; verify admin vs subscriber permissions, HTTP status codes, error messages, and response payloads for retrieval, cache-clearing, and post-type-specific flows.

* **Chores**
  * Updated PHPUnit coverage configuration to exclude development tools from coverage collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1699)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->