### PR TITLE
fix: use event delegation for GAAD and Black Friday notice dismiss handlers

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -558,32 +558,35 @@ const edacScriptVars = edac_script_vars;
 		/**
 		 * GAAD Pre-Sale Notice Ajax
 		 */
-		if ( jQuery( '.edac_gaad_presale_notice' ).length ) {
-			jQuery( '.edac_gaad_presale_notice .notice-dismiss' ).on( 'click', function() {
+		jQuery( document ).on(
+			'click',
+			'.edac_gaad_presale_notice .notice-dismiss',
+			function() {
 				edacNoticeAjax( 'edac_gaad_presale_notice_ajax' );
-			} );
-		}
+			}
+		);
 
 		/**
 		 * GAAD Sale Notice Ajax
 		 */
-		if ( jQuery( '.edac_gaad_sale_notice' ).length ) {
-			jQuery( '.edac_gaad_sale_notice .notice-dismiss' ).on( 'click', function() {
+		jQuery( document ).on(
+			'click',
+			'.edac_gaad_sale_notice .notice-dismiss',
+			function() {
 				edacNoticeAjax( 'edac_gaad_sale_notice_ajax' );
-			} );
-		}
+			}
+		);
 
 		/**
 		 * Black Friday Notice Ajax
 		 */
-		if ( jQuery( '.edac_black_friday_notice' ).length ) {
-			jQuery( '.edac_black_friday_notice .notice-dismiss' ).on(
-				'click',
-				function() {
-					edacNoticeAjax( 'edac_black_friday_notice_ajax' );
-				}
-			);
-		}
+		jQuery( document ).on(
+			'click',
+			'.edac_black_friday_notice .notice-dismiss',
+			function() {
+				edacNoticeAjax( 'edac_black_friday_notice_ajax' );
+			}
+		);
 
 		function edacNoticeAjax( functionName = null ) {
 			jQuery.ajax( {


### PR DESCRIPTION
## Summary

- Switches the GAAD presale, GAAD sale, and Black Friday admin notice dismiss handlers from direct jQuery event binding to `jQuery(document).on('click', selector, fn)` event delegation.

## Why

WordPress's `common.js` adds the `.notice-dismiss` button **dynamically** inside its own `document.ready` handler. The EDAC admin script also runs in `document.ready`. In certain environments — plugin conflicts, theme interactions, or other factors that alter script execution order — the EDAC ready handler can run before WordPress has injected the dismiss button. When this happens, `jQuery('.edac_gaad_presale_notice .notice-dismiss')` returns an empty set and the click handler is never bound.

The result: WordPress still removes the notice visually (it has its own handler on the element it created), but our AJAX call never fires, `update_option` is never called, and the banner reappears on the next page load. This matches the reported symptoms — "dismiss isn't working."

Event delegation on `document` fires for any matching click that bubbles up regardless of when the target element was inserted, eliminating the race condition entirely.

## Test plan

- [ ] On an admin page where the GAAD presale notice is visible, click the dismiss (×) button — notice should not reappear after a page reload
- [ ] Repeat for the GAAD sale notice (visible May 20–22)
- [ ] Confirm the Black Friday notice dismiss still works when that notice is active
- [ ] Verify no JS console errors on admin pages where notices are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of notice dismissal functionality to ensure dismiss buttons work consistently across different page load scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->