### PR TITLE
fix: replace AJAX notice dismiss with redirect-based approach

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -135,7 +135,12 @@ class Admin_Notices {
 				break;
 		}
 
-		wp_safe_redirect( remove_query_arg( [ 'edac_dismiss_notice', '_wpnonce' ] ) );
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '/wp-admin/';
+		$redirect_to = remove_query_arg(
+			[ 'edac_dismiss_notice', '_wpnonce' ],
+			set_url_scheme( '//' . wp_parse_url( home_url(), PHP_URL_HOST ) . $request_uri )
+		);
+		wp_safe_redirect( $redirect_to );
 		exit;
 	}
 
@@ -193,7 +198,7 @@ class Admin_Notices {
 	public function edac_get_black_friday_message() {
 
 		// Construct the promotional message.
-		$message  = '<div class="edac_black_friday_notice notice notice-info">';
+		$message  = '<div class="edac_black_friday_notice notice notice-info" style="position: relative; padding-right: 38px;">';
 		$message .= '<p><strong>' . esc_html__( '🎉 Black Friday special! 🎉', 'accessibility-checker' ) . '</strong><br />';
 		$message .= esc_html__( 'Upgrade to a paid version of Accessibility Checker from November 24th to December 3rd and get 30% off! Full site scanning, site-wide open issues report, ignore logs, and more.', 'accessibility-checker' ) . '<br />';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://my.equalizedigital.com/support/pre-sale-questions/', 'admin-notice', 'BlackFriday25-presale', false ) ) . '">' . esc_html__( 'Ask a Pre-Sale Question', 'accessibility-checker' ) . '</a> ';
@@ -237,7 +242,7 @@ class Admin_Notices {
 	 */
 	public function edac_get_gaad_presale_message() {
 
-		$message  = '<div class="edac_gaad_presale_notice notice notice-info">';
+		$message  = '<div class="edac_gaad_presale_notice notice notice-info" style="position: relative; padding-right: 38px;">';
 		$message .= '<p><strong>' . esc_html__( '⚡️ Global Accessibility Awareness Day Flash Sale', 'accessibility-checker' ) . '</strong><br />';
 
 		if ( defined( 'EDACP_VERSION' ) && edac_is_pro() ) {
@@ -289,7 +294,7 @@ class Admin_Notices {
 	 */
 	public function edac_get_gaad_sale_message() {
 
-		$message  = '<div class="edac_gaad_sale_notice notice notice-info">';
+		$message  = '<div class="edac_gaad_sale_notice notice notice-info" style="position: relative; padding-right: 38px;">';
 		$message .= '<p><strong>' . esc_html__( '⚡️ Global Accessibility Awareness Day Flash Sale', 'accessibility-checker' ) . '</strong><br />';
 
 		if ( defined( 'EDACP_VERSION' ) && edac_is_pro() ) {

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -33,10 +33,9 @@ class Admin_Notices {
 
 		add_action( 'in_admin_header', [ $this, 'edac_remove_admin_notices' ], 1000 );
 		add_action( 'in_admin_header', [ $this, 'hook_notices' ], 1001 );
-		// Ajax handlers for notices.
-		add_action( 'wp_ajax_edac_black_friday_notice_ajax', [ $this, 'edac_black_friday_notice_ajax' ] );
-		add_action( 'wp_ajax_edac_gaad_presale_notice_ajax', [ $this, 'edac_gaad_presale_notice_ajax' ] );
-		add_action( 'wp_ajax_edac_gaad_sale_notice_ajax', [ $this, 'edac_gaad_sale_notice_ajax' ] );
+		// Redirect-based dismiss handler for promotional notices.
+		add_action( 'admin_init', [ $this, 'handle_dismiss_notice' ] );
+		// Ajax handler for review notice.
 		add_action( 'wp_ajax_edac_review_notice_ajax', [ $this, 'edac_review_notice_ajax' ] );
 		// Save fixes transient on save.
 		add_action( 'updated_option', [ $this, 'set_fixes_transient_on_save' ] );
@@ -97,6 +96,63 @@ class Admin_Notices {
 	}
 
 	/**
+	 * Handle redirect-based dismiss for promotional notices.
+	 *
+	 * Saves the dismiss option and redirects back to the originating page,
+	 * stripping the dismiss query parameters from the URL.
+	 *
+	 * @return void
+	 */
+	public function handle_dismiss_notice() {
+
+		if ( ! isset( $_GET['edac_dismiss_notice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$notice = sanitize_key( wp_unslash( $_GET['edac_dismiss_notice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		check_admin_referer( 'edac_dismiss_notice_' . $notice );
+
+		if ( ! Helpers::current_user_can_see_widgets_and_notices() ) {
+			wp_die( esc_html__( 'Permission Denied', 'accessibility-checker' ) );
+		}
+
+		switch ( $notice ) {
+			case 'gaad_presale':
+				update_option( 'edac_gaad_presale_notice_dismiss_2026', true );
+				break;
+			case 'gaad_sale':
+				update_option( 'edac_gaad_sale_notice_dismiss_2026', true );
+				delete_option( 'edac_gaad_notice_dismiss_2026' );
+				delete_option( 'edac_gaad_notice_dismiss_2025' );
+				delete_option( 'edac_gaad_notice_dismiss_2024' );
+				delete_option( 'edac_gaad_notice_dismiss' );
+				break;
+			case 'black_friday':
+				update_option( 'edac_black_friday_2025_notice_dismiss', true );
+				delete_option( 'edac_black_friday_2024_notice_dismiss' );
+				delete_option( 'edac_black_friday_2023_notice_dismiss' );
+				break;
+		}
+
+		wp_safe_redirect( remove_query_arg( [ 'edac_dismiss_notice', '_wpnonce' ] ) );
+		exit;
+	}
+
+	/**
+	 * Build a dismiss URL for a promotional notice.
+	 *
+	 * @param string $notice Notice key (e.g. 'gaad_presale').
+	 * @return string Nonce-protected URL that triggers handle_dismiss_notice().
+	 */
+	private function dismiss_url( string $notice ): string {
+		return wp_nonce_url(
+			add_query_arg( 'edac_dismiss_notice', $notice ),
+			'edac_dismiss_notice_' . $notice
+		);
+	}
+
+	/**
 	 * Black Friday Admin Notice
 	 *
 	 * @return void
@@ -137,47 +193,15 @@ class Admin_Notices {
 	public function edac_get_black_friday_message() {
 
 		// Construct the promotional message.
-		$message  = '<div class="edac_black_friday_notice notice notice-info is-dismissible">';
+		$message  = '<div class="edac_black_friday_notice notice notice-info">';
 		$message .= '<p><strong>' . esc_html__( '🎉 Black Friday special! 🎉', 'accessibility-checker' ) . '</strong><br />';
 		$message .= esc_html__( 'Upgrade to a paid version of Accessibility Checker from November 24th to December 3rd and get 30% off! Full site scanning, site-wide open issues report, ignore logs, and more.', 'accessibility-checker' ) . '<br />';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://my.equalizedigital.com/support/pre-sale-questions/', 'admin-notice', 'BlackFriday25-presale', false ) ) . '">' . esc_html__( 'Ask a Pre-Sale Question', 'accessibility-checker' ) . '</a> ';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'admin-notice', 'BlackFriday25-pricing', false ) ) . '">' . esc_html__( 'Upgrade Now', 'accessibility-checker' ) . '</a></p>';
+		$message .= '<a href="' . esc_url( $this->dismiss_url( 'black_friday' ) ) . '" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'accessibility-checker' ) . '</span></a>';
 		$message .= '</div>';
 
 		return $message;
-	}
-
-	/**
-	 * Black Friday Admin Notice Ajax
-	 *
-	 * @return void
-	 *
-	 *  - '-1' means that nonce could not be varified
-	 *  - '-2' means that update option wasn't successful
-	 */
-	public function edac_black_friday_notice_ajax() {
-
-		// nonce security.
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
-
-			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-
-		}
-
-		$results = update_option( 'edac_black_friday_2025_notice_dismiss', true );
-		// Delete old options if they exist.
-		delete_option( 'edac_black_friday_2024_notice_dismiss' );
-		delete_option( 'edac_black_friday_2023_notice_dismiss' );
-
-		if ( ! $results ) {
-
-			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-
-		}
-
-		wp_send_json_success( wp_json_encode( $results ) );
 	}
 
 	/**
@@ -213,7 +237,7 @@ class Admin_Notices {
 	 */
 	public function edac_get_gaad_presale_message() {
 
-		$message  = '<div class="edac_gaad_presale_notice notice notice-info is-dismissible">';
+		$message  = '<div class="edac_gaad_presale_notice notice notice-info">';
 		$message .= '<p><strong>' . esc_html__( '⚡️ Global Accessibility Awareness Day Flash Sale', 'accessibility-checker' ) . '</strong><br />';
 
 		if ( defined( 'EDACP_VERSION' ) && edac_is_pro() ) {
@@ -227,34 +251,10 @@ class Admin_Notices {
 			$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'admin-notice', 'GAAD2026-pricing-pre', false ) ) . '">' . esc_html__( 'View Pricing', 'accessibility-checker' ) . '</a></p>';
 		}
 
+		$message .= '<a href="' . esc_url( $this->dismiss_url( 'gaad_presale' ) ) . '" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'accessibility-checker' ) . '</span></a>';
 		$message .= '</div>';
 
 		return $message;
-	}
-
-	/**
-	 * GAAD Pre-Sale Notice Ajax
-	 *
-	 * @return void
-	 *
-	 *  - '-1' means that nonce could not be verified
-	 *  - '-2' means that update option wasn't successful
-	 */
-	public function edac_gaad_presale_notice_ajax() {
-
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
-			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-		}
-
-		$results = update_option( 'edac_gaad_presale_notice_dismiss_2026', true );
-
-		if ( ! $results ) {
-			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-		}
-
-		wp_send_json_success( wp_json_encode( $results ) );
 	}
 
 	/**
@@ -289,7 +289,7 @@ class Admin_Notices {
 	 */
 	public function edac_get_gaad_sale_message() {
 
-		$message  = '<div class="edac_gaad_sale_notice notice notice-info is-dismissible">';
+		$message  = '<div class="edac_gaad_sale_notice notice notice-info">';
 		$message .= '<p><strong>' . esc_html__( '⚡️ Global Accessibility Awareness Day Flash Sale', 'accessibility-checker' ) . '</strong><br />';
 
 		if ( defined( 'EDACP_VERSION' ) && edac_is_pro() ) {
@@ -303,40 +303,10 @@ class Admin_Notices {
 			$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/?discount=GAAD2026', 'admin-notice', 'GAAD2026-pricing', false ) ) . '">' . esc_html__( 'Upgrade Now', 'accessibility-checker' ) . '</a></p>';
 		}
 
+		$message .= '<a href="' . esc_url( $this->dismiss_url( 'gaad_sale' ) ) . '" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'accessibility-checker' ) . '</span></a>';
 		$message .= '</div>';
 
 		return $message;
-	}
-
-	/**
-	 * GAAD Sale Notice Ajax
-	 *
-	 * @return void
-	 *
-	 *  - '-1' means that nonce could not be verified
-	 *  - '-2' means that update option wasn't successful
-	 */
-	public function edac_gaad_sale_notice_ajax() {
-
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ajax-nonce' ) ) {
-			$error = new \WP_Error( '-1', __( 'Permission Denied', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-		}
-
-		$results = update_option( 'edac_gaad_sale_notice_dismiss_2026', true );
-		// Delete old option keys if they exist.
-		delete_option( 'edac_gaad_notice_dismiss_2026' );
-		delete_option( 'edac_gaad_notice_dismiss_2025' );
-		delete_option( 'edac_gaad_notice_dismiss_2024' );
-		delete_option( 'edac_gaad_notice_dismiss' );
-
-		if ( ! $results ) {
-			$error = new \WP_Error( '-2', __( 'Update option wasn\'t successful', 'accessibility-checker' ) );
-			wp_send_json_error( $error );
-
-		}
-
-		wp_send_json_success( wp_json_encode( $results ) );
 	}
 
 	/**

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -136,9 +136,14 @@ class Admin_Notices {
 		}
 
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '/wp-admin/';
+		$home_parts  = wp_parse_url( home_url() );
+		$authority   = $home_parts['host'] ?? '';
+		if ( isset( $home_parts['port'] ) ) {
+			$authority .= ':' . $home_parts['port'];
+		}
 		$redirect_to = remove_query_arg(
 			[ 'edac_dismiss_notice', '_wpnonce' ],
-			set_url_scheme( '//' . wp_parse_url( home_url(), PHP_URL_HOST ) . $request_uri )
+			set_url_scheme( '//' . $authority . $request_uri )
 		);
 		wp_safe_redirect( $redirect_to );
 		exit;

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -555,53 +555,6 @@ const edacScriptVars = edac_script_vars;
 			} );
 		}
 
-		/**
-		 * GAAD Pre-Sale Notice Ajax
-		 */
-		if ( jQuery( '.edac_gaad_presale_notice' ).length ) {
-			jQuery( '.edac_gaad_presale_notice .notice-dismiss' ).on( 'click', function() {
-				edacNoticeAjax( 'edac_gaad_presale_notice_ajax' );
-			} );
-		}
-
-		/**
-		 * GAAD Sale Notice Ajax
-		 */
-		if ( jQuery( '.edac_gaad_sale_notice' ).length ) {
-			jQuery( '.edac_gaad_sale_notice .notice-dismiss' ).on( 'click', function() {
-				edacNoticeAjax( 'edac_gaad_sale_notice_ajax' );
-			} );
-		}
-
-		/**
-		 * Black Friday Notice Ajax
-		 */
-		if ( jQuery( '.edac_black_friday_notice' ).length ) {
-			jQuery( '.edac_black_friday_notice .notice-dismiss' ).on(
-				'click',
-				function() {
-					edacNoticeAjax( 'edac_black_friday_notice_ajax' );
-				}
-			);
-		}
-
-		function edacNoticeAjax( functionName = null ) {
-			jQuery.ajax( {
-				url: ajaxurl,
-				method: 'GET',
-				data: {
-					action: functionName,
-					nonce: edacScriptVars.nonce,
-				},
-			} ).done( function( response ) {
-				if ( true === response.success ) {
-					const responseJSON = jQuery.parseJSON( response.data );
-				} else {
-					//console.log(response);
-				}
-			} );
-		}
-
 		if ( jQuery( '#edac-summary-panel' ).length ) {
 			refreshSummaryAndReadability();
 			edacDetailsAjax();

--- a/tests/phpunit/Admin/AdminNoticesTest.php
+++ b/tests/phpunit/Admin/AdminNoticesTest.php
@@ -193,11 +193,10 @@ class AdminNoticesTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'View ArchiveWP Pricing', $message );
 	}
 	/**
-	 * Test that GAAD AJAX handlers are registered.
+	 * Test that the redirect-based dismiss handler is registered on admin_init.
 	 */
-	public function test_gaad_ajax_hooks_are_registered() {
+	public function test_dismiss_notice_handler_is_registered() {
 		$this->admin_notices->init_hooks();
-		$this->assertSame( 10, has_action( 'wp_ajax_edac_gaad_presale_notice_ajax', [ $this->admin_notices, 'edac_gaad_presale_notice_ajax' ] ) );
-		$this->assertSame( 10, has_action( 'wp_ajax_edac_gaad_sale_notice_ajax', [ $this->admin_notices, 'edac_gaad_sale_notice_ajax' ] ) );
+		$this->assertSame( 10, has_action( 'admin_init', [ $this->admin_notices, 'handle_dismiss_notice' ] ) );
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces the JS AJAX dismiss pattern for the GAAD presale, GAAD sale, and Black Friday promotional notices with a nonce-protected GET redirect
- Removes the three promotional notice AJAX handlers and their `wp_ajax_` hooks
- Removes the `edacNoticeAjax` JS function (now unused)
- Adds a single `handle_dismiss_notice()` method on `admin_init` that handles all three notices
- Updates the notice HTML to use `<a class="notice-dismiss">` links (no `is-dismissible`) instead of relying on JS

## Why

The AJAX approach had several failure modes that were difficult to diagnose:

- Silent JS errors when the dismiss AJAX call failed (errors were swallowed with a commented-out `console.log`)
- A timing race between WordPress's `common.js` (which adds `.notice-dismiss` buttons dynamically) and the EDAC script binding click handlers to those buttons
- Potential nonce issues with no user-visible feedback on failure

The redirect approach is simpler and deterministic: clicking the dismiss link navigates to the current page with `?edac_dismiss_notice=gaad_presale&_wpnonce=xxx`, the `handle_dismiss_notice()` handler verifies the nonce via `check_admin_referer()`, saves the option, and redirects back with the parameters stripped. If anything fails, the link simply doesn't work — visible and debuggable rather than silent.

## What reviewers should know

- The `is-dismissible` class is removed from the notice divs; WordPress will no longer add its own dismiss button. Instead each notice outputs `<a href="[dismiss_url]" class="notice-dismiss">` which uses the same WordPress admin CSS for the × button appearance.
- The dismiss causes a page reload (brief, no animation). This is an acceptable tradeoff for a promotional notice.
- The review notice is unaffected — it uses custom buttons with its own AJAX handler, which is unchanged.
- The option keys and cleanup logic (deleting old option keys on dismiss) are preserved exactly.

## Test plan

- [ ] Click dismiss on the GAAD presale notice — page reloads without the notice, and it does not reappear
- [ ] Click dismiss on the GAAD sale notice (visible May 20–22) — same
- [ ] Click dismiss on the Black Friday notice (visible Nov 24 – Dec 3) — same
- [ ] Verify the dismiss link is not present if the dismiss option is already set
- [ ] Verify a tampered/missing nonce results in a `wp_die` error rather than silently failing
- [ ] Confirm the review notice AJAX dismiss is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Promotional notice dismissal moved from background AJAX to a redirect-based, nonce-protected dismiss flow; dismissal persistence and legacy keys handled transparently.
* **UI**
  * Promotional notices (Black Friday, GAAD Presale, GAAD Sale) no longer use the built-in dismissible container and now include nonce-protected dismiss links.
* **Tests**
  * Tests updated to assert the new dismiss handler registration and remove prior AJAX hook assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->