### PR TITLE
Fix: add per-post capability check to add_ignore AJAX handler

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Accessibility Checker
  * Plugin URI:        https://a11ychecker.com
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.42.0
+ * Version:           1.42.1
  * Requires PHP:      7.4
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
@@ -36,7 +36,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Current plugin version.
 if ( ! defined( 'EDAC_VERSION' ) ) {
-	define( 'EDAC_VERSION', '1.42.0' );
+	define( 'EDAC_VERSION', '1.42.1' );
 }
 
 // Current database version.

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -819,17 +819,32 @@ class Ajax {
 		}
 
 		global $wpdb;
-		$table_name           = $wpdb->prefix . 'accessibility_checker';
-		$raw_ids              = isset( $_REQUEST['ids'] ) ? (array) wp_unslash( $_REQUEST['ids'] ) : []; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitization handled below.
-		$ids                  = array_map(
+		$table_name = $wpdb->prefix . 'accessibility_checker';
+		$raw_ids    = isset( $_REQUEST['ids'] ) ? (array) wp_unslash( $_REQUEST['ids'] ) : []; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitization handled below.
+		$ids        = array_map(
 			function ( $value ) {
 				return (int) $value;
 			},
 			$raw_ids
 		); // Sanitizing array elements to integers.
-		$action               = isset( $_REQUEST['ignore_action'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ignore_action'] ) ) : '';
-		$type                 = isset( $_REQUEST['ignore_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ignore_type'] ) ) : '';
-		$siteid               = get_current_blog_id();
+		$action     = isset( $_REQUEST['ignore_action'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ignore_action'] ) ) : '';
+		$type       = isset( $_REQUEST['ignore_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ignore_type'] ) ) : '';
+		$siteid     = get_current_blog_id();
+
+		// Capability check: mirrors the REST /dismiss-issue endpoint.
+		$first_id    = reset( $ids );
+		$valid_table = edac_get_valid_table_name( $table_name );
+		if ( ! $first_id || ! $valid_table ) {
+			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
+		$post_id = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT postid FROM %i WHERE id = %d', $valid_table, $first_id )
+		);
+		if ( ! ( $post_id > 0 && current_user_can( 'edit_post', $post_id ) ) ) {
+			wp_send_json_error( new \WP_Error( '-5', __( 'Permission Denied', 'accessibility-checker' ) ) );
+		}
+
 		$ignre                = ( 'enable' === $action ) ? 1 : 0;
 		$ignre_user           = ( 'enable' === $action ) ? get_current_user_id() : null;
 		$ignre_user_info      = ( 'enable' === $action ) ? get_userdata( $ignre_user ) : '';

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -832,8 +832,9 @@ class Ajax {
 		$siteid     = get_current_blog_id();
 
 		// Capability check: verify edit_post on every post affected by this request.
-		$first_id    = reset( $ids );
-		$valid_table = edac_get_valid_table_name( $table_name );
+		$batch_object = null;
+		$first_id     = reset( $ids );
+		$valid_table  = edac_get_valid_table_name( $table_name );
 
 		if ( ! $first_id || ! $valid_table ) {
 			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
@@ -876,14 +877,8 @@ class Ajax {
 		// instead of IDs. It is a much less efficient query than by IDs - but many IDs run
 		// into request size limits which caused this to not function at all.
 		if ( isset( $_REQUEST['largeBatch'] ) && 'true' === $_REQUEST['largeBatch'] ) {
-			// Get the 'object' from the first id.
-			$first_id = $ids[0];
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- We need to get the latest value, not a cached value.
-			$object = $wpdb->get_var( $wpdb->prepare( 'SELECT object FROM %i WHERE id = %d', $table_name, $first_id ) );
-
-			if ( ! $object ) {
-				wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
-			}
+			// $batch_object was already resolved during the capability check above.
+			$object = $batch_object;
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe variable used for table name, caching not required for one time operation.
 			$wpdb->query( $wpdb->prepare( 'UPDATE %i SET ignre = %d, ignre_user = %d, ignre_date = %s, ignre_comment = %s, ignre_reason = %s, ignre_global = %d WHERE siteid = %d and object = %s', $table_name, $ignre, $ignre_user, $ignre_date, $ignre_comment, $ignre_reason, $ignore_global, $siteid, $object ) );
 		} else {

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -857,7 +857,11 @@ class Ajax {
 			$affected_post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT postid FROM %i WHERE id IN ({$id_placeholders})", $query_args ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- Permission check requires direct lookup.
 		}
 
-		foreach ( (array) $affected_post_ids as $affected_post_id ) {
+		if ( empty( $affected_post_ids ) ) {
+			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+		}
+
+		foreach ( $affected_post_ids as $affected_post_id ) {
 			if ( ! current_user_can( 'edit_post', (int) $affected_post_id ) ) {
 				wp_send_json_error( new \WP_Error( '-5', __( 'Permission Denied', 'accessibility-checker' ) ) );
 			}

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -831,18 +831,35 @@ class Ajax {
 		$type       = isset( $_REQUEST['ignore_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['ignore_type'] ) ) : '';
 		$siteid     = get_current_blog_id();
 
-		// Capability check: mirrors the REST /dismiss-issue endpoint.
+		// Capability check: verify edit_post on every post affected by this request.
 		$first_id    = reset( $ids );
 		$valid_table = edac_get_valid_table_name( $table_name );
+
 		if ( ! $first_id || ! $valid_table ) {
 			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
 		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
-		$post_id = (int) $wpdb->get_var(
-			$wpdb->prepare( 'SELECT postid FROM %i WHERE id = %d', $valid_table, $first_id )
-		);
-		if ( ! ( $post_id > 0 && current_user_can( 'edit_post', $post_id ) ) ) {
-			wp_send_json_error( new \WP_Error( '-5', __( 'Permission Denied', 'accessibility-checker' ) ) );
+
+		if ( isset( $_REQUEST['largeBatch'] ) && 'true' === $_REQUEST['largeBatch'] ) {
+			// largeBatch updates every row sharing the same object string across the site;
+			// collect all distinct postids that would be affected and check each one.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
+			$batch_object = $wpdb->get_var( $wpdb->prepare( 'SELECT object FROM %i WHERE id = %d', $valid_table, $first_id ) );
+			if ( ! $batch_object ) {
+				wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
+			$affected_post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT postid FROM %i WHERE siteid = %d AND object = %s', $valid_table, $siteid, $batch_object ) );
+		} else {
+			// Small batch: look up the post for every supplied ID in one query.
+			$id_placeholders   = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+			$query_args        = array_merge( [ $valid_table ], $ids );
+			$affected_post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT postid FROM %i WHERE id IN ({$id_placeholders})", $query_args ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- Permission check requires direct lookup.
+		}
+
+		foreach ( (array) $affected_post_ids as $affected_post_id ) {
+			if ( ! current_user_can( 'edit_post', (int) $affected_post_id ) ) {
+				wp_send_json_error( new \WP_Error( '-5', __( 'Permission Denied', 'accessibility-checker' ) ) );
+			}
 		}
 
 		$ignre                = ( 'enable' === $action ) ? 1 : 0;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Accessibility Checker ***
 
+2026-05-20 - version 1.42.1
+* Updated - improved permission handling for the ignore functionality.
+
 2026-05-18 - version 1.42.0
 * Updated - add support for role="none" in several of the link and image alt related rules.
 * Updated - added support for named anchors as jump links.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Accessibility Checker ***
 
 2026-05-20 - version 1.42.1
-* Updated - improved permission handling for the ignore functionality.
+* Updated - improved permission handling for the ignore feature.
 
 2026-05-18 - version 1.42.0
 * Updated - add support for role="none" in several of the link and image alt related rules.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-checker",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.",
   "author": "Equalize Digital",
   "license": "GPL-2.0+",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, EAA, WCAG, ADA, WP accessibility, accessibility scanner
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 1.42.0
+Stable tag: 1.42.1
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -278,6 +278,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 11. Enable weekly email reports so you can get updates in your inbox about accessibility status without logging into your website.
 
 == Changelog ==
+
+2026-05-20 - version 1.42.1
+* Updated - improved permission handling for the ignore functionality.
 
 2026-05-18 - version 1.42.0
 * Updated - add support for role="none" in several of the link and image alt related rules.

--- a/readme.txt
+++ b/readme.txt
@@ -280,7 +280,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 2026-05-20 - version 1.42.1
-* Updated - improved permission handling for the ignore functionality.
+* Updated - improved permission handling for the ignore feature.
 
 2026-05-18 - version 1.42.0
 * Updated - add support for role="none" in several of the link and image alt related rules.

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -376,9 +376,10 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
 		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
-		// instance (instanceof check), so substituting an anonymous class no
-		// longer works. Use a real screen and toggle the public property.
-		set_current_screen( 'post' );
+		// instance. Use WP_Screen::get() to obtain one without the side effects
+		// of set_current_screen() (e.g. setting $hook_suffix, $typenow, firing
+		// the current_screen action).
+		$GLOBALS['current_screen']                  = WP_Screen::get( 'post' );
 		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 }

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -375,40 +375,10 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	 * @param bool $is_block_editor Whether the screen should behave as block editor.
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
-		$GLOBALS['current_screen'] = new class( $is_block_editor ) {
-			/**
-			 * True or false whether the screen is block editor.
-			 *
-			 * @var bool
-			 */
-			private $is_block_editor;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param bool $is_block_editor Whether the screen should behave as block editor.
-			 */
-			public function __construct( bool $is_block_editor ) {
-				$this->is_block_editor = $is_block_editor;
-			}
-
-			/**
-			 * Mock is_block_editor method.
-			 *
-			 * @return bool
-			 */
-			public function is_block_editor(): bool {
-				return $this->is_block_editor;
-			}
-
-			/**
-			 * Mock in_admin method.
-			 *
-			 * @return bool
-			 */
-			public function in_admin(): bool {
-				return true;
-			}
-		};
+		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
+		// instance (instanceof check), so substituting an anonymous class no
+		// longer works. Use a real screen and toggle the public property.
+		set_current_screen( 'post' );
+		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 }

--- a/tests/phpunit/Admin/MetaBoxesTest.php
+++ b/tests/phpunit/Admin/MetaBoxesTest.php
@@ -128,32 +128,11 @@ class MetaBoxesTest extends WP_UnitTestCase {
 	 * @param bool $is_block_editor Whether the screen should behave as block editor.
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
-		$GLOBALS['current_screen'] = new class( $is_block_editor ) {
-			/**
-			 * True or false whether the screen is block editor.
-			 *
-			 * @var bool
-			 */
-			private $is_block_editor;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param bool $is_block_editor Whether the screen should behave as block editor.
-			 */
-			public function __construct( bool $is_block_editor ) {
-				$this->is_block_editor = $is_block_editor;
-			}
-
-			/**
-			 * Mock is_block_editor method.
-			 *
-			 * @return bool
-			 */
-			public function is_block_editor(): bool {
-				return $this->is_block_editor;
-			}
-		};
+		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
+		// instance, so we must use a real screen and toggle its public
+		// is_block_editor property rather than substituting an anonymous class.
+		set_current_screen( 'post' );
+		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 
 	/**

--- a/tests/phpunit/Admin/MetaBoxesTest.php
+++ b/tests/phpunit/Admin/MetaBoxesTest.php
@@ -129,9 +129,10 @@ class MetaBoxesTest extends WP_UnitTestCase {
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
 		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
-		// instance, so we must use a real screen and toggle its public
-		// is_block_editor property rather than substituting an anonymous class.
-		set_current_screen( 'post' );
+		// instance. Use WP_Screen::get() to obtain one without the side effects
+		// of set_current_screen() (e.g. setting $hook_suffix, $typenow, firing
+		// the current_screen action).
+		$GLOBALS['current_screen']                  = WP_Screen::get( 'post' );
 		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 


### PR DESCRIPTION
## Summary

- The `edac_insert_ignore_data` AJAX action had no capability check beyond nonce verification, allowing any logged-in user to dismiss accessibility issues on posts they cannot edit
- Added `current_user_can('edit_post', $postid)` for every post affected by the request — both the small-batch (per-ID lookup) and `largeBatch` (object-string site-wide lookup) paths
- Matches the authorization model already enforced by the REST `/dismiss-issue` endpoint

## Details

**Small batch path:** resolves `DISTINCT postid` for all supplied IDs in one query and checks `edit_post` on each before any `UPDATE` runs.

**largeBatch path:** resolves the `object` string from the first ID, then finds all `DISTINCT postid` values site-wide that share that object (matching exactly what the `UPDATE … WHERE object = %s` would touch), and checks `edit_post` on each.

Any failing check returns `wp_send_json_error()` with code `-5 Permission Denied` before the database is written.

## Test plan

- [ ] As an administrator, dismiss an issue — should succeed (`success: true`)
- [ ] As a subscriber/editor without `edit_post` on the target post, send `edac_insert_ignore_data` with a valid nonce — should return `success: false`, code `-5`
- [ ] Send a small batch with mixed post IDs (user can edit first post but not others) — should be rejected
- [ ] Send a `largeBatch` request where the object string appears on posts the user cannot edit — should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened permission checks for bulk "ignore" updates: edit rights are now verified for each affected post and the operation halts if any unauthorized items are found.
  * Improved validation and handling of ignore targets and large-batch updates to reduce partial or invalid changes and improve reliability.

* **Documentation**
  * Version bumped to 1.42.1 and changelog/readme updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->