### PR TITLE
Tests: fix screen mocks for WP 7.0 (instanceof WP_Screen)

### DIFF
--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -376,9 +376,10 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
 		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
-		// instance (instanceof check), so substituting an anonymous class no
-		// longer works. Use a real screen and toggle the public property.
-		set_current_screen( 'post' );
+		// instance. Use WP_Screen::get() to obtain one without the side effects
+		// of set_current_screen() (e.g. setting $hook_suffix, $typenow, firing
+		// the current_screen action).
+		$GLOBALS['current_screen']                  = WP_Screen::get( 'post' );
 		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 }

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -375,40 +375,10 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	 * @param bool $is_block_editor Whether the screen should behave as block editor.
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
-		$GLOBALS['current_screen'] = new class( $is_block_editor ) {
-			/**
-			 * True or false whether the screen is block editor.
-			 *
-			 * @var bool
-			 */
-			private $is_block_editor;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param bool $is_block_editor Whether the screen should behave as block editor.
-			 */
-			public function __construct( bool $is_block_editor ) {
-				$this->is_block_editor = $is_block_editor;
-			}
-
-			/**
-			 * Mock is_block_editor method.
-			 *
-			 * @return bool
-			 */
-			public function is_block_editor(): bool {
-				return $this->is_block_editor;
-			}
-
-			/**
-			 * Mock in_admin method.
-			 *
-			 * @return bool
-			 */
-			public function in_admin(): bool {
-				return true;
-			}
-		};
+		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
+		// instance (instanceof check), so substituting an anonymous class no
+		// longer works. Use a real screen and toggle the public property.
+		set_current_screen( 'post' );
+		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 }

--- a/tests/phpunit/Admin/MetaBoxesTest.php
+++ b/tests/phpunit/Admin/MetaBoxesTest.php
@@ -128,32 +128,11 @@ class MetaBoxesTest extends WP_UnitTestCase {
 	 * @param bool $is_block_editor Whether the screen should behave as block editor.
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
-		$GLOBALS['current_screen'] = new class( $is_block_editor ) {
-			/**
-			 * True or false whether the screen is block editor.
-			 *
-			 * @var bool
-			 */
-			private $is_block_editor;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param bool $is_block_editor Whether the screen should behave as block editor.
-			 */
-			public function __construct( bool $is_block_editor ) {
-				$this->is_block_editor = $is_block_editor;
-			}
-
-			/**
-			 * Mock is_block_editor method.
-			 *
-			 * @return bool
-			 */
-			public function is_block_editor(): bool {
-				return $this->is_block_editor;
-			}
-		};
+		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
+		// instance, so we must use a real screen and toggle its public
+		// is_block_editor property rather than substituting an anonymous class.
+		set_current_screen( 'post' );
+		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 
 	/**

--- a/tests/phpunit/Admin/MetaBoxesTest.php
+++ b/tests/phpunit/Admin/MetaBoxesTest.php
@@ -129,9 +129,10 @@ class MetaBoxesTest extends WP_UnitTestCase {
 	 */
 	private function set_mock_screen( bool $is_block_editor ): void {
 		// As of WP 7.0, get_current_screen() requires an actual WP_Screen
-		// instance, so we must use a real screen and toggle its public
-		// is_block_editor property rather than substituting an anonymous class.
-		set_current_screen( 'post' );
+		// instance. Use WP_Screen::get() to obtain one without the side effects
+		// of set_current_screen() (e.g. setting $hook_suffix, $typenow, firing
+		// the current_screen action).
+		$GLOBALS['current_screen']                  = WP_Screen::get( 'post' );
 		$GLOBALS['current_screen']->is_block_editor = $is_block_editor;
 	}
 


### PR DESCRIPTION
## Summary

WP 7.0 added an `instanceof WP_Screen` guard to `get_current_screen()` (in `wp-admin/includes/screen.php`):

```php
if ( ! $current_screen instanceof WP_Screen ) {
    return null;
}
```

Two of our PHPUnit tests substituted anonymous classes into `$GLOBALS['current_screen']` to simulate block-editor vs classic-editor contexts. Those mocks no longer satisfy the new `instanceof` check, so `Helpers::is_block_editor()` short-circuits to `false` and the following tests fail when run against WP 7.0:

- `EnqueueAdminTest::testSidebarScriptEnqueuesInBlockEditorForScannablePost`
- `EnqueueAdminTest::testSrOnlyFormatEnqueuesOnPostEditor`
- `EnqueueAdminTest::testSrOnlyFormatEnqueuesOnPostNewEditor`
- `EnqueueAdminTest::testSrOnlyFormatEnqueuesInFullSiteEditor`
- `MetaBoxesTest::test_register_meta_boxes_skips_block_editor_when_setting_disabled`

## Fix

`WP_Screen` is `final`, so it can't be subclassed. The cleanest path is to use `set_current_screen()` to install a real `WP_Screen` and toggle its public `is_block_editor` property:

```php
private function set_mock_screen( bool $is_block_editor ): void {
    set_current_screen( 'post' );
    $GLOBALS['current_screen']->is_block_editor = $is_block_editor;
}
```

Bonus: `set_current_screen()` wires up `in_admin` correctly, so the previously-needed `in_admin()` mock method goes away.

## Test plan

- `composer test` (WP 7.0): **839 passed, 14 skipped, 0 failures** — the 5 previously-failing tests now pass and no other tests regress.
- Should remain green on older supported WP versions since `set_current_screen()` and the `is_block_editor` public property both predate WP 7.0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test setup to increase reliability and better reflect WordPress screen behavior, reducing false positives and improving confidence in editor-related features during testing.
  * Adjusted unit tests to use real screen context for more accurate coverage and more robust QA, with no user-facing changes. End-user functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->