### PR TITLE
Fix: skip img empty alt warning when image is inside a button with an accessible name

### DIFF
--- a/src/pageScanner/checks/img-alt-empty-check.js
+++ b/src/pageScanner/checks/img-alt-empty-check.js
@@ -65,12 +65,18 @@ function isInsideValidCaption( node ) {
 	}
 
 	// Check if inside button with valid accessible name
-	const button = node.closest( 'button, [role="button"]' );
+	const button = node.closest( 'button, [role~="button"]' );
 	if ( button ) {
 		if ( button.hasAttribute( 'aria-label' ) && button.getAttribute( 'aria-label' ).trim() !== '' ) {
 			return true;
 		}
+		if ( button.hasAttribute( 'aria-labelledby' ) && button.getAttribute( 'aria-labelledby' ).trim() !== '' ) {
+			return true;
+		}
 		if ( button.hasAttribute( 'title' ) && button.getAttribute( 'title' ).trim() !== '' ) {
+			return true;
+		}
+		if ( button.textContent.trim() !== '' ) {
 			return true;
 		}
 	}

--- a/src/pageScanner/checks/img-alt-empty-check.js
+++ b/src/pageScanner/checks/img-alt-empty-check.js
@@ -64,6 +64,17 @@ function isInsideValidCaption( node ) {
 		}
 	}
 
+	// Check if inside button with valid accessible name
+	const button = node.closest( 'button, [role="button"]' );
+	if ( button ) {
+		if ( button.hasAttribute( 'aria-label' ) && button.getAttribute( 'aria-label' ).trim() !== '' ) {
+			return true;
+		}
+		if ( button.hasAttribute( 'title' ) && button.getAttribute( 'title' ).trim() !== '' ) {
+			return true;
+		}
+	}
+
 	return false;
 }
 

--- a/tests/jest/rules/imgAltEmpty.test.js
+++ b/tests/jest/rules/imgAltEmpty.test.js
@@ -113,13 +113,38 @@ describe( 'Image Alt Empty Validation', () => {
 			shouldPass: true,
 		},
 		{
+			name: 'should pass for img with empty alt inside button with aria-labelledby',
+			html: '<div id="btn-label">Close</div><button aria-labelledby="btn-label"><img src="close.svg" alt=""></button>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for img with empty alt inside button with text content',
+			html: '<button><img src="close.svg" alt=""> Close</button>',
+			shouldPass: true,
+		},
+		{
 			name: 'should pass for img with empty alt inside role="button" element with aria-label',
 			html: '<div role="button" aria-label="Close"><img src="close.svg" alt=""></div>',
 			shouldPass: true,
 		},
 		{
+			name: 'should pass for img with empty alt inside role="button" element with title',
+			html: '<div role="button" title="Close"><img src="close.svg" alt=""></div>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for img with empty alt inside multi-value role="button" element with aria-label',
+			html: '<div role="button presentation" aria-label="Close"><img src="close.svg" alt=""></div>',
+			shouldPass: true,
+		},
+		{
 			name: 'should fail for img with empty alt inside button without accessible name',
 			html: '<button><img src="close.svg" alt=""></button>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for img with empty alt inside multi-value role="button" element without accessible name',
+			html: '<div role="button presentation"><img src="close.svg" alt=""></div>',
 			shouldPass: false,
 		},
 	];

--- a/tests/jest/rules/imgAltEmpty.test.js
+++ b/tests/jest/rules/imgAltEmpty.test.js
@@ -100,6 +100,28 @@ describe( 'Image Alt Empty Validation', () => {
 			html: '<img src="smiley.jpg" alt="" class="wp-smiley">',
 			shouldPass: true,
 		},
+
+		// Button context - image with empty alt inside button with accessible name
+		{
+			name: 'should pass for img with empty alt inside button with aria-label',
+			html: '<button aria-label="Close"><img src="close.svg" alt=""></button>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for img with empty alt inside button with title',
+			html: '<button title="Close"><img src="close.svg" alt=""></button>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for img with empty alt inside role="button" element with aria-label',
+			html: '<div role="button" aria-label="Close"><img src="close.svg" alt=""></div>',
+			shouldPass: true,
+		},
+		{
+			name: 'should fail for img with empty alt inside button without accessible name',
+			html: '<button><img src="close.svg" alt=""></button>',
+			shouldPass: false,
+		},
 	];
 
 	testCases.forEach( ( testCase ) => {


### PR DESCRIPTION
## Summary

- Adds an exception to the `img_alt_empty` check so images with `alt=""` inside a `<button>` (or `[role="button"]`) that has a non-empty `aria-label` or `title` are no longer flagged as violations.
- Adds 4 new Jest test cases covering the button-with-aria-label, button-with-title, role="button"-with-aria-label, and button-with-no-accessible-name scenarios.

## Why

Closes #1700. An image with `alt=""` inside a labelled button is intentionally decorative — the button's `aria-label` already provides the accessible name for the interactive element. Flagging this as a "needs review" issue is a false positive.

This mirrors the existing exception already in place for `<a>` elements: if an anchor has `aria-label`, `title`, or sufficient text content, the empty-alt image inside it is skipped. The same logic applies to buttons.

**Example that was incorrectly flagged:**
```html
<button aria-label="Close" class="cky-banner-btn-close">
  <img alt="" src="close.svg">
</button>
```

## What reviewers should know

- The fix is in `src/pageScanner/checks/img-alt-empty-check.js` inside the existing `isInsideValidCaption` helper (which already handles anchors, figures, and WP captions).
- A button **without** an accessible name still triggers the warning — only labelled buttons are exempted.
- All 18 Jest tests pass.

Fixes PRO-811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images inside button-like controls that have an accessible name (aria-label, aria-labelledby, title, or visible text) are now treated as having sufficient captioning for accessibility checks, reducing false empty-alt warnings.

* **Tests**
  * Added test coverage for image validation in button contexts, covering cases with and without accessible names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->