### PR TITLE
Feature: add Equalize Digital tab to WP 7.0+ Plugins screen

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -14,6 +14,7 @@ use EDAC\Admin\Post_Save;
 use EqualizeDigital\AccessibilityChecker\Admin\Upgrade_Promotion;
 use EqualizeDigital\AccessibilityChecker\Admin\Admin_Footer_Text;
 use EqualizeDigital\AccessibilityChecker\Admin\Activation_Redirect;
+use EqualizeDigital\AccessibilityChecker\Admin\Plugin_List_Tab;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -80,6 +80,9 @@ class Admin {
 		$plugin_row_meta = new Plugin_Row_Meta();
 		$plugin_row_meta->init_hooks();
 
+		$plugin_list_tab = new Plugin_List_Tab();
+		$plugin_list_tab->init_hooks();
+
 		$admin_footer_text = new Admin_Footer_Text();
 		$admin_footer_text->init();
 

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -5,7 +5,7 @@
  * @package Accessibility_Checker
  */
 
-namespace EDAC\Admin;
+namespace EqualizeDigital\AccessibilityChecker\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -90,18 +90,18 @@ class Plugin_List_Tab {
 	 *
 	 * @since 1.43.0
 	 *
-	 * @param string $text  The current status text.
-	 * @param int    $count The number of plugins with this status.
-	 * @param string $type  The status type slug.
+	 * @param string $text   The current status text.
+	 * @param int    $_count Unused — "Equalize Digital" does not inflect by count.
+	 * @param string $type   The status type slug.
 	 *
 	 * @return string The status text.
 	 */
-	public function get_status_text( $text, $count, $type ) {
+	public function get_status_text( $text, $_count, $type ) {
 		if ( self::STATUS_SLUG !== $type ) {
 			return $text;
 		}
 
-		return \_nx( 'Equalize Digital', 'Equalize Digital', $count, 'plugin status', 'accessibility-checker' );
+		return \_\_( 'Equalize Digital', 'accessibility-checker' );
 	}
 
 	/**

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -101,8 +101,7 @@ class Plugin_List_Tab {
 			return $text;
 		}
 
-		// translators: %s: Number of plugins.
-		return \_nx( 'Equalize Digital <span class="count">(%s)</span>', 'Equalize Digital <span class="count">(%s)</span>', $count, 'plugin status', 'accessibility-checker' );
+		return \_nx( 'Equalize Digital', 'Equalize Digital', $count, 'plugin status', 'accessibility-checker' );
 	}
 
 	/**

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Plugin List Tab class file for the Accessibility Checker plugin.
+ *
+ * @package Accessibility_Checker
+ */
+
+namespace EDAC\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers an "Equalize Digital" tab on the WordPress Plugins screen.
+ *
+ * The tab appears when 2 or more Equalize Digital plugins are installed,
+ * using the plugins_list and plugins_list_status_text filters added in WP 7.0.
+ *
+ * @since 1.43.0
+ */
+class Plugin_List_Tab {
+
+	/**
+	 * Minimum number of Equalize Digital plugins required to show the tab.
+	 *
+	 * @var int
+	 */
+	const MINIMUM_FOR_TAB = 2;
+
+	/**
+	 * The status slug used for the Equalize Digital tab.
+	 *
+	 * @var string
+	 */
+	const STATUS_SLUG = 'equalize-digital';
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @since 1.43.0
+	 *
+	 * @return void
+	 */
+	public function init_hooks(): void {
+		global $wp_version;
+
+		if ( \version_compare( $wp_version, '7.0-alpha0', '<' ) ) {
+			return;
+		}
+
+		add_filter( 'plugins_list', [ $this, 'filter_plugins_list' ] );
+		add_filter( 'plugins_list_status_text', [ $this, 'get_status_text' ], 10, 3 );
+	}
+
+	/**
+	 * Filters the plugins list to add an Equalize Digital group.
+	 *
+	 * Only adds the group when 2 or more Equalize Digital plugins are installed.
+	 *
+	 * @since 1.43.0
+	 *
+	 * @param array<string, array<string, array<string, string>>> $plugins The plugins list keyed by status.
+	 *
+	 * @return array<string, array<string, array<string, string>>> The filtered plugins list.
+	 */
+	public function filter_plugins_list( $plugins ) {
+		if ( ! \is_array( $plugins ) || ! isset( $plugins['all'] ) ) {
+			return $plugins;
+		}
+
+		$equalize_digital_plugins = [];
+		foreach ( $plugins['all'] as $plugin_file => $plugin_data ) {
+			if ( $this->is_equalize_digital_plugin( $plugin_data ) ) {
+				$equalize_digital_plugins[ $plugin_file ] = $plugin_data;
+			}
+		}
+
+		if ( \count( $equalize_digital_plugins ) < self::MINIMUM_FOR_TAB ) {
+			return $plugins;
+		}
+
+		$plugins[ self::STATUS_SLUG ] = $equalize_digital_plugins;
+
+		return $plugins;
+	}
+
+	/**
+	 * Returns the label text for the Equalize Digital tab.
+	 *
+	 * @since 1.43.0
+	 *
+	 * @param string $text  The current status text.
+	 * @param int    $count The number of plugins with this status.
+	 * @param string $type  The status type slug.
+	 *
+	 * @return string The status text.
+	 */
+	public function get_status_text( $text, $count, $type ) {
+		if ( self::STATUS_SLUG !== $type ) {
+			return $text;
+		}
+
+		return \_nx( 'Equalize Digital', 'Equalize Digital', $count, 'plugin status', 'accessibility-checker' );
+	}
+
+	/**
+	 * Determines whether a plugin belongs to Equalize Digital.
+	 *
+	 * @since 1.43.0
+	 *
+	 * @param array<string, string> $plugin_data The plugin header data.
+	 *
+	 * @return bool
+	 */
+	private function is_equalize_digital_plugin( $plugin_data ): bool {
+		if ( ! \is_array( $plugin_data ) || empty( $plugin_data['AuthorURI'] ) ) {
+			return false;
+		}
+
+		return false !== \strpos( $plugin_data['AuthorURI'], 'equalizedigital.com' );
+	}
+}

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -65,7 +65,7 @@ class Plugin_List_Tab {
 	 * @return array<string, array<string, array<string, string>>> The filtered plugins list.
 	 */
 	public function filter_plugins_list( $plugins ) {
-		if ( ! \is_array( $plugins ) || ! isset( $plugins['all'] ) ) {
+		if ( ! \is_array( $plugins ) || ! isset( $plugins['all'] ) || ! \is_array( $plugins['all'] ) ) {
 			return $plugins;
 		}
 
@@ -101,7 +101,8 @@ class Plugin_List_Tab {
 			return $text;
 		}
 
-		return \_nx( 'Equalize Digital', 'Equalize Digital', $count, 'plugin status', 'accessibility-checker' );
+		// translators: %s: Number of plugins.
+		return \_nx( 'Equalize Digital <span class="count">(%s)</span>', 'Equalize Digital <span class="count">(%s)</span>', $count, 'plugin status', 'accessibility-checker' );
 	}
 
 	/**
@@ -118,6 +119,6 @@ class Plugin_List_Tab {
 			return false;
 		}
 
-		return false !== \strpos( $plugin_data['AuthorURI'], 'equalizedigital.com' );
+		return false !== \stripos( $plugin_data['AuthorURI'], 'equalizedigital.com' );
 	}
 }

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -26,7 +26,7 @@ class Plugin_List_Tab {
 	 *
 	 * @var int
 	 */
-	const MINIMUM_FOR_TAB = 2;
+	const MINIMUM_FOR_TAB = 3;
 
 	/**
 	 * The status slug used for the Equalize Digital tab.

--- a/admin/class-plugin-list-tab.php
+++ b/admin/class-plugin-list-tab.php
@@ -101,7 +101,7 @@ class Plugin_List_Tab {
 			return $text;
 		}
 
-		return \_\_( 'Equalize Digital', 'accessibility-checker' );
+		return \__( 'Equalize Digital', 'accessibility-checker' );
 	}
 
 	/**


### PR DESCRIPTION
## What changed

Adds a new `Plugin_List_Tab` class (`admin/class-plugin-list-tab.php`) and wires it into `Admin::init()`.

The class hooks into two filters introduced in WordPress 7.0:

- **`plugins_list`** — appends an `equalize-digital` status group containing every installed plugin whose `AuthorURI` contains `equalizedigital.com`. The tab only appears when 2 or more such plugins are found (matching the convention used by Yoast and others).
- **`plugins_list_status_text`** — returns the "Equalize Digital" label for that tab.

Both hooks are version-gated behind `version_compare( $wp_version, '7.0-alpha0', '<' )` so the behaviour is a no-op on older WordPress installs.

## Why

WordPress 7.0 added `plugins_list` and `plugins_list_status_text` to let plugin authors surface a branded tab on the Plugins screen for their suite of plugins. This gives Equalize Digital users a convenient way to filter and view all Equalize Digital plugins in one place.

## Reviewer notes

- Detection is done via `AuthorURI` containing `equalizedigital.com` — reliable across both the free and Pro plugins without hardcoding slugs.
- Minimum threshold is 2 plugins (`MINIMUM_FOR_TAB`), so the tab won't appear for users who only have one Equalize Digital plugin installed.
- No changes to existing behaviour on WordPress < 7.0.

## Test plan

- [ ] Install two or more Equalize Digital plugins on a WordPress 7.0+ site and verify the "Equalize Digital" tab appears on the Plugins screen
- [ ] Verify the tab correctly filters to only Equalize Digital plugins
- [ ] Confirm no tab appears when only one Equalize Digital plugin is installed
- [ ] Confirm no regressions on WordPress < 7.0 (hooks should not be registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a custom "Equalize Digital" tab on the WordPress Plugins screen (visible on WordPress 7.0+ when three or more Equalize Digital plugins are installed).
  * Shows a plural-aware, accessibility-friendly status label that reflects the number of grouped plugins and reduces noise by requiring a higher threshold before grouping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->