### PR TITLE
🧪 POC: Per-rule exclusions config for JS scanner checks

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -133,18 +133,19 @@ class Enqueue_Admin {
 					'edac-editor-app',
 					'edac_editor_app',
 					[
-						'postID'       => $post_id,
-						'edacUrl'      => esc_url_raw( get_site_url() ),
-						'edacApiUrl'   => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
-						'baseurl'      => plugin_dir_url( __DIR__ ),
-						'active'       => $active,
-						'pro'          => $pro,
-						'debug'        => $debug,
-						'scanUrl'      => $scan_url,
-						'maxAltLength' => max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) ),
-						'version'      => EDAC_VERSION,
-						'postStatus'   => get_post_status( $post_id ),
-						'restNonce'    => wp_create_nonce( 'wp_rest' ),
+						'postID'         => $post_id,
+						'edacUrl'        => esc_url_raw( get_site_url() ),
+						'edacApiUrl'     => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
+						'baseurl'        => plugin_dir_url( __DIR__ ),
+						'active'         => $active,
+						'pro'            => $pro,
+						'debug'          => $debug,
+						'scanUrl'        => $scan_url,
+						'maxAltLength'   => max( 1, absint( apply_filters( 'edac_max_alt_length', 300 ) ) ),
+						'ruleExclusions' => self::get_rule_exclusions(),
+						'version'        => EDAC_VERSION,
+						'postStatus'     => get_post_status( $post_id ),
+						'restNonce'      => wp_create_nonce( 'wp_rest' ),
 					]
 				);
 
@@ -447,5 +448,20 @@ class Enqueue_Admin {
 	 */
 	private static function get_current_page_slug(): ?string {
 		return isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display only.
+	}
+
+	/**
+	 * Build a map of rule slug => exclusion selectors for rules that declare exclusions.
+	 *
+	 * @return array<string, string[]>
+	 */
+	private static function get_rule_exclusions(): array {
+		$exclusions = [];
+		foreach ( edac_register_rules() as $rule ) {
+			if ( ! empty( $rule['exclusions'] ) ) {
+				$exclusions[ $rule['slug'] ] = $rule['exclusions'];
+			}
+		}
+		return $exclusions;
 	}
 }

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -455,10 +455,10 @@ class Enqueue_Admin {
 	 *
 	 * @return array<string, string[]>
 	 */
-	private static function get_rule_exclusions(): array {
+	public static function get_rule_exclusions(): array {
 		$exclusions = [];
 		foreach ( edac_register_rules() as $rule ) {
-			if ( ! empty( $rule['exclusions'] ) ) {
+			if ( ! empty( $rule['slug'] ) && ! empty( $rule['exclusions'] ) && is_array( $rule['exclusions'] ) ) {
 				$exclusions[ $rule['slug'] ] = $rule['exclusions'];
 			}
 		}

--- a/includes/classes/Rules/Rule/AriaHiddenRule.php
+++ b/includes/classes/Rules/Rule/AriaHiddenRule.php
@@ -62,6 +62,11 @@ class AriaHiddenRule implements RuleInterface {
 			'combines'              => [
 				'aria_hidden_validation',
 			],
+			'exclusions'            => [
+				'.wp-block-spacer',
+				'.wp-block-cover__background.has-background-dim',
+				'.wp-block-post-featured-image__overlay.has-background-dim',
+			],
 		];
 	}
 }

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -163,6 +163,7 @@ class Enqueue_Frontend {
 					'editorLink'       => get_edit_post_link( $post_id ),
 					'scannerBundleUrl' => esc_url_raw( add_query_arg( 'ver', EDAC_VERSION, plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/pageScanner.bundle.js' ) ),
 					'adminThemeColor'  => self::get_admin_theme_color(),
+					'ruleExclusions'   => \EDAC\Admin\Enqueue_Admin::get_rule_exclusions(),
 				]
 			);
 

--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -112,6 +112,7 @@ const injectIframe = ( previewUrl, postID ) => {
 				}
 
 				iframeDocument.defaultView.scanOptions = {
+					...iframeDocument.defaultView.scanOptions,
 					maxAltLength: window.edac_editor_app.maxAltLength,
 					ruleExclusions: window.edac_editor_app.ruleExclusions,
 				};

--- a/src/editorApp/checkPage.js
+++ b/src/editorApp/checkPage.js
@@ -106,15 +106,14 @@ const injectIframe = ( previewUrl, postID ) => {
 		body.setAttribute( 'data-iframe-post-id', postID );
 
 		if ( iframeDocument ) {
-			if ( window?.edac_editor_app?.maxAltLength ) {
-				// if the frame doesn't have window.scanOptions then create is as an object.
+			if ( window?.edac_editor_app?.maxAltLength || window?.edac_editor_app?.ruleExclusions ) {
 				if ( ! iframeDocument.defaultView.scanOptions ) {
 					iframeDocument.defaultView.scanOptions = {};
 				}
 
-				// set the maxAlthLength for the scanOptions.
 				iframeDocument.defaultView.scanOptions = {
 					maxAltLength: window.edac_editor_app.maxAltLength,
+					ruleExclusions: window.edac_editor_app.ruleExclusions,
 				};
 			}
 

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -1779,6 +1779,14 @@ class AccessibilityCheckerHighlight {
 		const scriptId = 'edac-accessibility-checker-scanner-script';
 
 		return new Promise( ( resolve, reject ) => {
+			// Ensure rule exclusions from the localized config are available to the scanner.
+			if ( window.edacFrontendHighlighterApp?.ruleExclusions ) {
+				window.scanOptions = {
+					...window.scanOptions,
+					ruleExclusions: window.edacFrontendHighlighterApp.ruleExclusions,
+				};
+			}
+
 			const runScan = () => {
 				self._runScanOrShowError( densityMetrics )
 					.then( resolve )

--- a/src/pageScanner/checks/aria-hidden-valid-usage.js
+++ b/src/pageScanner/checks/aria-hidden-valid-usage.js
@@ -14,16 +14,19 @@ const srClasses = [
 
 export default {
 	id: 'aria_hidden_valid_usage',
-	evaluate: ( node ) => {
+	evaluate: ( node, options = {} ) => {
 		// Check if element is hidden with CSS
 		const computedStyle = window.getComputedStyle( node );
 		if ( computedStyle.display === 'none' || computedStyle.visibility === 'hidden' ) {
 			return true;
 		}
 
-		// Check for valid element properties
-		if ( node.classList.contains( 'wp-block-spacer' ) ) {
-			return true;
+		// Check against configured exclusion selectors.
+		const exclusions = options?.exclusions || [];
+		for ( const selector of exclusions ) {
+			if ( node.matches( selector ) ) {
+				return true;
+			}
 		}
 
 		const role = node.getAttribute( 'role' );

--- a/src/pageScanner/checks/aria-hidden-valid-usage.js
+++ b/src/pageScanner/checks/aria-hidden-valid-usage.js
@@ -22,10 +22,14 @@ export default {
 		}
 
 		// Check against configured exclusion selectors.
-		const exclusions = options?.exclusions || [];
+		const exclusions = Array.isArray( options?.exclusions ) ? options.exclusions : [];
 		for ( const selector of exclusions ) {
-			if ( node.matches( selector ) ) {
-				return true;
+			try {
+				if ( node.matches( selector ) ) {
+					return true;
+				}
+			} catch ( e ) {
+				// Skip malformed selectors so the scan remains stable.
 			}
 		}
 

--- a/src/pageScanner/config/rules.js
+++ b/src/pageScanner/config/rules.js
@@ -119,7 +119,12 @@ export const checksArray = [
 	hasAmbiguousText,
 	anchorExists,
 	imageInputHasAlt,
-	ariaHiddenValidUsage,
+	{
+		...ariaHiddenValidUsage,
+		options: {
+			exclusions: window?.scanOptions?.ruleExclusions?.aria_hidden || [],
+		},
+	},
 	tableHasHeaders,
 	headingIsEmpty,
 	transcriptMissing,

--- a/tests/jest/rules/ariaHiddenValid.test.js
+++ b/tests/jest/rules/ariaHiddenValid.test.js
@@ -9,10 +9,23 @@ beforeAll( async () => {
 	const ariaHiddenRule = ariaHiddenRuleModule.default;
 	const ariaHiddenCheck = ariaHiddenCheckModule.default;
 
-	// Configure axe with the imported rules
+	// Configure axe with the imported rules.
+	// Pass the WordPress-specific exclusions the same way config/rules.js does
+	// at runtime via window.scanOptions, so tests reflect production behaviour.
 	axe.configure( {
 		rules: [ ariaHiddenRule ],
-		checks: [ ariaHiddenCheck ],
+		checks: [
+			{
+				...ariaHiddenCheck,
+				options: {
+					exclusions: [
+						'.wp-block-spacer',
+						'.wp-block-cover__background.has-background-dim',
+						'.wp-block-post-featured-image__overlay.has-background-dim',
+					],
+				},
+			},
+		],
 	} );
 } );
 
@@ -72,6 +85,16 @@ describe( 'Aria Hidden Validation', () => {
 		{
 			name: 'should pass for wp-block-spacer class',
 			html: '<div class="wp-block-spacer" aria-hidden="true"></div>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for cover block background dim overlay',
+			html: '<span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for post featured image overlay with dim',
+			html: '<span class="wp-block-post-featured-image__overlay has-background-dim has-background-dim-10 has-contrast-2-background-color" style="border-radius:5px" aria-hidden="true"></span>',
 			shouldPass: true,
 		},
 		{


### PR DESCRIPTION
## Summary

- Adds an `exclusions` key to PHP rule configs, allowing WordPress-specific CSS selectors to be declared at the rule level rather than hardcoded in generic JS check logic
- Threads those exclusions through the existing `scanOptions` pipeline (PHP → `wp_localize_script` → iframe `window.scanOptions`) so the JS check can apply them via `node.matches()`
- Removes the hardcoded `wp-block-spacer` check from `aria-hidden-valid-usage.js` and replaces it with the new config-driven approach; adds the two new WP core block overlay patterns from issue #567 at the same time

## Motivation

The JS scanner rules are used as a standalone package outside of WordPress. Hardcoding WordPress class names (like `wp-block-spacer`) directly in the JS checks pollutes generic accessibility logic with framework-specific knowledge. This approach keeps the JS checks clean and moves all WordPress-specific exclusion knowledge into the PHP rule config where it belongs.

## How it works

**PHP rule config** (`AriaHiddenRule.php`):
```php
'exclusions' => [
    '.wp-block-spacer',
    '.wp-block-cover__background.has-background-dim',
    '.wp-block-post-featured-image__overlay.has-background-dim',
],
```

**Collected at enqueue time** (`class-enqueue-admin.php`) and passed as `ruleExclusions` in `edac_editor_app`.

**Forwarded to iframe** (`checkPage.js`) via `window.scanOptions.ruleExclusions`.

**Applied in JS check** (`aria-hidden-valid-usage.js`) using `node.matches(selector)` — no WordPress knowledge in the check itself.

## Test plan

- [ ] Verify cover block background dim spans no longer trigger aria-hidden warnings
- [ ] Verify post featured image overlay spans no longer trigger aria-hidden warnings  
- [ ] Verify legitimate aria-hidden misuse still flags correctly
- [ ] Verify `wp-block-spacer` elements still pass (now via config rather than hardcoded)
- [ ] Confirm the JS package used outside WordPress still functions with an empty exclusions array

Closes #567

Fixes PRO-475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable exclusions for aria-hidden validation, enabling administrators to exclude specific elements and block types from accessibility checks, providing more tailored validation results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->