### PR TITLE
Fix: FK reading grade of 0 < x < 1 collapses to 0 (normalize to 1)

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -80,7 +80,7 @@ class Ajax {
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
 			$text_statistics          = new \DaveChild\TextStatistics\TextStatistics();
-			$simplified_summary_grade = (int) floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
+			$simplified_summary_grade = edac_normalize_fk_grade( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
 		}
 		$simplified_summary_grade_failed = ( $simplified_summary_grade > 9 ) ? true : false;
 
@@ -671,7 +671,7 @@ class Ajax {
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
 			$text_statistics          = new \DaveChild\TextStatistics\TextStatistics();
-			$simplified_summary_grade = (int) floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
+			$simplified_summary_grade = edac_normalize_fk_grade( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
 		}
 
 		$simplified_summary_grade_failed = ( $simplified_summary_grade > 9 ) ? true : false;

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1077,7 +1077,7 @@ class REST_Api {
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
 			$text_statistics          = new \DaveChild\TextStatistics\TextStatistics();
-			$simplified_summary_grade = (int) floor( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
+			$simplified_summary_grade = edac_normalize_fk_grade( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
 		}
 
 		$simplified_summary_grade_failed      = $simplified_summary_grade >= 9;

--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -290,9 +290,7 @@ class Summary_Generator {
 		$content_grade = 0;
 
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
-			$content_grade = floor(
-				( new \DaveChild\TextStatistics\TextStatistics() )->fleschKincaidGradeLevel( $content )
-			);
+			$content_grade = edac_normalize_fk_grade( ( new \DaveChild\TextStatistics\TextStatistics() )->fleschKincaidGradeLevel( $content ) );
 		}
 
 		return (int) round( $content_grade );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -947,7 +947,7 @@ function edac_format_datetime_from_utc( string $utc_datetime ): string {
  * very simple content as "not calculable." Values above 0 but below 1 are
  * normalized to 1 so that compliance checks treat them correctly.
  *
- * @since 1.44.0
+ * @since x.x.x
  *
  * @param float|bool|null $fk_grade Raw Flesch-Kincaid grade level returned by the library.
  * @return int Normalized grade: 0 when the library returned 0, false, or null (not enough content),

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -941,6 +941,26 @@ function edac_format_datetime_from_utc( string $utc_datetime ): string {
 }
 
 /**
+ * Normalize a raw Flesch-Kincaid grade level float to a whole-number grade.
+ *
+ * `floor()` alone collapses any FK value in (0, 1) to 0, which misrepresents
+ * very simple content as "not calculable." Values above 0 but below 1 are
+ * normalized to 1 so that compliance checks treat them correctly.
+ *
+ * @since 1.44.0
+ *
+ * @param float $fk_grade Raw Flesch-Kincaid grade level returned by the library.
+ * @return int Normalized grade: 0 when the library returned 0 (not enough content),
+ *             otherwise max(1, floor($fk_grade)).
+ */
+function edac_normalize_fk_grade( float $fk_grade ): int {
+	if ( $fk_grade <= 0 ) {
+		return 0;
+	}
+	return max( 1, (int) floor( $fk_grade ) );
+}
+
+/**
  * Determine the icon name to display for the readability panel.
  *
  * PHP equivalent of the JS getPanelIcon() helper used in the readability sidebar panel.

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -949,11 +949,12 @@ function edac_format_datetime_from_utc( string $utc_datetime ): string {
  *
  * @since 1.44.0
  *
- * @param float $fk_grade Raw Flesch-Kincaid grade level returned by the library.
- * @return int Normalized grade: 0 when the library returned 0 (not enough content),
+ * @param float|bool|null $fk_grade Raw Flesch-Kincaid grade level returned by the library.
+ * @return int Normalized grade: 0 when the library returned 0, false, or null (not enough content),
  *             otherwise max(1, floor($fk_grade)).
  */
-function edac_normalize_fk_grade( float $fk_grade ): int {
+function edac_normalize_fk_grade( $fk_grade ): int {
+	$fk_grade = (float) $fk_grade;
 	if ( $fk_grade <= 0 ) {
 		return 0;
 	}

--- a/tests/phpunit/helper-functions/NormalizeFkGradeTest.php
+++ b/tests/phpunit/helper-functions/NormalizeFkGradeTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tests for the edac_normalize_fk_grade helper.
+ *
+ * @package Accessibility_Checker
+ * @since 1.44.0
+ */
+
+/**
+ * Tests for edac_normalize_fk_grade.
+ *
+ * @covers ::edac_normalize_fk_grade
+ * @since 1.44.0
+ */
+class NormalizeFkGradeTest extends WP_UnitTestCase {
+
+	/**
+	 * Verifies FK grade normalization for the given input/expected pair.
+	 *
+	 * @dataProvider data_normalize_fk_grade
+	 *
+	 * @param float $input    Raw FK grade float.
+	 * @param int   $expected Expected normalized integer grade.
+	 */
+	public function test_normalize_fk_grade( float $input, int $expected ) {
+		$this->assertSame( $expected, edac_normalize_fk_grade( $input ) );
+	}
+
+	/**
+	 * Data provider for test_normalize_fk_grade.
+	 *
+	 * @return array<string, array{float, int}>
+	 */
+	public static function data_normalize_fk_grade(): array {
+		return [
+			'zero stays zero'            => [ 0.0, 0 ],
+			'negative stays zero'        => [ -1.5, 0 ],
+			'fractional above zero is 1' => [ 0.01, 1 ],
+			'mid-fraction is 1'          => [ 0.5, 1 ],
+			'just below 1.0 is 1'        => [ 0.99, 1 ],
+			'exactly 1.0 is 1'           => [ 1.0, 1 ],
+			'1.9 floors to 1'            => [ 1.9, 1 ],
+			'9.0 is 9'                   => [ 9.0, 9 ],
+			'9.9 floors to 9'            => [ 9.9, 9 ],
+			'10.0 is 10'                 => [ 10.0, 10 ],
+			'whole grade passes through' => [ 5.0, 5 ],
+		];
+	}
+}

--- a/tests/phpunit/helper-functions/NormalizeFkGradeTest.php
+++ b/tests/phpunit/helper-functions/NormalizeFkGradeTest.php
@@ -19,17 +19,17 @@ class NormalizeFkGradeTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_normalize_fk_grade
 	 *
-	 * @param float $input    Raw FK grade float.
-	 * @param int   $expected Expected normalized integer grade.
+	 * @param float|bool|null $input    Raw FK grade value (float, or false/null from the library on empty content).
+	 * @param int             $expected Expected normalized integer grade.
 	 */
-	public function test_normalize_fk_grade( float $input, int $expected ) {
+	public function test_normalize_fk_grade( $input, int $expected ) {
 		$this->assertSame( $expected, edac_normalize_fk_grade( $input ) );
 	}
 
 	/**
 	 * Data provider for test_normalize_fk_grade.
 	 *
-	 * @return array<string, array{float, int}>
+	 * @return array<string, array{mixed, int}>
 	 */
 	public static function data_normalize_fk_grade(): array {
 		return [
@@ -44,6 +44,8 @@ class NormalizeFkGradeTest extends WP_UnitTestCase {
 			'9.9 floors to 9'            => [ 9.9, 9 ],
 			'10.0 is 10'                 => [ 10.0, 10 ],
 			'whole grade passes through' => [ 5.0, 5 ],
+			'false returns zero'         => [ false, 0 ],
+			'null returns zero'          => [ null, 0 ],
 		];
 	}
 }

--- a/tests/phpunit/helper-functions/NormalizeFkGradeTest.php
+++ b/tests/phpunit/helper-functions/NormalizeFkGradeTest.php
@@ -3,14 +3,14 @@
  * Tests for the edac_normalize_fk_grade helper.
  *
  * @package Accessibility_Checker
- * @since 1.44.0
+ * @since x.x.x
  */
 
 /**
  * Tests for edac_normalize_fk_grade.
  *
  * @covers ::edac_normalize_fk_grade
- * @since 1.44.0
+ * @since x.x.x
  */
 class NormalizeFkGradeTest extends WP_UnitTestCase {
 


### PR DESCRIPTION
Fixes #1497

## Description

`floor()` applied directly to a Flesch-Kincaid grade in the range (0, 1) silently collapses it to `0`. That `0` is then interpreted as "not enough content to determine a reading level," so content with a legitimately simple FK grade (e.g. 0.5 or 0.8) is misrepresented as uncalculable and incorrectly flagged as failing.

## What changed

Introduces `edac_normalize_fk_grade( float $fk_grade ): int` in `includes/helper-functions.php`:

- Returns `0` when the library returns ≤ 0 (truly not enough content)
- Returns `max(1, floor($fk_grade))` otherwise — so any positive sub-1 value becomes grade 1

Replaces the raw `floor()` pattern at all four affected call sites:

| File | Location |
|------|----------|
| `admin/class-ajax.php` | Classic metabox readability (line ~83) |
| `admin/class-ajax.php` | Sidebar AJAX readability (line ~674) |
| `includes/classes/class-summary-generator.php` | `calculate_content_grade()` |
| `includes/classes/class-rest-api.php` | `get_readability_data()` |

## Tests

Adds `tests/phpunit/helper-functions/NormalizeFkGradeTest.php` with 11 data-driven cases covering: exact zero, negatives, the 0.01–0.99 boundary, 1.0, mid-grade values, and grades above 9.

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simplified summary and readability reading-level calculations by normalizing Flesch–Kincaid grade values more consistently before applying “too high”/failure logic, yielding more accurate results for fractional and very low grade values.
* **Tests**
  * Added automated PHPUnit coverage for the grade-normalization behavior, including zero/negative inputs and boundary/rounding cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->