### PR TITLE
Email Reports: Update dashboard link destination to license keys page

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -98,7 +98,7 @@ class AccessibilityReportsPage implements PageInterface {
 			]
 		);
 
-		$dashboard_url       = edac_link_wrapper( 'https://my.equalizedigital.com/', 'accessibility-reports', 'account', false );
+		$dashboard_url       = edac_link_wrapper( 'https://my.equalizedigital.com/license-keys/', 'accessibility-reports', 'account', false );
 		$signup_url          = edac_link_wrapper( 'https://my.equalizedigital.com/sign-up/', 'accessibility-reports', 'signup', false );
 		$privacy_url         = edac_link_wrapper( 'https://equalizedigital.com/privacy-policy/', 'accessibility-reports', 'privacy', false );
 		$data_processing_url = edac_link_wrapper( 'https://equalizedigital.com/data-terms/', 'accessibility-reports', 'dpa', false );


### PR DESCRIPTION
## Summary

- Updates the "Your key is in your dashboard" link on the Email Reports settings page to point directly to `https://my.equalizedigital.com/license-keys/` instead of the generic dashboard root (`https://my.equalizedigital.com/`).

## Why

Takes users directly to where their license key lives, reducing friction and support questions. Requested in [#1662](https://github.com/equalizedigital/accessibility-checker/issues/1662).

## Changes

- `admin/AdminPage/AccessibilityReportsPage.php` — updated `$dashboard_url` in `AccessibilityReportsPage`.

## Testing

1. Go to **Settings → Accessibility Reports** (`/wp-admin/admin.php?page=accessibility_checker_settings&tab=accessibility-reports`).
2. Locate the text *"Got the plugin from Equalize Digital? Your key is in your dashboard."*
3. Click **dashboard** — confirm it navigates to `https://my.equalizedigital.com/license-keys/`.

Closes #1662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Free License Key messaging link in the Accessibility Reports page to direct users to the license keys section for more direct access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/equalizedigital/accessibility-checker/pull/1728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->