### PR TITLE
[Email Reports] Modify Reports Enabled message for free users

### DIFF
--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -238,9 +238,7 @@ class AccessibilityReportsPage implements PageInterface {
 									<span class="edac-reports-card__status edac-reports-card__status--success" aria-hidden="true"><?php echo wp_kses( $this->get_status_icon( 'check' ), $allowed_icon_html ); ?></span>
 								</div>
 								<p><?php esc_html_e( 'Weekly accessibility reports for this site are being emailed to the account owner of the license key.', 'accessibility-checker' ); ?></p>
-								<?php if ( ! $is_pro ) : ?>
-									<p><?php esc_html_e( 'To send emails to additional recipients, upgrade to Pro.', 'accessibility-checker' ); ?></p>
-								<?php endif; ?>
+
 								<p class="edac-reports-card__meta">
 									<?php if ( $next_send_date ) : ?>
 										<?php /* translators: %s: next report date. */ ?>

--- a/admin/AdminPage/AccessibilityReportsPage.php
+++ b/admin/AdminPage/AccessibilityReportsPage.php
@@ -237,7 +237,10 @@ class AccessibilityReportsPage implements PageInterface {
 									<h3><?php esc_html_e( 'Reports Enabled', 'accessibility-checker' ); ?></h3>
 									<span class="edac-reports-card__status edac-reports-card__status--success" aria-hidden="true"><?php echo wp_kses( $this->get_status_icon( 'check' ), $allowed_icon_html ); ?></span>
 								</div>
-								<p><?php esc_html_e( 'You’ll receive weekly accessibility reports for this site.', 'accessibility-checker' ); ?></p>
+								<p><?php esc_html_e( 'Weekly accessibility reports for this site are being emailed to the account owner of the license key.', 'accessibility-checker' ); ?></p>
+								<?php if ( ! $is_pro ) : ?>
+									<p><?php esc_html_e( 'To send emails to additional recipients, upgrade to Pro.', 'accessibility-checker' ); ?></p>
+								<?php endif; ?>
 								<p class="edac-reports-card__meta">
 									<?php if ( $next_send_date ) : ?>
 										<?php /* translators: %s: next report date. */ ?>


### PR DESCRIPTION
## Summary

- Replaces "You'll receive weekly accessibility reports for this site." with the clearer "Weekly accessibility reports for this site are being emailed to the account owner of the license key."
- Adds a Pro upsell paragraph ("To send emails to additional recipients, upgrade to Pro.") that only appears for free users (`! $is_pro`)

Closes #1664

## Test plan

- [ ] Activate a free license key on the Email Reports settings page (`/wp-admin/admin.php?page=accessibility_checker_settings&tab=accessibility-reports`)
- [ ] Confirm the "Reports Enabled" card shows: "Weekly accessibility reports for this site are being emailed to the account owner of the license key."
- [ ] Confirm the "To send emails to additional recipients, upgrade to Pro." line appears below it for free users
- [ ] Repeat with a Pro license key and confirm the upgrade upsell paragraph is **not** shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Clarified weekly accessibility report messaging to state that report emails are sent to the account owner associated with the license key (replacing the previous “You’ll receive…” wording).
  * Removed the prior note about Pro-only extra recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->