### PR TITLE
Remove dead is_numeric check on policy page option

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -784,7 +784,6 @@ function edac_include_accessibility_statement_link_cb() {
 function edac_accessibility_policy_page_cb() {
 
 	$policy_page = get_option( 'edac_accessibility_policy_page' );
-	$policy_page = is_numeric( $policy_page ) ? get_page_link( $policy_page ) : $policy_page;
 	?>
 
 	<input style="width: 100%;" type="text" name="edac_accessibility_policy_page" id="edac_accessibility_policy_page" value="<?php echo esc_attr( $policy_page ); ?>">


### PR DESCRIPTION
## Summary
- `edac_accessibility_policy_page` has only ever stored a URL string — the `is_numeric` branch that would call `get_page_link()` has been unreachable for years
- Removes one line of dead code so AI agents (and humans) stop reasoning about a code path that doesn't exist

## Test plan
- [ ] Visit Settings → confirm the accessibility policy page URL field still displays and saves correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The accessibility policy setting now displays the saved value directly instead of converting it to a derived page link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->