### PR TITLE
Use a rest api url that works on subsites as well as if someone changes the rest api base

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -87,7 +87,8 @@ class Enqueue_Admin {
 				[
 					'postID'                   => $post_id,
 					'nonce'                    => wp_create_nonce( 'ajax-nonce' ),
-					'edacApiUrl'               => esc_url_raw( rest_url() . 'accessibility-checker/v1' ),
+					'edacApiUrl'               => esc_url_raw( rest_url( 'accessibility-checker/v1' ) ),
+					'fixesRestUrl'             => esc_url_raw( rest_url( 'edac/v1' ) ),
 					'restNonce'                => wp_create_nonce( 'wp_rest' ),
 					'proUrl'                   => esc_url_raw( edac_generate_link_type( [ 'utm_content' => '__name__' ] ) ),
 					'hasDismissEndpoint'       => method_exists( \EDAC\Inc\REST_Api::class, 'dismiss_issue' ),

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -157,6 +157,7 @@ class Enqueue_Frontend {
 					'userCanEdit'      => current_user_can( 'edit_post', $post_id ),
 					'edacUrl'          => esc_url_raw( get_site_url() ),
 					'restUrl'          => esc_url_raw( rest_url( 'accessibility-checker/v1' ) ),
+					'fixesRestUrl'     => esc_url_raw( rest_url( 'edac/v1' ) ),
 					'ajaxurl'          => admin_url( 'admin-ajax.php' ),
 					'loggedIn'         => is_user_logged_in(),
 					'appCssUrl'        => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,

--- a/includes/classes/class-enqueue-frontend.php
+++ b/includes/classes/class-enqueue-frontend.php
@@ -156,6 +156,7 @@ class Enqueue_Frontend {
 					'isPro'            => edac_is_pro(),
 					'userCanEdit'      => current_user_can( 'edit_post', $post_id ),
 					'edacUrl'          => esc_url_raw( get_site_url() ),
+					'restUrl'          => esc_url_raw( rest_url( 'accessibility-checker/v1' ) ),
 					'ajaxurl'          => admin_url( 'admin-ajax.php' ),
 					'loggedIn'         => is_user_logged_in(),
 					'appCssUrl'        => EDAC_PLUGIN_URL . 'build/css/frontendHighlighterApp.css?ver=' . EDAC_VERSION,

--- a/src/common/saveFixSettingsRest.js
+++ b/src/common/saveFixSettingsRest.js
@@ -41,8 +41,10 @@ export const saveFixSettings = ( fixSettingsContainer ) => {
 		liveRegion.innerText = __( 'Saving...', 'accessibility-checker' );
 	}
 
+	const fixesRestUrl = window.edacFrontendHighlighterApp?.fixesRestUrl ?? window.edac_script_vars?.fixesRestUrl;
+
 	// make a rest call to save the settings
-	fetch( '/wp-json/edac/v1/fixes/update/', {
+	fetch( `${ fixesRestUrl }/fixes/update/`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',

--- a/src/common/saveFixSettingsRest.js
+++ b/src/common/saveFixSettingsRest.js
@@ -43,6 +43,18 @@ export const saveFixSettings = ( fixSettingsContainer ) => {
 
 	const fixesRestUrl = window.edacFrontendHighlighterApp?.fixesRestUrl ?? window.edac_script_vars?.fixesRestUrl;
 
+	if ( ! fixesRestUrl ) {
+		fixSettingsContainer.classList.remove( 'edac-fix-settings--saving' );
+		fixButtons.forEach( ( button ) => {
+			button.disabled = false;
+		} );
+		fixSettingsContainer.classList.add( 'edac-fix-settings--saved--error' );
+		if ( liveRegion ) {
+			liveRegion.innerText = __( 'Saving failed: Missing REST API URL.', 'accessibility-checker' );
+		}
+		return;
+	}
+
 	// make a rest call to save the settings
 	fetch( `${ fixesRestUrl }/fixes/update/`, {
 		method: 'POST',

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -1863,7 +1863,7 @@ class AccessibilityCheckerHighlight {
 
 	saveScanResults( postId, nonce, violations, densityMetrics ) {
 		const self = this;
-		return fetch( '/wp-json/accessibility-checker/v1/post-scan-results/' + postId, {
+		return fetch( `${ edacFrontendHighlighterApp.restUrl }/post-scan-results/${ postId }`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -1943,7 +1943,7 @@ class AccessibilityCheckerHighlight {
 		}
 
 		// Validate required parameters
-		if ( ! edacFrontendHighlighterApp?.edacUrl || ! edacFrontendHighlighterApp?.postID ) {
+		if ( ! edacFrontendHighlighterApp?.restUrl || ! edacFrontendHighlighterApp?.postID ) {
 			const summary = document.querySelector( '.edac-highlight-panel-controls-summary' );
 			if ( summary ) {
 				summary.textContent = __( 'Error: Missing required parameters.', 'accessibility-checker' );
@@ -1956,7 +1956,7 @@ class AccessibilityCheckerHighlight {
 		this.clearIssuesButton.textContent = __( 'Clearing...', 'accessibility-checker' );
 		const summary = document.querySelector( '.edac-highlight-panel-controls-summary' );
 
-		fetch( `${ edacFrontendHighlighterApp.edacUrl }/wp-json/accessibility-checker/v1/clear-issues/${ edacFrontendHighlighterApp.postID }`, {
+		fetch( `${ edacFrontendHighlighterApp.restUrl }/clear-issues/${ edacFrontendHighlighterApp.postID }`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -1863,7 +1863,11 @@ class AccessibilityCheckerHighlight {
 
 	saveScanResults( postId, nonce, violations, densityMetrics ) {
 		const self = this;
-		return fetch( `${ edacFrontendHighlighterApp.restUrl }/post-scan-results/${ postId }`, {
+		const restUrl = window.edacFrontendHighlighterApp?.restUrl;
+		if ( ! restUrl ) {
+			return Promise.reject( new Error( 'Missing REST API URL.' ) );
+		}
+		return fetch( `${ restUrl }/post-scan-results/${ postId }`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -1943,7 +1947,7 @@ class AccessibilityCheckerHighlight {
 		}
 
 		// Validate required parameters
-		if ( ! edacFrontendHighlighterApp?.restUrl || ! edacFrontendHighlighterApp?.postID ) {
+		if ( ! window.edacFrontendHighlighterApp?.restUrl || ! window.edacFrontendHighlighterApp?.postID ) {
 			const summary = document.querySelector( '.edac-highlight-panel-controls-summary' );
 			if ( summary ) {
 				summary.textContent = __( 'Error: Missing required parameters.', 'accessibility-checker' );
@@ -1956,7 +1960,7 @@ class AccessibilityCheckerHighlight {
 		this.clearIssuesButton.textContent = __( 'Clearing...', 'accessibility-checker' );
 		const summary = document.querySelector( '.edac-highlight-panel-controls-summary' );
 
-		fetch( `${ edacFrontendHighlighterApp.restUrl }/clear-issues/${ edacFrontendHighlighterApp.postID }`, {
+		fetch( `${ window.edacFrontendHighlighterApp.restUrl }/clear-issues/${ window.edacFrontendHighlighterApp.postID }`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -112,6 +112,76 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * FixesRestUrl is present in the edac_script_vars localized to the admin script.
+	 */
+	public function testLocalizedAdminDataIncludesFixesRestUrl(): void {
+		global $wp_scripts;
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$localized_data = (string) $wp_scripts->get_data( 'edac', 'data' );
+
+		$this->assertNotEmpty( $localized_data );
+		$this->assertStringContainsString( 'fixesRestUrl', $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl uses the edac/v1 namespace and matches rest_url().
+	 */
+	public function testAdminFixesRestUrlContainsEdacV1Namespace(): void {
+		global $wp_scripts;
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$localized_data = (string) $wp_scripts->get_data( 'edac', 'data' );
+		$expected       = rest_url( 'edac/v1' );
+
+		$this->assertStringContainsString( 'edac', $localized_data );
+		$this->assertStringContainsString( (string) wp_parse_url( $expected, PHP_URL_HOST ), $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl must be an absolute URL — a root-relative /wp-json path would break
+	 * subdomain multisite installs by resolving to the main site instead of the subsite.
+	 */
+	public function testAdminFixesRestUrlIsAbsolute(): void {
+		global $wp_scripts;
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$localized_data = (string) $wp_scripts->get_data( 'edac', 'data' );
+
+		$this->assertDoesNotMatchRegularExpression( '/"fixesRestUrl"\s*:\s*"\\\\?\/wp-json/', $localized_data );
+		$this->assertMatchesRegularExpression( '/"fixesRestUrl"\s*:\s*"https?/', $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl in edac_script_vars must follow a custom REST base prefix set via
+	 * the rest_url_prefix filter. Verifies the URL is built with rest_url() rather than
+	 * a hardcoded /wp-json/ string.
+	 * Pretty permalinks are required for the prefix filter to be applied.
+	 */
+	public function testAdminFixesRestUrlRespectsCustomRestPrefix(): void {
+		global $wp_scripts;
+
+		update_option( 'permalink_structure', '/%postname%/' );
+		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+
+		$prefix_callback = static fn() => 'custom-api';
+		add_filter( 'rest_url_prefix', $prefix_callback );
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		remove_filter( 'rest_url_prefix', $prefix_callback );
+		delete_option( 'permalink_structure' );
+
+		$localized_data = (string) $wp_scripts->get_data( 'edac', 'data' );
+
+		$this->assertStringContainsString( 'custom-api', $localized_data );
+		$this->assertStringNotContainsString( 'wp-json', $localized_data );
+	}
+
+	/**
 	 * Test that the base script and editor script is enqueued in the editor for an existing page.
 	 *
 	 * @return void

--- a/tests/phpunit/includes/classes/EnqueueFrontendTest.php
+++ b/tests/phpunit/includes/classes/EnqueueFrontendTest.php
@@ -74,6 +74,132 @@ class EnqueueFrontendTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper: enqueue the frontend highlighter as an admin and return the localized data string.
+	 *
+	 * @return string The raw JS localized-data string for edac-frontend-highlighter-app.
+	 */
+	private function enqueueAndGetLocalizedData(): string {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		global $post;
+		$post = $this->factory()->post->create_and_get( [ 'post_type' => 'post' ] );
+
+		Enqueue_Frontend::maybe_enqueue_frontend_highlighter();
+
+		global $wp_scripts;
+		return (string) $wp_scripts->get_data( 'edac-frontend-highlighter-app', 'data' );
+	}
+
+	/**
+	 * RestUrl is present in the localized data passed to the frontend highlighter script.
+	 */
+	public function testLocalizedDataIncludesRestUrl(): void {
+		$localized_data = $this->enqueueAndGetLocalizedData();
+
+		$this->assertNotEmpty( $localized_data );
+		$this->assertStringContainsString( 'restUrl', $localized_data );
+	}
+
+	/**
+	 * RestUrl uses the accessibility-checker/v1 namespace and matches rest_url().
+	 */
+	public function testRestUrlMatchesRestUrlFunction(): void {
+		$localized_data = $this->enqueueAndGetLocalizedData();
+		$expected       = rest_url( 'accessibility-checker/v1' );
+
+		$this->assertStringContainsString( 'accessibility-checker', $localized_data );
+		$this->assertStringContainsString( 'v1', $localized_data );
+		// The URL must be derived from rest_url(), not hardcoded — verify the host is present.
+		$this->assertStringContainsString( (string) wp_parse_url( $expected, PHP_URL_HOST ), $localized_data );
+	}
+
+	/**
+	 * RestUrl must be an absolute URL, not a root-relative path like /wp-json/...
+	 * A root-relative URL on a subdomain multisite would resolve to the main site.
+	 */
+	public function testRestUrlIsAbsolute(): void {
+		$localized_data = $this->enqueueAndGetLocalizedData();
+
+		// The value following "restUrl" must not be a bare /wp-json path.
+		$this->assertDoesNotMatchRegularExpression( '/"restUrl"\s*:\s*"\\\\?\/wp-json/', $localized_data );
+		// And the scheme must be present.
+		$this->assertMatchesRegularExpression( '/"restUrl"\s*:\s*"https?/', $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl is present in the localized data passed to the frontend highlighter script.
+	 */
+	public function testLocalizedDataIncludesFixesRestUrl(): void {
+		$localized_data = $this->enqueueAndGetLocalizedData();
+
+		$this->assertStringContainsString( 'fixesRestUrl', $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl uses the edac/v1 namespace and matches rest_url().
+	 */
+	public function testFixesRestUrlContainsEdacV1Namespace(): void {
+		$localized_data = $this->enqueueAndGetLocalizedData();
+		$expected       = rest_url( 'edac/v1' );
+
+		$this->assertStringContainsString( 'edac', $localized_data );
+		$this->assertStringContainsString( (string) wp_parse_url( $expected, PHP_URL_HOST ), $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl must be an absolute URL, not a root-relative path.
+	 */
+	public function testFixesRestUrlIsAbsolute(): void {
+		$localized_data = $this->enqueueAndGetLocalizedData();
+
+		$this->assertDoesNotMatchRegularExpression( '/"fixesRestUrl"\s*:\s*"\\\\?\/wp-json/', $localized_data );
+		$this->assertMatchesRegularExpression( '/"fixesRestUrl"\s*:\s*"https?/', $localized_data );
+	}
+
+	/**
+	 * RestUrl must follow a custom REST base prefix set via the rest_url_prefix filter.
+	 * Verifies the URL is built with rest_url() rather than a hardcoded /wp-json/ string.
+	 * Pretty permalinks are required for the prefix filter to be applied.
+	 */
+	public function testRestUrlRespectsCustomRestPrefix(): void {
+		update_option( 'permalink_structure', '/%postname%/' );
+		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+
+		$prefix_callback                        = static fn() => 'custom-api';
+		add_filter( 'rest_url_prefix', $prefix_callback );
+		$this->added_filters['rest_url_prefix'] = $prefix_callback;
+
+		$localized_data = $this->enqueueAndGetLocalizedData();
+
+		remove_filter( 'rest_url_prefix', $prefix_callback );
+		delete_option( 'permalink_structure' );
+
+		$this->assertStringContainsString( 'custom-api', $localized_data );
+		$this->assertStringNotContainsString( 'wp-json', $localized_data );
+	}
+
+	/**
+	 * FixesRestUrl must follow a custom REST base prefix set via the rest_url_prefix filter.
+	 */
+	public function testFixesRestUrlRespectsCustomRestPrefix(): void {
+		update_option( 'permalink_structure', '/%postname%/' );
+		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+
+		$prefix_callback                        = static fn() => 'custom-api';
+		add_filter( 'rest_url_prefix', $prefix_callback );
+		$this->added_filters['rest_url_prefix'] = $prefix_callback;
+
+		$localized_data = $this->enqueueAndGetLocalizedData();
+
+		remove_filter( 'rest_url_prefix', $prefix_callback );
+		delete_option( 'permalink_structure' );
+
+		$this->assertStringContainsString( 'custom-api', $localized_data );
+		$this->assertStringNotContainsString( 'wp-json', $localized_data );
+	}
+
+	/**
 	 * Ensure the highlighter uses the filtered post ID when determining scannable post types.
 	 */
 	public function testFrontendHighlighterUsesFilteredPostIdForScannableType(): void {


### PR DESCRIPTION
This pull request updates how REST API endpoint URLs are handled throughout the plugin, ensuring they are dynamically passed from PHP to JavaScript rather than being hardcoded. This change improves compatibility with custom site configurations and makes the codebase more maintainable. The main updates involve adding new variables for REST URLs in PHP and refactoring JavaScript to use these variables.

**REST API URL Handling Improvements:**

* Added `restUrl` and `fixesRestUrl` variables to the localized script data in both admin (`maybe_enqueue_admin_and_editor_app_scripts`) and frontend (`maybe_enqueue_frontend_highlighter`) PHP enqueue functions, ensuring all REST endpoint URLs are dynamically generated and available for JavaScript. [[1]](diffhunk://#diff-08c88f445001d7ed0fbe04a8716610497b84d9e5810641addf68ede866d28d88L90-R91) [[2]](diffhunk://#diff-91b6de794f75bc6d1044d2eaf7ece1edcd1de611b2df0a9d259e0703493dd831R159-R160)

* Updated JavaScript (`src/frontendHighlighterApp/index.js` and `src/common/saveFixSettingsRest.js`) to use the new `restUrl` and `fixesRestUrl` variables instead of hardcoded REST endpoint paths, improving flexibility and reliability. [[1]](diffhunk://#diff-bece1bbb785a9261a7e6aca0d5cb83eda772f26999f3c83a31e4e57f728c75acL1866-R1866) [[2]](diffhunk://#diff-bece1bbb785a9261a7e6aca0d5cb83eda772f26999f3c83a31e4e57f728c75acL1959-R1959) [[3]](diffhunk://#diff-bfcab1b82f7302040b04fdea8d36f3f042a9690cc1deecdfd607f1cce0465c46R44-R47)

**Validation and Error Handling:**

* Modified the frontend highlighter app to validate the presence of `restUrl` instead of the previously used `edacUrl`, ensuring required parameters are correctly checked before making API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend and admin now receive explicit REST endpoint URLs so the apps use configurable API bases.
* **Bug Fixes**
  * Frontend actions (save/clear) handle missing REST URL gracefully and surface a “Missing REST API URL.” message.
* **Tests**
  * Added tests covering REST endpoint exposure and custom REST prefix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->