### PR TITLE
Create Accessibility Issue template structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
@@ -1,0 +1,207 @@
+name: Accessibility Report
+description: Let us know if you encounter an accessibility issue so we can fix it.
+title: "[Accessibility]: "
+labels:
+  - a11y
+  - needs-triage
+assignees:
+  - amberhinds
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use this template when creating an accessibility issue.
+
+        - Please use the latest version of Accessibility Checker.
+        - Search for existing issues before creating a new one.
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Before submitting
+      options:
+        - label: I've read and understood the contribution guidelines.
+          required: true
+        - label: I've searched for related issues and confirmed this is not a duplicate.
+          required: true
+
+  - type: textarea
+    id: impacted-element
+    attributes:
+      label: Impacted element or component
+      description: What part of the plugin or interface is affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshot(s) or video
+      description: Attach screenshots or paste links to videos demonstrating the issue.
+
+  - type: textarea
+    id: recommended-fix
+    attributes:
+      label: Recommended fix or expected behavior
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Is this a critical blocker?
+      options:
+        - Yes - there is no workaround for this issue.
+        - No - this is an accessibility problem, but it is minor or not a blocker.
+        - Unsure
+    validations:
+      required: true
+
+  - type: dropdown
+  id: wcag-sc
+  attributes:
+    label: Related WCAG Success Criterion
+    description: Select the WCAG Success Criterion that is most closely related to this issue.
+    options:
+      - Not sure
+      - 1.1.1 Non-text Content
+      - 1.2.1 Audio-only and Video-only (Prerecorded)
+      - 1.2.2 Captions (Prerecorded)
+      - 1.2.3 Audio Description or Media Alternative (Prerecorded)
+      - 1.2.4 Captions (Live)
+      - 1.2.5 Audio Description (Prerecorded)
+      - 1.3.1 Info and Relationships
+      - 1.3.2 Meaningful Sequence
+      - 1.3.3 Sensory Characteristics
+      - 1.3.4 Orientation
+      - 1.3.5 Identify Input Purpose
+      - 1.4.1 Use of Color
+      - 1.4.2 Audio Control
+      - 1.4.3 Contrast (Minimum)
+      - 1.4.4 Resize Text
+      - 1.4.5 Images of Text
+      - 1.4.10 Reflow
+      - 1.4.11 Non-text Contrast
+      - 1.4.12 Text Spacing
+      - 1.4.13 Content on Hover or Focus
+      - 2.1.1 Keyboard
+      - 2.1.2 No Keyboard Trap
+      - 2.1.4 Character Key Shortcuts
+      - 2.2.1 Timing Adjustable
+      - 2.2.2 Pause, Stop, Hide
+      - 2.3.1 Three Flashes or Below Threshold
+      - 2.4.1 Bypass Blocks
+      - 2.4.2 Page Titled
+      - 2.4.3 Focus Order
+      - 2.4.4 Link Purpose (In Context)
+      - 2.4.5 Multiple Ways
+      - 2.4.6 Headings and Labels
+      - 2.4.7 Focus Visible
+      - 2.4.11 Focus Not Obscured (Minimum)
+      - 2.5.1 Pointer Gestures
+      - 2.5.2 Pointer Cancellation
+      - 2.5.3 Label in Name
+      - 2.5.4 Motion Actuation
+      - 2.5.7 Dragging Movements
+      - 2.5.8 Target Size (Minimum)
+      - 3.1.1 Language of Page
+      - 3.2.1 On Focus
+      - 3.2.2 On Input
+      - 3.2.3 Consistent Navigation
+      - 3.2.4 Consistent Identification
+      - 3.2.6 Consistent Help
+      - 3.3.1 Error Identification
+      - 3.3.2 Labels or Instructions
+      - 3.3.3 Error Suggestion
+      - 3.3.4 Error Prevention (Legal, Financial, Data)
+      - 3.3.7 Redundant Entry
+      - 3.3.8 Accessible Authentication (Minimum)
+      - 4.1.1 Parsing
+      - 4.1.2 Name, Role, Value
+      - 4.1.3 Status Messages
+  validations:
+    required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce this behavior?
+      placeholder: |
+        1. Go to...
+        2. Click...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: input
+    id: wordpress-version
+    attributes:
+      label: WordPress version
+      placeholder: e.g. 7.0
+
+  - type: input
+    id: accessibility-checker-version
+    attributes:
+      label: Accessibility Checker version
+      placeholder: e.g. 1.24.0
+    validations:
+      required: true
+
+  - type: input
+    id: active-theme
+    attributes:
+      label: Active theme
+      placeholder: e.g. Twenty Twenty-Six
+
+  - type: checkboxes
+    id: screen-reader
+    attributes:
+      label: Which screen reader are you using? (if applicable)
+      options:
+        - label: NVDA
+        - label: VoiceOver
+        - label: JAWS
+        - label: Other
+
+  - type: input
+    id: other-screen-reader
+    attributes:
+      label: Other screen reader
+      placeholder: Specify if you selected Other
+
+  - type: checkboxes
+    id: browser
+    attributes:
+      label: Which browser is affected?
+      options:
+        - label: Internet Explorer
+        - label: Edge
+        - label: Chrome
+        - label: Firefox
+        - label: Safari
+        - label: Brave
+
+  - type: checkboxes
+    id: editor
+    attributes:
+      label: Which editor is affected? (if relevant)
+      options:
+        - label: Classic Editor
+        - label: Gutenberg
+        - label: Classic Editor Plugin
+        - label: Page Builder
+
+  - type: input
+    id: page-builder
+    attributes:
+      label: Page Builder name
+      placeholder: Elementor, Beaver Builder, Divi, etc.
+

--- a/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
@@ -66,69 +66,69 @@ body:
       required: true
 
   - type: dropdown
-  id: wcag-sc
-  attributes:
-    label: Related WCAG Success Criterion
-    description: Select the WCAG Success Criterion that is most closely related to this issue.
-    options:
-      - Not sure
-      - 1.1.1 Non-text Content
-      - 1.2.1 Audio-only and Video-only (Prerecorded)
-      - 1.2.2 Captions (Prerecorded)
-      - 1.2.3 Audio Description or Media Alternative (Prerecorded)
-      - 1.2.4 Captions (Live)
-      - 1.2.5 Audio Description (Prerecorded)
-      - 1.3.1 Info and Relationships
-      - 1.3.2 Meaningful Sequence
-      - 1.3.3 Sensory Characteristics
-      - 1.3.4 Orientation
-      - 1.3.5 Identify Input Purpose
-      - 1.4.1 Use of Color
-      - 1.4.2 Audio Control
-      - 1.4.3 Contrast (Minimum)
-      - 1.4.4 Resize Text
-      - 1.4.5 Images of Text
-      - 1.4.10 Reflow
-      - 1.4.11 Non-text Contrast
-      - 1.4.12 Text Spacing
-      - 1.4.13 Content on Hover or Focus
-      - 2.1.1 Keyboard
-      - 2.1.2 No Keyboard Trap
-      - 2.1.4 Character Key Shortcuts
-      - 2.2.1 Timing Adjustable
-      - 2.2.2 Pause, Stop, Hide
-      - 2.3.1 Three Flashes or Below Threshold
-      - 2.4.1 Bypass Blocks
-      - 2.4.2 Page Titled
-      - 2.4.3 Focus Order
-      - 2.4.4 Link Purpose (In Context)
-      - 2.4.5 Multiple Ways
-      - 2.4.6 Headings and Labels
-      - 2.4.7 Focus Visible
-      - 2.4.11 Focus Not Obscured (Minimum)
-      - 2.5.1 Pointer Gestures
-      - 2.5.2 Pointer Cancellation
-      - 2.5.3 Label in Name
-      - 2.5.4 Motion Actuation
-      - 2.5.7 Dragging Movements
-      - 2.5.8 Target Size (Minimum)
-      - 3.1.1 Language of Page
-      - 3.2.1 On Focus
-      - 3.2.2 On Input
-      - 3.2.3 Consistent Navigation
-      - 3.2.4 Consistent Identification
-      - 3.2.6 Consistent Help
-      - 3.3.1 Error Identification
-      - 3.3.2 Labels or Instructions
-      - 3.3.3 Error Suggestion
-      - 3.3.4 Error Prevention (Legal, Financial, Data)
-      - 3.3.7 Redundant Entry
-      - 3.3.8 Accessible Authentication (Minimum)
-      - 4.1.1 Parsing
-      - 4.1.2 Name, Role, Value
-      - 4.1.3 Status Messages
-  validations:
-    required: true
+    id: wcag-sc
+    attributes:
+      label: Related WCAG Success Criterion
+      description: Select the WCAG Success Criterion that is most closely related to this issue.
+      options:
+        - Not sure
+        - 1.1.1 Non-text Content
+        - 1.2.1 Audio-only and Video-only (Prerecorded)
+        - 1.2.2 Captions (Prerecorded)
+        - 1.2.3 Audio Description or Media Alternative (Prerecorded)
+        - 1.2.4 Captions (Live)
+        - 1.2.5 Audio Description (Prerecorded)
+        - 1.3.1 Info and Relationships
+        - 1.3.2 Meaningful Sequence
+        - 1.3.3 Sensory Characteristics
+        - 1.3.4 Orientation
+        - 1.3.5 Identify Input Purpose
+        - 1.4.1 Use of Color
+        - 1.4.2 Audio Control
+        - 1.4.3 Contrast (Minimum)
+        - 1.4.4 Resize Text
+        - 1.4.5 Images of Text
+        - 1.4.10 Reflow
+        - 1.4.11 Non-text Contrast
+        - 1.4.12 Text Spacing
+        - 1.4.13 Content on Hover or Focus
+        - 2.1.1 Keyboard
+        - 2.1.2 No Keyboard Trap
+        - 2.1.4 Character Key Shortcuts
+        - 2.2.1 Timing Adjustable
+        - 2.2.2 Pause, Stop, Hide
+        - 2.3.1 Three Flashes or Below Threshold
+        - 2.4.1 Bypass Blocks
+        - 2.4.2 Page Titled
+        - 2.4.3 Focus Order
+        - 2.4.4 Link Purpose (In Context)
+        - 2.4.5 Multiple Ways
+        - 2.4.6 Headings and Labels
+        - 2.4.7 Focus Visible
+        - 2.4.11 Focus Not Obscured (Minimum)
+        - 2.5.1 Pointer Gestures
+        - 2.5.2 Pointer Cancellation
+        - 2.5.3 Label in Name
+        - 2.5.4 Motion Actuation
+        - 2.5.7 Dragging Movements
+        - 2.5.8 Target Size (Minimum)
+        - 3.1.1 Language of Page
+        - 3.2.1 On Focus
+        - 3.2.2 On Input
+        - 3.2.3 Consistent Navigation
+        - 3.2.4 Consistent Identification
+        - 3.2.6 Consistent Help
+        - 3.3.1 Error Identification
+        - 3.3.2 Labels or Instructions
+        - 3.3.3 Error Suggestion
+        - 3.3.4 Error Prevention (Legal, Financial, Data)
+        - 3.3.7 Redundant Entry
+        - 3.3.8 Accessible Authentication (Minimum)
+        - 4.1.1 Parsing
+        - 4.1.2 Name, Role, Value
+        - 4.1.3 Status Messages
+    validations:
+      required: true
 
   - type: textarea
     id: reproduction

--- a/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
@@ -21,9 +21,9 @@ body:
     attributes:
       label: Before submitting
       options:
-        - label: I've read and understood the contribution guidelines.
+        - label: I've read and understood the [contribution guidelines](https://github.com/equalizedigital/accessibility-checker/blob/develop/.github/CONTRIBUTING.md).
           required: true
-        - label: I've searched for related issues and confirmed this is not a duplicate.
+        - label: I've searched for [related issues](https://github.com/equalizedigital/accessibility-checker/issues) and confirmed this is not a duplicate.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Accessibility_Issue.yml
@@ -51,8 +51,6 @@ body:
     id: recommended-fix
     attributes:
       label: Recommended fix or expected behavior
-    validations:
-      required: true
 
   - type: dropdown
     id: severity
@@ -62,8 +60,6 @@ body:
         - Yes - there is no workaround for this issue.
         - No - this is an accessibility problem, but it is minor or not a blocker.
         - Unsure
-    validations:
-      required: true
 
   - type: dropdown
     id: wcag-sc
@@ -127,8 +123,6 @@ body:
         - 4.1.1 Parsing
         - 4.1.2 Name, Role, Value
         - 4.1.3 Status Messages
-    validations:
-      required: true
 
   - type: textarea
     id: reproduction
@@ -151,7 +145,7 @@ body:
     id: accessibility-checker-version
     attributes:
       label: Accessibility Checker version
-      placeholder: e.g. 1.24.0
+      placeholder: e.g. 1.43.0
     validations:
       required: true
 


### PR DESCRIPTION
Adds GitHub Issue Forms to standardize accessibility issue reporting and improve the information collected during triage.

- Added a new Accessibility Report issue form (.github/ISSUE_TEMPLATE/accessibility-report.yml)
- Converted the existing bug Markdown issue template to GitHub's structured form format
- Added required acknowledgements for contribution guidelines and duplicate issue checks
- Added structured fields for:
- Impacted element or component
- Issue description
- Screenshots or videos
- Expected behavior or recommended fix
- Reproduction steps
- WordPress version
- Accessibility Checker version
- Active theme
- Added dropdown for accessibility impact severity
- Added dropdown for selecting the related WCAG Success Criterion
- Added checkboxes for affected screen readers, browsers, and editors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new accessibility issue reporting template with guided fields. Reports can now be submitted with structured details including affected elements, issue descriptions, reproduction steps, severity, WCAG success criteria, and optional screenshots plus environment/context information to improve triage quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->