### PR TITLE
PRO-960: Restore global dismiss/unignore inline in DismissPanel

### DIFF
--- a/src/issueModal/api.js
+++ b/src/issueModal/api.js
@@ -23,7 +23,7 @@ export const toggleIssueDismiss = async ( issueId, ignore = true, reason = '', c
 			reason: ignore ? reason : '',
 			comment: ignore ? comment : '',
 			ignore_global: ignore && ignoreGlobal ? 1 : 0,
-			largeBatch: ignore && ignoreGlobal,
+			largeBatch: ignoreGlobal,
 		},
 	} );
 };

--- a/src/issueModal/api.js
+++ b/src/issueModal/api.js
@@ -11,7 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
  * @param {boolean} ignore       - True to dismiss, false to restore.
  * @param {string}  reason       - The reason for dismissing the issue.
  * @param {string}  comment      - Optional comment for the dismissal.
- * @param {boolean} ignoreGlobal - True to dismiss all instances of this issue across all pages (Pro only).
+ * @param {boolean} ignoreGlobal - True to apply the action (dismiss or undismiss) across all matching instances on all pages (Pro only).
  * @return {Promise} Promise that resolves with the response data.
  */
 export const toggleIssueDismiss = async ( issueId, ignore = true, reason = '', comment = '', ignoreGlobal = false ) => {

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -41,7 +41,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 		setSuccessNotice( null );
 
 		try {
-			const response = await toggleIssueDismiss( issue.id, ignore, ignore ? dismissReason : '', ignore ? comment : '', ignore && isGlobal );
+			const response = await toggleIssueDismiss( issue.id, ignore, ignore ? dismissReason : '', ignore ? comment : '', ignore ? isGlobal : isGloballyDismissed );
 			setIsIgnored( ignore );
 			setSuccessNotice(
 				ignore

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -60,6 +60,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 				issue.ignre_global = response.ignre_global ?? ( isGlobal ? 1 : 0 );
 			} else if ( ! ignore ) {
 				issue.ignre = '0';
+				issue.ignre_global = 0;
 				issue.user = '';
 				issue.ignre_user_name = '';
 				issue.ignre_date = '';
@@ -257,6 +258,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 												<Button
 													variant="tertiary"
 													type="button"
+													disabled={ isSubmitting }
 													onClick={ () => {
 														onClose();
 														handleToggleIgnore( true, forceGlobal ).then( () => {
@@ -273,6 +275,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 													<Button
 														variant="tertiary"
 														type="button"
+														disabled={ isSubmitting }
 														onClick={ () => {
 															onClose();
 															handleToggleIgnore( true, true );

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -13,7 +13,6 @@ import RichTextarea from './RichTextarea';
 import { toggleIssueDismiss } from '../api';
 import { setPendingRefetch } from '../index';
 import { getDismissReasonOptions } from '../../sidebar/utils/dismissHelpers';
-import ExternalLinkIcon from '../../sidebar/components/ExternalLinkIcon';
 
 /**
  * Dismiss Panel Component
@@ -35,20 +34,6 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 	const isGloballyDismissed = issue?.ignre_global === 1 || issue?.ignre_global === '1';
 	const dismissReasonOptions = getDismissReasonOptions();
 	const dismissReasonLabel = dismissReasonOptions.find( ( option ) => option.value === issue?.ignre_reason )?.label;
-	const getGlobalIgnoresUrl = () => {
-		if ( window?.ajaxurl ) {
-			const adminUrl = new URL( window.ajaxurl, window.location.origin );
-			adminUrl.pathname = adminUrl.pathname.replace( /admin-ajax\.php$/, 'admin.php' );
-			adminUrl.search = 'page=accessibility_checker_ignored&tab=global';
-			return adminUrl.toString();
-		}
-		if ( window?.edac_editor_app?.edacUrl ) {
-			const baseUrl = window.edac_editor_app.edacUrl.replace( /\/$/, '' );
-			return `${ baseUrl }/wp-admin/admin.php?page=accessibility_checker_ignored&tab=global`;
-		}
-		return 'admin.php?page=accessibility_checker_ignored&tab=global';
-	};
-
 	const handleToggleIgnore = async ( ignore, isGlobal = false ) => {
 		setIsSubmitting( true );
 		setError( null );
@@ -178,21 +163,20 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 								) }
 								{ isGloballyDismissed ? (
 									<div className="edac-analysis__dismissed-actions">
-										<p>
-											{ __( 'This issue was dismissed globally. Manage Global Dismissals to reopen it.', 'accessibility-checker' ) }
-										</p>
 										<Button
 											variant="secondary"
-											href={ getGlobalIgnoresUrl() }
-											target="_blank"
-											rel="noreferrer noopener"
+											onClick={ () => handleToggleIgnore( false ) }
+											disabled={ isSubmitting }
 											className="edac-analysis__dismiss-button"
-											onClick={ () => setPendingRefetch( true ) }
 										>
-											{ __( 'Manage Global Dismissals', 'accessibility-checker' ) }
-											<span style={ { marginLeft: '0.5rem' } }>
-												<ExternalLinkIcon />
-											</span>
+											{ isSubmitting ? (
+												<>
+													<Spinner />
+													{ __( 'Removing...', 'accessibility-checker' ) }
+												</>
+											) : (
+												__( 'Remove Global Dismissal', 'accessibility-checker' )
+											) }
 										</Button>
 									</div>
 								) : (
@@ -279,6 +263,16 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 													} }
 												>
 													{ __( 'Dismiss & Close Modal', 'accessibility-checker' ) }
+												</Button>
+												<Button
+													variant="tertiary"
+													type="button"
+													onClick={ () => {
+														onClose();
+														handleToggleIgnore( true, true );
+													} }
+												>
+													{ __( 'Dismiss Globally (all pages)', 'accessibility-checker' ) }
 												</Button>
 											</div>
 										) }

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -278,7 +278,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 															handleToggleIgnore( true, true );
 														} }
 													>
-														{ __( 'Dismiss Globally (all pages)', 'accessibility-checker' ) }
+														{ __( 'Dismiss Globally', 'accessibility-checker' ) }
 													</Button>
 												) }
 											</div>

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -23,8 +23,9 @@ import { getDismissReasonOptions } from '../../sidebar/utils/dismissHelpers';
  * @param {Function} props.onToggle     - Callback when panel is toggled.
  * @param {Function} props.onIgnore     - Callback when issue is dismissed/restored.
  * @param {Function} props.onCloseModal - Callback to close the parent modal.
+ * @param {boolean}  props.forceGlobal  - When true, the primary dismiss action targets all pages (global dismiss).
  */
-const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => {
+const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceGlobal = false } ) => {
 	const [ comment, setComment ] = useState( issue?.ignre_comment ? decodeEntities( issue.ignre_comment ) : '' );
 	const [ dismissReason, setDismissReason ] = useState( issue?.ignre_reason || 'false_positive' );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
@@ -84,14 +85,18 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 		}
 	};
 
+	const dismissIdleLabel = forceGlobal
+		? __( 'Dismiss Globally', 'accessibility-checker' )
+		: __( 'Dismiss Issue', 'accessibility-checker' );
+	const dismissBusyLabel = forceGlobal
+		? __( 'Dismissing globally...', 'accessibility-checker' )
+		: __( 'Dismissing...', 'accessibility-checker' );
 	const dismissButtonLabel = isSubmitting ? (
 		<>
 			<Spinner />
-			{ __( 'Dismissing...', 'accessibility-checker' ) }
+			{ dismissBusyLabel }
 		</>
-	) : (
-		__( 'Dismiss Issue', 'accessibility-checker' )
-	);
+	) : dismissIdleLabel;
 
 	let panelTitle;
 	if ( isIgnored ) {
@@ -203,7 +208,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 							<form
 								onSubmit={ ( e ) => {
 									e.preventDefault();
-									handleToggleIgnore( true );
+									handleToggleIgnore( true, forceGlobal );
 								} }
 							>
 								<RadioControl
@@ -254,7 +259,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 													type="button"
 													onClick={ () => {
 														onClose();
-														handleToggleIgnore( true, false ).then( () => {
+														handleToggleIgnore( true, forceGlobal ).then( () => {
 															// close the entire modal after dismissing.
 															if ( onCloseModal ) {
 																onCloseModal();
@@ -264,16 +269,18 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal } ) => 
 												>
 													{ __( 'Dismiss & Close Modal', 'accessibility-checker' ) }
 												</Button>
-												<Button
-													variant="tertiary"
-													type="button"
-													onClick={ () => {
-														onClose();
-														handleToggleIgnore( true, true );
-													} }
-												>
-													{ __( 'Dismiss Globally (all pages)', 'accessibility-checker' ) }
-												</Button>
+												{ ! forceGlobal && (
+													<Button
+														variant="tertiary"
+														type="button"
+														onClick={ () => {
+															onClose();
+															handleToggleIgnore( true, true );
+														} }
+													>
+														{ __( 'Dismiss Globally (all pages)', 'accessibility-checker' ) }
+													</Button>
+												) }
 											</div>
 										) }
 									/>


### PR DESCRIPTION
## Summary

- Replaces the dead external "Manage Global Dismissals" link (pointing to a page being removed) with an inline **Remove Global Dismissal** button that calls the existing API directly
- Adds **Dismiss Globally (all pages)** to the dropdown beside the main "Dismiss Issue" button so users can globally dismiss without leaving the panel
- Removes `getGlobalIgnoresUrl()` helper and `ExternalLinkIcon` import, which are no longer needed

## Context

The global dismiss/unignore options were removed from `DismissPanel` because the unignore flow had UX issues in the sidebar. This PR restores the functionality inline using `handleToggleIgnore(false)` / `handleToggleIgnore(true, true)` — the same API path that already existed.

The external link it replaces pointed to `accessibility_checker_ignored&tab=global`, which is being removed as part of the Open Issues Refactor project.

Companion pro-plugin PR: equalizedigital/accessibility-checker-pro#<TBD>

## Test plan

- [ ] Open an issue in the free plugin sidebar or modal
- [ ] Dismiss it globally via the new dropdown option — confirm success notice and `ignre_global` is set
- [ ] Reopen the panel with the globally dismissed issue — confirm "Remove Global Dismissal" button appears instead of external link
- [ ] Click "Remove Global Dismissal" — confirm the issue is fully reopened
- [ ] Confirm non-globally-dismissed issues still show "Reopen Issue" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `forceGlobal` option to control whether issue dismissals apply globally or per-issue.
  * Button labels now dynamically reflect the dismiss scope ("Dismiss Globally" vs. issue-specific variants).
  * Added direct "Remove Global Dismissal" action for globally dismissed issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->