### PR TITLE
PRO-1039: Replace remaining 'Ignore' terminology with 'Dismiss'

### DIFF
--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -139,7 +139,7 @@ class Admin_Notices {
 		// Construct the promotional message.
 		$message  = '<div class="edac_black_friday_notice notice notice-info is-dismissible">';
 		$message .= '<p><strong>' . esc_html__( '🎉 Black Friday special! 🎉', 'accessibility-checker' ) . '</strong><br />';
-		$message .= esc_html__( 'Upgrade to a paid version of Accessibility Checker from November 24th to December 3rd and get 30% off! Full site scanning, site-wide open issues report, ignore logs, and more.', 'accessibility-checker' ) . '<br />';
+		$message .= esc_html__( 'Upgrade to a paid version of Accessibility Checker from November 24th to December 3rd and get 30% off! Full site scanning, site-wide open issues report, dismiss logs, and more.', 'accessibility-checker' ) . '<br />';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://my.equalizedigital.com/support/pre-sale-questions/', 'admin-notice', 'BlackFriday25-presale', false ) ) . '">' . esc_html__( 'Ask a Pre-Sale Question', 'accessibility-checker' ) . '</a> ';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'admin-notice', 'BlackFriday25-pricing', false ) ) . '">' . esc_html__( 'Upgrade Now', 'accessibility-checker' ) . '</a></p>';
 		$message .= '</div>';

--- a/admin/class-admin-notices.php
+++ b/admin/class-admin-notices.php
@@ -139,7 +139,7 @@ class Admin_Notices {
 		// Construct the promotional message.
 		$message  = '<div class="edac_black_friday_notice notice notice-info is-dismissible">';
 		$message .= '<p><strong>' . esc_html__( '🎉 Black Friday special! 🎉', 'accessibility-checker' ) . '</strong><br />';
-		$message .= esc_html__( 'Upgrade to a paid version of Accessibility Checker from November 24th to December 3rd and get 30% off! Full site scanning, site-wide open issues report, dismiss logs, and more.', 'accessibility-checker' ) . '<br />';
+		$message .= esc_html__( 'Upgrade to a paid version of Accessibility Checker from November 24th to December 3rd and get 30% off! Full site scanning, site-wide open issues report, dismissal logs, and more.', 'accessibility-checker' ) . '<br />';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://my.equalizedigital.com/support/pre-sale-questions/', 'admin-notice', 'BlackFriday25-presale', false ) ) . '">' . esc_html__( 'Ask a Pre-Sale Question', 'accessibility-checker' ) . '</a> ';
 		$message .= '<a class="button button-primary" href="' . esc_url( edac_link_wrapper( 'https://equalizedigital.com/accessibility-checker/pricing/', 'admin-notice', 'BlackFriday25-pricing', false ) ) . '">' . esc_html__( 'Upgrade Now', 'accessibility-checker' ) . '</a></p>';
 		$message .= '</div>';

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -837,7 +837,7 @@ class Ajax {
 		$valid_table  = edac_get_valid_table_name( $table_name );
 
 		if ( ! $first_id || ! $valid_table ) {
-			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+			wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
 		}
 
 		if ( isset( $_REQUEST['largeBatch'] ) && 'true' === $_REQUEST['largeBatch'] ) {
@@ -846,7 +846,7 @@ class Ajax {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
 			$batch_object = $wpdb->get_var( $wpdb->prepare( 'SELECT object FROM %i WHERE id = %d', $valid_table, $first_id ) );
 			if ( ! $batch_object ) {
-				wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+				wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
 			}
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
 			$affected_post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT postid FROM %i WHERE siteid = %d AND object = %s', $valid_table, $siteid, $batch_object ) );
@@ -858,7 +858,7 @@ class Ajax {
 		}
 
 		if ( empty( $affected_post_ids ) ) {
-			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+			wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
 		}
 
 		foreach ( $affected_post_ids as $affected_post_id ) {
@@ -902,7 +902,7 @@ class Ajax {
 		];
 
 		if ( ! $data ) {
-			wp_send_json_error( new \WP_Error( '-2', __( 'No ignore data to return', 'accessibility-checker' ) ) );
+			wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
 		}
 		wp_send_json_success( wp_json_encode( $data ) );
 	}

--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -837,7 +837,7 @@ class Ajax {
 		$valid_table  = edac_get_valid_table_name( $table_name );
 
 		if ( ! $first_id || ! $valid_table ) {
-			wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
+			wp_send_json_error( new \WP_Error( '-2', __( 'No dismissal data to return', 'accessibility-checker' ) ) );
 		}
 
 		if ( isset( $_REQUEST['largeBatch'] ) && 'true' === $_REQUEST['largeBatch'] ) {
@@ -846,7 +846,7 @@ class Ajax {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
 			$batch_object = $wpdb->get_var( $wpdb->prepare( 'SELECT object FROM %i WHERE id = %d', $valid_table, $first_id ) );
 			if ( ! $batch_object ) {
-				wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
+				wp_send_json_error( new \WP_Error( '-2', __( 'No dismissal data to return', 'accessibility-checker' ) ) );
 			}
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permission check requires direct lookup.
 			$affected_post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT postid FROM %i WHERE siteid = %d AND object = %s', $valid_table, $siteid, $batch_object ) );
@@ -858,7 +858,7 @@ class Ajax {
 		}
 
 		if ( empty( $affected_post_ids ) ) {
-			wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
+			wp_send_json_error( new \WP_Error( '-2', __( 'No dismissal data to return', 'accessibility-checker' ) ) );
 		}
 
 		foreach ( $affected_post_ids as $affected_post_id ) {
@@ -902,7 +902,7 @@ class Ajax {
 		];
 
 		if ( ! $data ) {
-			wp_send_json_error( new \WP_Error( '-2', __( 'No dismiss data to return', 'accessibility-checker' ) ) );
+			wp_send_json_error( new \WP_Error( '-2', __( 'No dismissal data to return', 'accessibility-checker' ) ) );
 		}
 		wp_send_json_success( wp_json_encode( $data ) );
 	}

--- a/admin/site-health/class-pro.php
+++ b/admin/site-health/class-pro.php
@@ -71,11 +71,11 @@ class Pro {
 					'value' => esc_html( get_option( 'edacp_simplified_summary_heading' ) ),
 				],
 				'ignore_permissions'     => [
-					'label' => __( 'Ignore Permissions', 'accessibility-checker' ),
+					'label' => __( 'Dismiss Permissions', 'accessibility-checker' ),
 					'value' => esc_html( get_option( 'edacp_ignore_user_roles' ) ? implode( ', ', get_option( 'edacp_ignore_user_roles' ) ) : __( 'None', 'accessibility-checker' ) ),
 				],
 				'ignores_db_table_count' => [
-					'label' => __( 'Ignores DB Table Count', 'accessibility-checker' ),
+					'label' => __( 'Dismisses DB Table Count', 'accessibility-checker' ),
 					'value' => absint( edac_database_table_count( 'accessibility_checker_global_ignores' ) ),
 				],
 				'fixes'                  => [

--- a/admin/site-health/class-pro.php
+++ b/admin/site-health/class-pro.php
@@ -75,7 +75,7 @@ class Pro {
 					'value' => esc_html( get_option( 'edacp_ignore_user_roles' ) ? implode( ', ', get_option( 'edacp_ignore_user_roles' ) ) : __( 'None', 'accessibility-checker' ) ),
 				],
 				'ignores_db_table_count' => [
-					'label' => __( 'Dismisses DB Table Count', 'accessibility-checker' ),
+					'label' => __( 'Dismissals DB Table Count', 'accessibility-checker' ),
 					'value' => absint( edac_database_table_count( 'accessibility_checker_global_ignores' ) ),
 				],
 				'fixes'                  => [

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -191,7 +191,7 @@ function edac_register_setting() {
 
 	add_settings_field(
 		'edacp_ignore_user_roles',
-		__( 'Ignore Permissions', 'accessibility-checker' ),
+		__( 'Dismiss Permissions', 'accessibility-checker' ),
 		'edac_ignore_user_roles_cb',
 		'edac_settings',
 		'edac_permissions',
@@ -682,7 +682,7 @@ function edac_post_types_cb() {
 		<?php } else { ?>
 			<p class="edac-description">
 				<?php
-				esc_html_e( 'Choose which post types should be checked during a scan. Please note, removing a previously selected post type will remove its scanned information and any custom ignored warnings that have been setup.', 'accessibility-checker' );
+				esc_html_e( 'Choose which post types should be checked during a scan. Please note, removing a previously selected post type will remove its scanned information and any custom dismissed warnings that have been setup.', 'accessibility-checker' );
 				?>
 			</p>
 			<?php
@@ -1000,7 +1000,7 @@ function edac_ignore_user_roles_cb() {
 		<?php endif; ?>
 	</fieldset>
 	<p class="edac-description">
-		<?php esc_html_e( 'Choose which user roles have permission to ignore issues.', 'accessibility-checker' ); ?>
+		<?php esc_html_e( 'Choose which user roles have permission to dismiss issues.', 'accessibility-checker' ); ?>
 	</p>
 	<?php
 }

--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -1211,7 +1211,7 @@ class AccessibilityCheckerHighlight {
 			const typeIconUri = typeIconDataUris[ matchingObj.rule_type ];
 			const typeBadgeHtml = `<span class="edac-badge edac-badge--${ matchingObj.rule_type } edac-badge--large">
 				${ typeIconUri ? `<img src="${ typeIconUri }" width="16" height="16" style="display:block;width:16px;height:16px;flex-shrink:0" alt="" />` : '' }
-				<span class="edac-badge__label">${ { error: __( 'Problem', 'accessibility-checker' ), warning: __( 'Needs Review', 'accessibility-checker' ), ignored: __( 'Ignored', 'accessibility-checker' ) }[ matchingObj.rule_type ] ?? matchingObj.rule_type }</span>
+				<span class="edac-badge__label">${ { error: __( 'Problem', 'accessibility-checker' ), warning: __( 'Needs Review', 'accessibility-checker' ), ignored: __( 'Dismissed', 'accessibility-checker' ) }[ matchingObj.rule_type ] ?? matchingObj.rule_type }</span>
 			</span>`;
 
 			content += `</div>`;
@@ -1619,8 +1619,8 @@ class AccessibilityCheckerHighlight {
 		const breakdownParts = [ problemsLabel, reviewLabel ];
 		if ( ignoredCount > 0 ) {
 			breakdownParts.push( sprintf(
-				// translators: %d is the number of ignored issues.
-				_n( '%d Ignored', '%d Ignored', ignoredCount, 'accessibility-checker' ),
+				// translators: %d is the number of dismissed issues.
+				_n( '%d Dismissed', '%d Dismissed', ignoredCount, 'accessibility-checker' ),
 				ignoredCount
 			) );
 		}


### PR DESCRIPTION
## Summary
- Follow-up to the rule-class wording fix already on `develop` (PRO-1039 scope item: "all other files and components where 'Ignore' terminology appears").
- Updates the remaining user-facing strings still saying "Ignore" to "Dismiss":
  - `includes/options-page.php` — settings field label and descriptions
  - `admin/class-admin-notices.php` — Black Friday promo notice copy
  - `admin/class-ajax.php` — AJAX error message (4 occurrences)
  - `admin/site-health/class-pro.php` — Site Health info labels
  - `src/frontendHighlighterApp/index.js` — highlighter badge label and summary count text

## Test plan
- [x] `php -l` on all changed PHP files
- [x] `node --check` on the changed JS file
- [x] Verified no remaining translatable strings contain "Ignore"/"ignore" outside of internal field/variable names (e.g. `ignore_global`, `ignore_user_roles`), which are out of scope per Linear discussion
- [ ] Manually verify settings page, Black Friday notice, and frontend highlighter render correctly with new copy

Closes PRO-1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated terminology throughout the user interface to improve consistency and clarity by replacing “ignore” with “dismiss” across user-facing elements, including promotional notices, AJAX error messaging, permissions labels, site health indicators, options page descriptions, and issue status badges/counts in the admin and frontend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->