### PR TITLE
a11y: announce dismiss/reopen result to screen readers via speak() (PRO-1068)

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -259,6 +259,7 @@ class Enqueue_Admin {
 				'wp-i18n',
 				'wp-api-fetch',
 				'wp-html-entities',
+				'wp-a11y',
 			],
 			EDAC_VERSION,
 			true

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -5,6 +5,7 @@
  */
 
 import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Panel, PanelBody, Button, Spinner, Notice, RadioControl, Dropdown } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
@@ -46,11 +47,11 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 		try {
 			const response = await toggleIssueDismiss( issue.id, ignore, ignore ? dismissReason : '', ignore ? comment : '', ignore ? isGlobal : isGloballyDismissed );
 			setIsIgnored( ignore );
-			setSuccessNotice(
-				ignore
-					? __( 'Issue dismissed successfully.', 'accessibility-checker' )
-					: __( 'Issue reopened successfully.', 'accessibility-checker' ),
-			);
+			const successMessage = ignore
+				? __( 'Issue dismissed successfully.', 'accessibility-checker' )
+				: __( 'Issue reopened successfully.', 'accessibility-checker' );
+			setSuccessNotice( successMessage );
+			speak( successMessage, 'polite' );
 			// Keep local issue fields in sync so UI reflects reason/comment immediately.
 			// Use the same keys as both the details processor and dismiss response.
 			if ( ignore && response && response.success ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,5 +137,6 @@ module.exports = {
 		'@wordpress/rich-text': [ 'wp', 'richText' ],
 		'@wordpress/html-entities': [ 'wp', 'htmlEntities' ],
 		'@wordpress/code-editor': [ 'wp', 'codeEditor' ],
+		'@wordpress/a11y': [ 'wp', 'a11y' ],
 	},
 };


### PR DESCRIPTION
## Summary

- Adds `speak()` from `@wordpress/a11y` to `DismissPanel.js` alongside the existing `setSuccessNotice()` call so screen reader users hear the dismiss/reopen outcome without needing to navigate to the visible notice
- The same string is reused for both the visible notice and the `speak()` call so they are always in sync
- Covers both the block editor modal and the pro Issues Explorer (which uses `DismissPanel` via its `DismissModal` component)

Also wires up the dependency properly:
- `webpack.config.js`: adds `'@wordpress/a11y'` to externals so it resolves to the global `wp.a11y` rather than bundling the package inline
- `class-enqueue-admin.php`: adds `wp-a11y` to the `edac-issue-modal` script dependency array

## Test plan

- [x] `speak()` fires after dismiss/reopen alongside `setSuccessNotice()`
- [x] `@wordpress/a11y` added to webpack externals
- [x] `wp-a11y` added to PHP script dependency array
- [ ] Open the block editor on a post with accessibility issues
- [ ] Open the issue modal and dismiss an issue — verify a screen reader announces "Issue dismissed successfully."
- [ ] Reopen the dismissed issue — verify the screen reader announces "Issue reopened successfully."
- [ ] Confirm the visible success notice also appears as before (no regression)

Fixes: PRO-1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)