### PR TITLE
Remove extra WordPress.org plugin tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Equalize Digital Accessibility Checker - WCAG, ADA, EAA and Section 508 compliance ===
 Contributors: equalizedigital, alh0319, stevejonesdev
-Tags: accessibility, EAA, WCAG, ADA, WP accessibility, accessibility scanner
+Tags: accessibility, EAA, WCAG, ADA, WP accessibility
 Requires at least: 6.7
 Tested up to: 7.0
 Stable tag: 1.44.1


### PR DESCRIPTION
## Summary
- remove the extra 'accessibility scanner' tag from readme.txt
- keep plugin metadata within WordPress.org's 5-tag limit

## Why
WordPress.org warned that one tag was ignored because the plugin listed more than 5 tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin metadata tags to enhance discoverability in accessibility-related searches and categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->