### PR TITLE
Focus accordion toggle before clearing dismiss success notice

### DIFF
--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -9,7 +9,7 @@ import { speak } from '@wordpress/a11y';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Panel, PanelBody, Button, Spinner, Notice, RadioControl, Dropdown } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import RichTextarea from './RichTextarea';
 import { toggleIssueDismiss } from '../api';
 import { setPendingRefetch } from '../index';
@@ -28,6 +28,7 @@ import { getDismissReasonOptions } from '../../sidebar/utils/dismissHelpers';
  * @param {boolean}  props.isPro        - Whether the current UI is running in Pro.
  */
 const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceGlobal = false, isPro = typeof window !== 'undefined' && window.edac_editor_app?.pro === '1' } ) => {
+	const panelRef = useRef( null );
 	const [ comment, setComment ] = useState( issue?.ignre_comment ? decodeEntities( issue.ignre_comment ) : '' );
 	const [ dismissReason, setDismissReason ] = useState( issue?.ignre_reason || 'false_positive' );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
@@ -114,7 +115,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 	}
 
 	return (
-		<div className="edac-analysis__dismiss-panel" data-section="dismiss">
+		<div className="edac-analysis__dismiss-panel" data-section="dismiss" ref={ panelRef }>
 			<Panel>
 				<PanelBody
 					title={ panelTitle }
@@ -126,7 +127,10 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 							<Notice
 								status="success"
 								isDismissible={ true }
-								onRemove={ () => setSuccessNotice( null ) }
+								onRemove={ () => {
+									panelRef.current?.querySelector( '.components-panel__body-toggle' )?.focus();
+									setSuccessNotice( null );
+								} }
 							>
 								{ successNotice }
 							</Notice>

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -128,7 +128,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 								status="success"
 								isDismissible={ true }
 								onRemove={ () => {
-									panelRef.current?.querySelector( '.components-panel__body-toggle' )?.focus();
+									panelRef.current?.querySelector( '.components-panel__body-toggle, button' )?.focus();
 									setSuccessNotice( null );
 								} }
 							>


### PR DESCRIPTION
## Summary

- Adds a `useRef` on the outer `DismissPanel` wrapper div
- On notice dismiss (`onRemove`), focuses the `PanelBody` toggle button (`.components-panel__body-toggle`) **before** clearing the notice state, so focus moves to a live element before the notice's close button is unmounted
- Resolves PRO-1065

## Why focus first, then clear?

The notice's dismiss button is about to be removed from the DOM. If we cleared state first, React would unmount the button while it still has focus — the browser then tries to recover focus, usually landing on `<body>`. By focusing the toggle button first (still in the DOM), the transition is seamless and no focus loss occurs.

## Test plan

- [ ] Dismiss an issue in the issue modal
- [ ] When the success notice appears, press Tab to reach its "Close" button and activate it (or click it)
- [ ] Verify focus lands on the "Dismiss Issue" accordion toggle, not `<body>` or the modal backdrop
- [ ] Also verify clicking the notice close button with a mouse doesn't break anything visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When dismissing success notices in the issue modal, focus is now properly managed and returned to the panel’s control for improved keyboard navigation and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->