### PR TITLE
Add @since update tool and release prep integration

### DIFF
--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -33,10 +33,39 @@ MAIN_BRANCH=main
 DEVELOP_BRANCH=develop
 RELEASE_BRANCH_NAME=release/${BUMPED_VERSION}
 
+# Ensure local tags are fully in sync with remote tags before release prep.
+verify_local_tags_match_remote() {
+  local local_tags_file
+  local remote_tags_file
+
+  local_tags_file=$(mktemp)
+  remote_tags_file=$(mktemp)
+
+  # Always clean up temporary files before returning.
+  trap 'rm -f "${local_tags_file}" "${remote_tags_file}"' RETURN
+
+  # --refs avoids peeled annotated-tag entries (^{}) for clean one-line refs.
+  git show-ref --tags | awk '{print $1" "$2}' | sort > "${local_tags_file}"
+  git ls-remote --tags --refs origin | awk '{print $1" "$2}' | sort > "${remote_tags_file}"
+
+  if ! diff -u "${remote_tags_file}" "${local_tags_file}" >/dev/null; then
+    echo
+    echo "Error: local tags do not match tags on origin."
+    echo "Please sync tags before running release prep."
+    echo
+    diff -u "${remote_tags_file}" "${local_tags_file}" || true
+    return 1
+  fi
+
+  echo "Tag sync check passed: local tags match origin."
+  return 0
+}
+
 echo
 echo "Creating release branch"
 echo
-git fetch
+git fetch origin --tags --prune-tags
+verify_local_tags_match_remote
 git checkout ${DEVELOP_BRANCH}
 git pull
 git checkout -b ${RELEASE_BRANCH_NAME}
@@ -56,20 +85,20 @@ echo
 # Function to fetch WordPress versions and calculate required version
 update_wp_requires_version() {
     echo "Fetching WordPress version list..."
-    
+
     # Get current "Tested up to" version from readme.txt
     local tested_up_to=$(grep "Tested up to:" "${README_PATH}" | sed -E 's/Tested up to: ([0-9]+\.[0-9]+).*/\1/')
-    
+
     if [[ -z "${tested_up_to}" ]]; then
         echo "Error: Could not extract 'Tested up to' version from readme.txt" >&2
         return 1
     fi
-    
+
     echo "Current 'Tested up to': ${tested_up_to}"
-    
+
     # Try to fetch WordPress versions from the API first
     local wp_versions_json=$(curl -s --max-time 10 "https://api.wordpress.org/core/version-check/1.7/" 2>/dev/null || echo "")
-    
+
     if [[ -n "${wp_versions_json}" ]]; then
         echo "Using WordPress API for version data..."
         # Parse JSON response to get version list in reverse chronological order
@@ -83,7 +112,7 @@ update_wp_requires_version() {
         echo "API unavailable, trying to parse releases page..."
         # Fallback: try to parse the releases page
         local releases_html=$(curl -s --max-time 15 "https://wordpress.org/download/releases/" 2>/dev/null || echo "")
-        
+
         if [[ -n "${releases_html}" ]]; then
             # Extract version numbers from the releases page
             # Look for patterns like "WordPress 6.8" or "wordpress-6.7.zip"
@@ -97,20 +126,20 @@ update_wp_requires_version() {
             return 1
         fi
     fi
-    
+
     if [[ -z "${versions_list}" ]]; then
         echo "Error: No WordPress versions found in response" >&2
         return 1
     fi
-    
+
     echo "Found WordPress versions (latest first):"
     echo "${versions_list}" | head -10
-    
+
     # Find the current tested version in the list and go back 2 versions (to support last 3 versions)
     local found_current=false
     local version_count=0
     local target_version=""
-    
+
     while IFS= read -r version; do
         if [[ "${found_current}" == true ]]; then
             version_count=$((version_count + 1))
@@ -123,13 +152,13 @@ update_wp_requires_version() {
             echo "Found current tested version ${tested_up_to} in version list"
         fi
     done <<< "${versions_list}"
-    
+
     if [[ "${found_current}" == false ]]; then
         echo "Warning: Current 'Tested up to' version ${tested_up_to} not found in WordPress version list" >&2
         echo "Available versions: $(echo "${versions_list}" | tr '\n' ' ')" >&2
         return 1
     fi
-    
+
     if [[ -z "${target_version}" ]]; then
         echo "Warning: Could not find version 2 releases back from ${tested_up_to}" >&2
         # Try to use the oldest version we found if we don't have enough history
@@ -140,19 +169,19 @@ update_wp_requires_version() {
             return 1
         fi
     fi
-    
+
     # Ensure we don't go below WordPress 5.0 (reasonable minimum)
     local min_major=$(echo "${target_version}" | cut -d. -f1)
     if [[ ${min_major} -lt 5 ]]; then
         target_version="5.0"
         echo "Adjusted to minimum supported version: ${target_version}"
     fi
-    
+
     echo "Setting 'Requires at least' to: ${target_version} (2 versions back from ${tested_up_to} to support last 3 versions)"
-    
+
     # Update the readme.txt file
     sed -i.bak -E "s/(Requires at least: )[0-9]+\.[0-9]+/\1${target_version}/" "${README_PATH}"
-    
+
     return 0
 }
 
@@ -170,6 +199,48 @@ echo "Committing version bump"
 echo
 git add ${MAIN_FILE_PATH} ${PACKAGE_JSON_PATH} ${README_PATH}
 git commit -m "Bump version ${VERSION} -> ${BUMPED_VERSION}"
+
+echo
+echo "Updating @since placeholder tags to ${BUMPED_VERSION}"
+echo
+
+# Stash any existing uncommitted work (tracked modifications + untracked files)
+# so that the subsequent git diff picks up only what the tool changes.
+STASH_MESSAGE="prep_release: pre-since-tag stash"
+git stash push --include-untracked -m "${STASH_MESSAGE}"
+STASH_CREATED=$?
+
+# Ensure the stash is always restored, even if the script exits early.
+restore_stash() {
+  if [[ ${STASH_CREATED} -eq 0 ]]; then
+    echo
+    echo "Restoring stashed changes"
+    echo
+    git stash pop
+  fi
+}
+trap restore_stash EXIT
+
+php tools/update-since-tags.php --version="${BUMPED_VERSION}" --changed-since-last-tag
+
+# Stage only the tracked PHP files that were modified by the tool.
+# git diff --name-only only lists tracked files with unstaged changes,
+# so untracked files are never included.
+SINCE_CHANGES=$(git diff --name-only -- '*.php')
+if [[ -n "${SINCE_CHANGES}" ]]; then
+  echo
+  echo "Committing @since tag updates"
+  echo
+  echo "${SINCE_CHANGES}" | xargs git add --
+  git commit -m "Update @since placeholders to ${BUMPED_VERSION}"
+else
+  echo "No @since placeholder tags found — skipping commit."
+fi
+
+# Restore stashed work now (trap will also fire on EXIT, guard against double-pop).
+restore_stash
+trap - EXIT
+
 git push -u origin ${RELEASE_BRANCH_NAME}
 
 echo

--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -34,26 +34,21 @@ DEVELOP_BRANCH=develop
 RELEASE_BRANCH_NAME=release/${BUMPED_VERSION}
 
 # Ensure local tags are fully in sync with remote tags before release prep.
+# Uses process substitution to avoid orphaned temp files on early exit.
 verify_local_tags_match_remote() {
-  local local_tags_file
-  local remote_tags_file
-
-  local_tags_file=$(mktemp)
-  remote_tags_file=$(mktemp)
-
-  # Always clean up temporary files before returning.
-  trap 'rm -f "${local_tags_file}" "${remote_tags_file}"' RETURN
-
-  # --refs avoids peeled annotated-tag entries (^{}) for clean one-line refs.
-  git show-ref --tags | awk '{print $1" "$2}' | sort > "${local_tags_file}"
-  git ls-remote --tags --refs origin | awk '{print $1" "$2}' | sort > "${remote_tags_file}"
-
-  if ! diff -u "${remote_tags_file}" "${local_tags_file}" >/dev/null; then
+  # --refs strips peeled annotated-tag entries (^{}) for clean one-line refs.
+  if ! diff -u \
+    <(git ls-remote --tags --refs origin 2>/dev/null | awk '{print $1" "$2}' | sort) \
+    <(git show-ref --tags 2>/dev/null | awk '{print $1" "$2}' | sort) \
+    >/dev/null; then
     echo
     echo "Error: local tags do not match tags on origin."
-    echo "Please sync tags before running release prep."
+    echo "Please sync tags before running release prep:"
+    echo "  git fetch origin --tags --prune-tags"
     echo
-    diff -u "${remote_tags_file}" "${local_tags_file}" || true
+    diff -u \
+      <(git ls-remote --tags --refs origin 2>/dev/null | awk '{print $1" "$2}' | sort) \
+      <(git show-ref --tags 2>/dev/null | awk '{print $1" "$2}' | sort) || true
     return 1
   fi
 
@@ -206,16 +201,25 @@ echo
 
 # Stash any existing uncommitted work (tracked modifications + untracked files)
 # so that the subsequent git diff picks up only what the tool changes.
+# Track stash ref before/after to guard against popping an unrelated stash when
+# git stash push exits 0 even if there was nothing to save.
 STASH_MESSAGE="prep_release: pre-since-tag stash"
+STASH_BEFORE=$(git rev-parse -q --verify refs/stash || true)
 git stash push --include-untracked -m "${STASH_MESSAGE}"
-STASH_CREATED=$?
+STASH_AFTER=$(git rev-parse -q --verify refs/stash || true)
+STASH_CREATED=false
+if [[ -n "${STASH_AFTER}" && "${STASH_AFTER}" != "${STASH_BEFORE}" ]]; then
+  STASH_CREATED=true
+fi
 
 # Ensure the stash is always restored, even if the script exits early.
+# Setting STASH_CREATED=false before popping prevents the EXIT trap double-pop.
 restore_stash() {
-  if [[ ${STASH_CREATED} -eq 0 ]]; then
+  if [[ "${STASH_CREATED}" == true ]]; then
     echo
     echo "Restoring stashed changes"
     echo
+    STASH_CREATED=false
     git stash pop
   fi
 }
@@ -223,15 +227,14 @@ trap restore_stash EXIT
 
 php tools/update-since-tags.php --version="${BUMPED_VERSION}" --changed-since-last-tag
 
-# Stage only the tracked PHP files that were modified by the tool.
-# git diff --name-only only lists tracked files with unstaged changes,
-# so untracked files are never included.
-SINCE_CHANGES=$(git diff --name-only -- '*.php')
-if [[ -n "${SINCE_CHANGES}" ]]; then
+# Stage only the tracked PHP files modified by the tool.
+# Use NUL-delimited output + mapfile + xargs -0 so paths with spaces are safe.
+mapfile -d '' SINCE_CHANGES < <(git diff --name-only -z -- '*.php')
+if (( ${#SINCE_CHANGES[@]} > 0 )); then
   echo
   echo "Committing @since tag updates"
   echo
-  echo "${SINCE_CHANGES}" | xargs git add --
+  printf '%s\0' "${SINCE_CHANGES[@]}" | xargs -0 git add --
   git commit -m "Update @since placeholders to ${BUMPED_VERSION}"
 else
   echo "No @since placeholder tags found — skipping commit."

--- a/tools/update-since-tags.php
+++ b/tools/update-since-tags.php
@@ -14,8 +14,8 @@
 
 declare( strict_types=1 );
 
-const EDAC_SINCE_TOOL_EXIT_OK = 0;
-const EDAC_SINCE_TOOL_EXIT_BAD_ARGS = 1;
+const EDAC_SINCE_TOOL_EXIT_OK            = 0;
+const EDAC_SINCE_TOOL_EXIT_BAD_ARGS      = 1;
 const EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR = 2;
 
 $opts = getopt(
@@ -32,65 +32,66 @@ $opts = getopt(
 );
 
 if ( isset( $opts['help'] ) ) {
-	echo "Usage: php tools/update-since-tags.php --version=<x.y.z> [options]\n\n";
-	echo "Options:\n";
-	echo "  --root=<path>                Root directory to scan (default: current working directory)\n";
-	echo "  --placeholder=<value>        Placeholder token after @since (default: x.x.x)\n";
-	echo "  --changed-since-tag=<tag>    Only scan tracked PHP files changed since this Git tag/ref\n";
-	echo "  --changed-since-last-tag     Only scan tracked PHP files changed since latest Git tag\n";
-	echo "  --dry-run                    Show what would be changed without writing files\n";
-	echo "  --help                       Show this help\n";
-	exit( EDAC_SINCE_TOOL_EXIT_OK );
+	edac_write_line( 'Usage: php tools/update-since-tags.php --version=<x.y.z> [options]' );
+	edac_write_line( '' );
+	edac_write_line( 'Options:' );
+	edac_write_line( '  --root=<path>                Root directory to scan (default: current working directory)' );
+	edac_write_line( '  --placeholder=<value>        Placeholder token after @since (default: x.x.x)' );
+	edac_write_line( '  --changed-since-tag=<tag>    Only scan tracked PHP files changed since this Git tag/ref' );
+	edac_write_line( '  --changed-since-last-tag     Only scan tracked PHP files changed since latest Git tag' );
+	edac_write_line( '  --dry-run                    Show what would be changed without writing files' );
+	edac_write_line( '  --help                       Show this help' );
+	exit( EDAC_SINCE_TOOL_EXIT_OK ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 // Backward compatibility for the earlier positional-argument usage.
 $version = $opts['version'] ?? ( $argv[1] ?? '' );
 if ( ! is_string( $version ) || ! preg_match( '/^\d+\.\d+\.\d+$/', $version ) ) {
-	fwrite( STDERR, "Error: --version is required and must be in x.y.z format.\n" );
-	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+	edac_write_line( 'Error: --version is required and must be in x.y.z format.', STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 $root = $opts['root'] ?? dirname( __DIR__ );
 if ( ! is_string( $root ) || ! is_dir( $root ) ) {
-	fwrite( STDERR, 'Error: root directory does not exist: ' . (string) $root . "\n" );
-	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+	edac_write_line( 'Error: root directory does not exist: ' . (string) $root, STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 $root = rtrim( (string) $root, DIRECTORY_SEPARATOR );
 
 $placeholder = $opts['placeholder'] ?? 'x.x.x';
 if ( ! is_string( $placeholder ) || '' === trim( $placeholder ) ) {
-	fwrite( STDERR, "Error: --placeholder must be a non-empty string.\n" );
-	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+	edac_write_line( 'Error: --placeholder must be a non-empty string.', STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
-$changed_since_tag = $opts['changed-since-tag'] ?? null;
+$changed_since_tag      = $opts['changed-since-tag'] ?? null;
 $changed_since_last_tag = isset( $opts['changed-since-last-tag'] );
-$dry_run = isset( $opts['dry-run'] );
+$dry_run                = isset( $opts['dry-run'] );
 
 if ( null !== $changed_since_tag && $changed_since_last_tag ) {
-	fwrite( STDERR, "Error: use either --changed-since-tag or --changed-since-last-tag, not both.\n" );
-	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+	edac_write_line( 'Error: use either --changed-since-tag or --changed-since-last-tag, not both.', STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 if ( $changed_since_last_tag ) {
 	$changed_since_tag = trim( edac_run_git( $root, 'describe --tags --abbrev=0' ) );
 	if ( '' === $changed_since_tag ) {
-		fwrite( STDERR, "Error: no tags found to use with --changed-since-last-tag.\n" );
-		exit( EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR );
+		edac_write_line( 'Error: no tags found to use with --changed-since-last-tag.', STDERR );
+		exit( EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 
 $excluded_dirs = [ '.git', 'vendor', 'node_modules', 'build', 'dist' ];
-$php_files = ( null !== $changed_since_tag )
+$php_files     = ( null !== $changed_since_tag )
 	? edac_get_changed_php_files_since_ref( $root, (string) $changed_since_tag )
 	: edac_get_all_php_files( $root, $excluded_dirs );
 
 $placeholder_regex = preg_quote( $placeholder, '/' );
-$pattern = '/@since(\s+)' . $placeholder_regex . '/i';
-$replacement = '@since${1}' . $version;
+$pattern           = '/@since(\s+)' . $placeholder_regex . '/i';
+$replacement       = '@since${1}' . $version;
 
 $updated_files = 0;
-$updated_tags = 0;
+$updated_tags  = 0;
 $scanned_files = 0;
 
 foreach ( $php_files as $file_path ) {
@@ -102,7 +103,7 @@ foreach ( $php_files as $file_path ) {
 
 	$contents = file_get_contents( $file_path ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 	if ( false === $contents ) {
-		fwrite( STDERR, "Warning: unable to read file: {$file_path}\n" );
+		edac_write_line( "Warning: unable to read file: {$file_path}", STDERR );
 		continue;
 	}
 
@@ -119,24 +120,24 @@ foreach ( $php_files as $file_path ) {
 	$display_path = ltrim( str_replace( $root, '', $file_path ), DIRECTORY_SEPARATOR );
 
 	if ( $dry_run ) {
-		echo "Would update {$count} tag(s) in {$display_path}\n";
+		edac_write_line( "Would update {$count} tag(s) in {$display_path}" );
 	} else {
 		$write_result = file_put_contents( $file_path, $new_contents ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
 		if ( false === $write_result ) {
-			fwrite( STDERR, "Warning: unable to write file: {$file_path}\n" );
+			edac_write_line( "Warning: unable to write file: {$file_path}", STDERR );
 			continue;
 		}
-		echo "Updated {$count} tag(s) in {$display_path}\n";
+		edac_write_line( "Updated {$count} tag(s) in {$display_path}" );
 	}
 
 	++$updated_files;
 	$updated_tags += (int) $count;
 }
 
-$mode = $dry_run ? 'DRY RUN' : 'DONE';
-echo "{$mode}: replaced {$updated_tags} placeholder @since tag(s) across {$updated_files} file(s); scanned {$scanned_files} PHP file(s).\n";
+$status_label = $dry_run ? 'DRY RUN' : 'DONE';
+edac_write_line( "{$status_label}: replaced {$updated_tags} placeholder @since tag(s) across {$updated_files} file(s); scanned {$scanned_files} PHP file(s)." );
 
-exit( EDAC_SINCE_TOOL_EXIT_OK );
+exit( EDAC_SINCE_TOOL_EXIT_OK ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 /**
  * Get all PHP files in the repository, excluding known dependency/build dirs.
@@ -146,7 +147,7 @@ exit( EDAC_SINCE_TOOL_EXIT_OK );
  * @return string[]
  */
 function edac_get_all_php_files( string $root, array $excluded_dirs ): array {
-	$files = [];
+	$files    = [];
 	$iterator = new RecursiveIteratorIterator(
 		new RecursiveDirectoryIterator( $root, RecursiveDirectoryIterator::SKIP_DOTS )
 	);
@@ -156,7 +157,7 @@ function edac_get_all_php_files( string $root, array $excluded_dirs ): array {
 			continue;
 		}
 
-		$path = $item->getPathname();
+		$path          = $item->getPathname();
 		$relative_path = ltrim( str_replace( $root, '', $path ), DIRECTORY_SEPARATOR );
 
 		foreach ( $excluded_dirs as $excluded ) {
@@ -184,7 +185,7 @@ function edac_get_all_php_files( string $root, array $excluded_dirs ): array {
  * @return string[]
  */
 function edac_get_changed_php_files_since_ref( string $root, string $ref ): array {
-	$cmd = 'diff --name-only ' . escapeshellarg( $ref . '..HEAD' ) . ' -- ' . escapeshellarg( '*.php' );
+	$cmd    = 'diff --name-only ' . escapeshellarg( $ref . '..HEAD' ) . ' -- ' . escapeshellarg( '*.php' );
 	$output = edac_run_git( $root, $cmd );
 
 	$files = [];
@@ -212,10 +213,19 @@ function edac_get_changed_php_files_since_ref( string $root, string $ref ): arra
  * @return string
  */
 function edac_run_git( string $root, string $args ): string {
-	$cmd = 'git -C ' . escapeshellarg( $root ) . ' ' . $args . ' 2>/dev/null';
+	$cmd    = 'git -C ' . escapeshellarg( $root ) . ' ' . $args . ' 2>/dev/null';
 	$output = shell_exec( $cmd ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
 
 	return is_string( $output ) ? $output : '';
 }
 
-
+/**
+ * Write a line to STDOUT/STDERR for CLI usage.
+ *
+ * @param string   $message Message to output.
+ * @param resource $stream  Output stream, STDOUT by default.
+ * @return void
+ */
+function edac_write_line( string $message, $stream = STDOUT ): void {
+	fwrite( $stream, $message . "\n" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+}

--- a/tools/update-since-tags.php
+++ b/tools/update-since-tags.php
@@ -1,0 +1,221 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Update placeholder @since tags in PHP docblocks.
+ *
+ * Usage examples:
+ * - php tools/update-since-tags.php --version=1.43.0
+ * - php tools/update-since-tags.php --version=1.43.0 --changed-since-last-tag
+ * - php tools/update-since-tags.php --version=1.43.0 --changed-since-tag=v1.42.0
+ * - php tools/update-since-tags.php --version=1.43.0 --root=/path/to/repo --dry-run
+ *
+ * @package AccessibilityChecker
+ */
+
+declare( strict_types=1 );
+
+const EDAC_SINCE_TOOL_EXIT_OK = 0;
+const EDAC_SINCE_TOOL_EXIT_BAD_ARGS = 1;
+const EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR = 2;
+
+$opts = getopt(
+	'',
+	[
+		'version:',
+		'root::',
+		'placeholder::',
+		'changed-since-tag::',
+		'changed-since-last-tag',
+		'dry-run',
+		'help',
+	]
+);
+
+if ( isset( $opts['help'] ) ) {
+	echo "Usage: php tools/update-since-tags.php --version=<x.y.z> [options]\n\n";
+	echo "Options:\n";
+	echo "  --root=<path>                Root directory to scan (default: current working directory)\n";
+	echo "  --placeholder=<value>        Placeholder token after @since (default: x.x.x)\n";
+	echo "  --changed-since-tag=<tag>    Only scan tracked PHP files changed since this Git tag/ref\n";
+	echo "  --changed-since-last-tag     Only scan tracked PHP files changed since latest Git tag\n";
+	echo "  --dry-run                    Show what would be changed without writing files\n";
+	echo "  --help                       Show this help\n";
+	exit( EDAC_SINCE_TOOL_EXIT_OK );
+}
+
+// Backward compatibility for the earlier positional-argument usage.
+$version = $opts['version'] ?? ( $argv[1] ?? '' );
+if ( ! is_string( $version ) || ! preg_match( '/^\d+\.\d+\.\d+$/', $version ) ) {
+	fwrite( STDERR, "Error: --version is required and must be in x.y.z format.\n" );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+}
+
+$root = $opts['root'] ?? dirname( __DIR__ );
+if ( ! is_string( $root ) || ! is_dir( $root ) ) {
+	fwrite( STDERR, 'Error: root directory does not exist: ' . (string) $root . "\n" );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+}
+$root = rtrim( (string) $root, DIRECTORY_SEPARATOR );
+
+$placeholder = $opts['placeholder'] ?? 'x.x.x';
+if ( ! is_string( $placeholder ) || '' === trim( $placeholder ) ) {
+	fwrite( STDERR, "Error: --placeholder must be a non-empty string.\n" );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+}
+
+$changed_since_tag = $opts['changed-since-tag'] ?? null;
+$changed_since_last_tag = isset( $opts['changed-since-last-tag'] );
+$dry_run = isset( $opts['dry-run'] );
+
+if ( null !== $changed_since_tag && $changed_since_last_tag ) {
+	fwrite( STDERR, "Error: use either --changed-since-tag or --changed-since-last-tag, not both.\n" );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS );
+}
+
+if ( $changed_since_last_tag ) {
+	$changed_since_tag = trim( edac_run_git( $root, 'describe --tags --abbrev=0' ) );
+	if ( '' === $changed_since_tag ) {
+		fwrite( STDERR, "Error: no tags found to use with --changed-since-last-tag.\n" );
+		exit( EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR );
+	}
+}
+
+$excluded_dirs = [ '.git', 'vendor', 'node_modules', 'build', 'dist' ];
+$php_files = ( null !== $changed_since_tag )
+	? edac_get_changed_php_files_since_ref( $root, (string) $changed_since_tag )
+	: edac_get_all_php_files( $root, $excluded_dirs );
+
+$placeholder_regex = preg_quote( $placeholder, '/' );
+$pattern = '/@since(\s+)' . $placeholder_regex . '/i';
+$replacement = '@since${1}' . $version;
+
+$updated_files = 0;
+$updated_tags = 0;
+$scanned_files = 0;
+
+foreach ( $php_files as $file_path ) {
+	++$scanned_files;
+
+	if ( ! is_file( $file_path ) || ! is_readable( $file_path ) ) {
+		continue;
+	}
+
+	$contents = file_get_contents( $file_path ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+	if ( false === $contents ) {
+		fwrite( STDERR, "Warning: unable to read file: {$file_path}\n" );
+		continue;
+	}
+
+	$count = preg_match_all( $pattern, $contents );
+	if ( 0 === $count ) {
+		continue;
+	}
+
+	$new_contents = preg_replace( $pattern, $replacement, $contents );
+	if ( ! is_string( $new_contents ) || $new_contents === $contents ) {
+		continue;
+	}
+
+	$display_path = ltrim( str_replace( $root, '', $file_path ), DIRECTORY_SEPARATOR );
+
+	if ( $dry_run ) {
+		echo "Would update {$count} tag(s) in {$display_path}\n";
+	} else {
+		$write_result = file_put_contents( $file_path, $new_contents ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+		if ( false === $write_result ) {
+			fwrite( STDERR, "Warning: unable to write file: {$file_path}\n" );
+			continue;
+		}
+		echo "Updated {$count} tag(s) in {$display_path}\n";
+	}
+
+	++$updated_files;
+	$updated_tags += (int) $count;
+}
+
+$mode = $dry_run ? 'DRY RUN' : 'DONE';
+echo "{$mode}: replaced {$updated_tags} placeholder @since tag(s) across {$updated_files} file(s); scanned {$scanned_files} PHP file(s).\n";
+
+exit( EDAC_SINCE_TOOL_EXIT_OK );
+
+/**
+ * Get all PHP files in the repository, excluding known dependency/build dirs.
+ *
+ * @param string   $root          Root directory.
+ * @param string[] $excluded_dirs Directory names to skip.
+ * @return string[]
+ */
+function edac_get_all_php_files( string $root, array $excluded_dirs ): array {
+	$files = [];
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $root, RecursiveDirectoryIterator::SKIP_DOTS )
+	);
+
+	foreach ( $iterator as $item ) {
+		if ( ! $item instanceof SplFileInfo || $item->isDir() ) {
+			continue;
+		}
+
+		$path = $item->getPathname();
+		$relative_path = ltrim( str_replace( $root, '', $path ), DIRECTORY_SEPARATOR );
+
+		foreach ( $excluded_dirs as $excluded ) {
+			$needle = $excluded . DIRECTORY_SEPARATOR;
+			if ( 0 === strpos( $relative_path, $needle ) || false !== strpos( $relative_path, DIRECTORY_SEPARATOR . $needle ) ) {
+				continue 2;
+			}
+		}
+
+		if ( 'php' === strtolower( (string) $item->getExtension() ) ) {
+			$files[] = $path;
+		}
+	}
+
+	sort( $files );
+
+	return $files;
+}
+
+/**
+ * Get tracked PHP files changed between a given ref and HEAD.
+ *
+ * @param string $root Root directory.
+ * @param string $ref  Git ref/tag.
+ * @return string[]
+ */
+function edac_get_changed_php_files_since_ref( string $root, string $ref ): array {
+	$cmd = 'diff --name-only ' . escapeshellarg( $ref . '..HEAD' ) . ' -- ' . escapeshellarg( '*.php' );
+	$output = edac_run_git( $root, $cmd );
+
+	$files = [];
+	foreach ( preg_split( '/\r?\n/', trim( $output ) ) as $line ) {
+		if ( '' === $line ) {
+			continue;
+		}
+
+		$path = $root . DIRECTORY_SEPARATOR . $line;
+		if ( is_file( $path ) ) {
+			$files[] = $path;
+		}
+	}
+
+	sort( $files );
+
+	return $files;
+}
+
+/**
+ * Run a Git command in the target root and return stdout.
+ *
+ * @param string $root Root directory.
+ * @param string $args Git args.
+ * @return string
+ */
+function edac_run_git( string $root, string $args ): string {
+	$cmd = 'git -C ' . escapeshellarg( $root ) . ' ' . $args . ' 2>/dev/null';
+	$output = shell_exec( $cmd ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+
+	return is_string( $output ) ? $output : '';
+}
+
+

--- a/tools/update-since-tags.php
+++ b/tools/update-since-tags.php
@@ -35,7 +35,7 @@ if ( isset( $opts['help'] ) ) {
 	edac_write_line( 'Usage: php tools/update-since-tags.php --version=<x.y.z> [options]' );
 	edac_write_line( '' );
 	edac_write_line( 'Options:' );
-	edac_write_line( '  --root=<path>                Root directory to scan (default: current working directory)' );
+	edac_write_line( '  --root=<path>                Root directory to scan (default: parent of the tools/ directory)' );
 	edac_write_line( '  --placeholder=<value>        Placeholder token after @since (default: x.x.x)' );
 	edac_write_line( '  --changed-since-tag=<tag>    Only scan tracked PHP files changed since this Git tag/ref' );
 	edac_write_line( '  --changed-since-last-tag     Only scan tracked PHP files changed since latest Git tag' );
@@ -51,26 +51,56 @@ if ( ! is_string( $version ) || ! preg_match( '/^\d+\.\d+\.\d+$/', $version ) ) 
 	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
-$root = $opts['root'] ?? dirname( __DIR__ );
-if ( ! is_string( $root ) || ! is_dir( $root ) ) {
-	edac_write_line( 'Error: root directory does not exist: ' . (string) $root, STDERR );
+// getopt() returns false (not null) for optional params given without a value (e.g. --root).
+$root_opt = $opts['root'] ?? dirname( __DIR__ );
+if ( false === $root_opt ) {
+	edac_write_line( 'Error: --root requires a value.', STDERR );
 	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
-$root = rtrim( (string) $root, DIRECTORY_SEPARATOR );
+if ( ! is_string( $root_opt ) || ! is_dir( $root_opt ) ) {
+	edac_write_line( 'Error: root directory does not exist: ' . (string) $root_opt, STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+// Use realpath() so filesystem-root paths like / or C:\ are preserved correctly.
+$root = realpath( $root_opt );
+if ( false === $root ) {
+	edac_write_line( 'Error: could not resolve root directory: ' . $root_opt, STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
 
-$placeholder = $opts['placeholder'] ?? 'x.x.x';
-if ( ! is_string( $placeholder ) || '' === trim( $placeholder ) ) {
+$placeholder_opt = $opts['placeholder'] ?? 'x.x.x';
+if ( false === $placeholder_opt ) {
+	edac_write_line( 'Error: --placeholder requires a value.', STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+if ( ! is_string( $placeholder_opt ) || '' === trim( $placeholder_opt ) ) {
 	edac_write_line( 'Error: --placeholder must be a non-empty string.', STDERR );
 	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
+$placeholder = $placeholder_opt;
 
-$changed_since_tag      = $opts['changed-since-tag'] ?? null;
+// getopt() returns false for optional params given without a value (e.g. --changed-since-tag).
+$changed_since_tag_opt = $opts['changed-since-tag'] ?? null;
+if ( false === $changed_since_tag_opt ) {
+	edac_write_line( 'Error: --changed-since-tag requires a value.', STDERR );
+	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+$changed_since_tag      = $changed_since_tag_opt;
 $changed_since_last_tag = isset( $opts['changed-since-last-tag'] );
 $dry_run                = isset( $opts['dry-run'] );
 
 if ( null !== $changed_since_tag && $changed_since_last_tag ) {
 	edac_write_line( 'Error: use either --changed-since-tag or --changed-since-last-tag, not both.', STDERR );
 	exit( EDAC_SINCE_TOOL_EXIT_BAD_ARGS ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+// Validate the supplied ref actually exists before proceeding.
+if ( null !== $changed_since_tag ) {
+	$ref_check = trim( edac_run_git( $root, 'rev-parse --verify ' . escapeshellarg( (string) $changed_since_tag ) ) );
+	if ( '' === $ref_check ) {
+		edac_write_line( 'Error: invalid Git reference or tag: ' . (string) $changed_since_tag, STDERR );
+		exit( EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 }
 
 if ( $changed_since_last_tag ) {
@@ -147,28 +177,36 @@ exit( EDAC_SINCE_TOOL_EXIT_OK ); // phpcs:ignore WordPress.Security.EscapeOutput
  * @return string[]
  */
 function edac_get_all_php_files( string $root, array $excluded_dirs ): array {
-	$files    = [];
-	$iterator = new RecursiveIteratorIterator(
-		new RecursiveDirectoryIterator( $root, RecursiveDirectoryIterator::SKIP_DOTS )
+	$files              = [];
+	$directory_iterator = new RecursiveDirectoryIterator( $root, RecursiveDirectoryIterator::SKIP_DOTS );
+
+	// Prune excluded directories before recursing into them for efficiency.
+	$filter = new RecursiveCallbackFilterIterator(
+		$directory_iterator,
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		static function ( SplFileInfo $item, $key, RecursiveCallbackFilterIterator $iterator ) use ( $root, $excluded_dirs ): bool {
+			if ( $item->isDir() ) {
+				$relative_path = ltrim( substr( $item->getPathname(), strlen( $root ) ), DIRECTORY_SEPARATOR );
+				foreach ( $excluded_dirs as $excluded ) {
+					if ( $relative_path === $excluded || 0 === strpos( $relative_path, $excluded . DIRECTORY_SEPARATOR ) ) {
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
 	);
+
+	$iterator = new RecursiveIteratorIterator( $filter );
 
 	foreach ( $iterator as $item ) {
 		if ( ! $item instanceof SplFileInfo || $item->isDir() ) {
 			continue;
 		}
 
-		$path          = $item->getPathname();
-		$relative_path = ltrim( str_replace( $root, '', $path ), DIRECTORY_SEPARATOR );
-
-		foreach ( $excluded_dirs as $excluded ) {
-			$needle = $excluded . DIRECTORY_SEPARATOR;
-			if ( 0 === strpos( $relative_path, $needle ) || false !== strpos( $relative_path, DIRECTORY_SEPARATOR . $needle ) ) {
-				continue 2;
-			}
-		}
-
 		if ( 'php' === strtolower( (string) $item->getExtension() ) ) {
-			$files[] = $path;
+			$files[] = $item->getPathname();
 		}
 	}
 
@@ -180,13 +218,21 @@ function edac_get_all_php_files( string $root, array $excluded_dirs ): array {
 /**
  * Get tracked PHP files changed between a given ref and HEAD.
  *
+ * Exits with EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR if the git command fails,
+ * so a bad ref or non-repo root does not silently return an empty list.
+ *
  * @param string $root Root directory.
  * @param string $ref  Git ref/tag.
  * @return string[]
  */
 function edac_get_changed_php_files_since_ref( string $root, string $ref ): array {
 	$cmd    = 'diff --name-only ' . escapeshellarg( $ref . '..HEAD' ) . ' -- ' . escapeshellarg( '*.php' );
-	$output = edac_run_git( $root, $cmd );
+	$output = edac_run_git( $root, $cmd, $exit_code );
+
+	if ( 0 !== $exit_code ) {
+		edac_write_line( "Error: git diff failed (exit {$exit_code}) for ref: {$ref}", STDERR );
+		exit( EDAC_SINCE_TOOL_EXIT_RUNTIME_ERROR ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 
 	$files = [];
 	foreach ( preg_split( '/\r?\n/', trim( $output ) ) as $line ) {
@@ -208,15 +254,17 @@ function edac_get_changed_php_files_since_ref( string $root, string $ref ): arra
 /**
  * Run a Git command in the target root and return stdout.
  *
- * @param string $root Root directory.
- * @param string $args Git args.
+ * @param string   $root      Root directory.
+ * @param string   $args      Git args (already shell-escaped as needed).
+ * @param int|null $exit_code Reference populated with the git process exit code.
  * @return string
  */
-function edac_run_git( string $root, string $args ): string {
-	$cmd    = 'git -C ' . escapeshellarg( $root ) . ' ' . $args . ' 2>/dev/null';
-	$output = shell_exec( $cmd ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+function edac_run_git( string $root, string $args, ?int &$exit_code = null ): string {
+	$cmd    = 'git -C ' . escapeshellarg( $root ) . ' ' . $args;
+	$output = [];
+	exec( $cmd, $output, $exit_code ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 
-	return is_string( $output ) ? $output : '';
+	return implode( "\n", $output );
 }
 
 /**


### PR DESCRIPTION
## What this PR does
- Adds a new PHP CLI tool: `tools/update-since-tags.php` to replace placeholder `@since x.x.x` values with a release version.
- Supports advanced flags: `--version`, `--dry-run`, `--changed-since-last-tag`, `--changed-since-tag`, `--root`, and `--placeholder`.
- Updates `scripts/prep_release.sh` to:
  - run the @since updater in a dedicated post-version-bump commit,
  - safely stash/restore local uncommitted work around the since-update step,
  - stage only tracked changed PHP files for the since commit,
  - verify local tags are in sync with `origin` before release prep continues.
## Commits
- Add @since placeholder update tool
- Update release prep flow for @since sync and tag checks
## Notes
- Existing unrelated untracked files were intentionally left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter release preparation validation by requiring local git tags to exactly match remote tags before creating the release branch.
  * Introduced a CLI tool to update PHP docblock `@since` placeholders to the target release version.
* **Bug Fixes**
  * Hardened the WordPress “version requirements” updater with stricter parsing and explicit failure when no versions are detected; keeps stopping behavior when “Tested up to” can’t be resolved, and enforces a minimum baseline of WordPress 5.0 in `readme.txt`.
  * Made `@since` updates safer by stashing/restoring local work, updating only relevant tracked PHP changes, and skipping commits when nothing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->