### PR TITLE
Add extra_data column and contrast data collection (DB 1.0.8)

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -41,7 +41,7 @@ if ( ! defined( 'EDAC_VERSION' ) ) {
 
 // Current database version.
 if ( ! defined( 'EDAC_DB_VERSION' ) ) {
-	define( 'EDAC_DB_VERSION', '1.0.7' );
+	define( 'EDAC_DB_VERSION', '1.0.8' );
 }
 
 // Plugin Folder Path.

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -36,11 +36,12 @@ class Insert_Rule_Data {
 	 * @param string|null $landmark          The landmark type (main, header, footer, nav), optional.
 	 * @param string|null $landmark_selector The landmark selector, optional.
 	 * @param array       $selectors         An array of selectors that point to the object, optional.
+	 * @param array|null  $extra_data        Optional arbitrary metadata to store as JSON (e.g. color contrast values).
 	 *
 	 * @return void|int|\WP_Error The ID of the inserted record, void if no
 	 * record was inserted or a WP_Error if the insert failed.
 	 */
-	public function insert( object $post, string $rule, string $ruletype, string $rule_obj, ?string $landmark = null, ?string $landmark_selector = null, array $selectors = [] ) {
+	public function insert( object $post, string $rule, string $ruletype, string $rule_obj, ?string $landmark = null, ?string $landmark_selector = null, array $selectors = [], ?array $extra_data = null ) {
 
 		if ( ! isset( $post->ID, $post->post_type )
 			|| empty( $rule )
@@ -66,6 +67,7 @@ class Insert_Rule_Data {
 			'rule'              => $rule,
 			'ruletype'          => $ruletype,
 			'object'            => esc_attr( $rule_obj ),
+			'extra_data'        => $extra_data ? wp_json_encode( $extra_data ) : null,
 			'recordcheck'       => 1,
 			'user'              => get_current_user_id(),
 			'ignre'             => 0,
@@ -111,7 +113,7 @@ class Insert_Rule_Data {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 				$wpdb->query(
 					$wpdb->prepare(
-						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d  WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
+						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d, extra_data = %s  WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
 						$table_name,
 						1,
 						$rule_data['landmark'],
@@ -120,6 +122,7 @@ class Insert_Rule_Data {
 						$rule_data['ancestry'],
 						$rule_data['xpath'],
 						$rule_data['ignre'],
+						$rule_data['extra_data'],
 						$rule_data['siteid'],
 						$rule_data['postid'],
 						$rule_data['rule'],
@@ -160,6 +163,7 @@ class Insert_Rule_Data {
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
 				'object'            => esc_attr( $rule_data['object'] ),
+				'extra_data'        => isset( $rule_data['extra_data'] ) ? sanitize_text_field( $rule_data['extra_data'] ) : null,
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -67,7 +67,7 @@ class Insert_Rule_Data {
 			'rule'              => $rule,
 			'ruletype'          => $ruletype,
 			'object'            => esc_attr( $rule_obj ),
-			'extra_data'        => $this->encode_extra_data( $extra_data ),
+			'extra_data'        => self::encode_extra_data( $extra_data ),
 			'recordcheck'       => 1,
 			'user'              => get_current_user_id(),
 			'ignre'             => 0,
@@ -113,7 +113,7 @@ class Insert_Rule_Data {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
 				$wpdb->query(
 					$wpdb->prepare(
-						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d, extra_data = %s  WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
+						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d, extra_data = %s WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
 						$table_name,
 						1,
 						$rule_data['landmark'],
@@ -163,7 +163,7 @@ class Insert_Rule_Data {
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
 				'object'            => esc_attr( $rule_data['object'] ),
-				'extra_data'        => isset( $rule_data['extra_data'] ) ? $this->encode_extra_data( json_decode( $rule_data['extra_data'], true ) ) : null,
+				'extra_data'        => isset( $rule_data['extra_data'] ) ? self::encode_extra_data( json_decode( $rule_data['extra_data'], true ) ) : null,
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),
@@ -198,12 +198,15 @@ class Insert_Rule_Data {
 	}
 
 	/**
-	 * Recursively sanitizes an array of extra data and returns it as a JSON string.
+	 * Recursively sanitizes an array and returns it as a JSON string.
+	 *
+	 * String values are passed through sanitize_text_field(); numeric and boolean
+	 * values are left as-is so they round-trip cleanly through JSON.
 	 *
 	 * @param array|null $data The extra data array to encode.
-	 * @return string|null JSON-encoded sanitized data, or null if input is empty.
+	 * @return string|null JSON-encoded sanitized data, or null if input is empty or encoding fails.
 	 */
-	private function encode_extra_data( ?array $data ): ?string {
+	private static function encode_extra_data( ?array $data ): ?string {
 		if ( ! $data ) {
 			return null;
 		}
@@ -215,6 +218,7 @@ class Insert_Rule_Data {
 				}
 			}
 		);
-		return wp_json_encode( $data );
+		$encoded = wp_json_encode( $data );
+		return false !== $encoded ? $encoded : null;
 	}
 }

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -67,7 +67,7 @@ class Insert_Rule_Data {
 			'rule'              => $rule,
 			'ruletype'          => $ruletype,
 			'object'            => esc_attr( $rule_obj ),
-			'extra_data'        => $extra_data ? wp_json_encode( $extra_data ) : null,
+			'extra_data'        => $this->encode_extra_data( $extra_data ),
 			'recordcheck'       => 1,
 			'user'              => get_current_user_id(),
 			'ignre'             => 0,
@@ -163,7 +163,7 @@ class Insert_Rule_Data {
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
 				'object'            => esc_attr( $rule_data['object'] ),
-				'extra_data'        => isset( $rule_data['extra_data'] ) ? sanitize_text_field( $rule_data['extra_data'] ) : null,
+				'extra_data'        => isset( $rule_data['extra_data'] ) ? $this->encode_extra_data( json_decode( $rule_data['extra_data'], true ) ) : null,
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),
@@ -195,5 +195,26 @@ class Insert_Rule_Data {
 			// Return insert id or error.
 			return $wpdb->insert_id;
 		}
+	}
+
+	/**
+	 * Recursively sanitizes an array of extra data and returns it as a JSON string.
+	 *
+	 * @param array|null $data The extra data array to encode.
+	 * @return string|null JSON-encoded sanitized data, or null if input is empty.
+	 */
+	private function encode_extra_data( ?array $data ): ?string {
+		if ( ! $data ) {
+			return null;
+		}
+		array_walk_recursive(
+			$data,
+			function ( &$value ) {
+				if ( is_string( $value ) ) {
+					$value = sanitize_text_field( $value );
+				}
+			}
+		);
+		return wp_json_encode( $data );
 	}
 }

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -67,7 +67,7 @@ class Insert_Rule_Data {
 			'rule'              => $rule,
 			'ruletype'          => $ruletype,
 			'object'            => esc_attr( $rule_obj ),
-			'extra_data'        => self::encode_extra_data( $extra_data ),
+			'extra_data'        => $extra_data,
 			'recordcheck'       => 1,
 			'user'              => get_current_user_id(),
 			'ignre'             => 0,
@@ -110,25 +110,28 @@ class Insert_Rule_Data {
 
 				// update existing record.
 				// Use selector for WHERE clause instead of object to match on unique identifier.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for adding data to database, caching not required for one time operation.
-				$wpdb->query(
-					$wpdb->prepare(
-						'UPDATE %i SET recordcheck = %d, landmark = %s, landmark_selector = %s, object = %s, ancestry = %s, xpath = %s, ignre = %d, extra_data = %s WHERE siteid = %d and postid = %d and rule = %s and selector = %s and type = %s',
-						$table_name,
-						1,
-						$rule_data['landmark'],
-						$rule_data['landmark_selector'],
-						$rule_data['object'],
-						$rule_data['ancestry'],
-						$rule_data['xpath'],
-						$rule_data['ignre'],
-						$rule_data['extra_data'],
-						$rule_data['siteid'],
-						$rule_data['postid'],
-						$rule_data['rule'],
-						$rule_data['selector'],
-						$rule_data['type']
-					)
+				// Using wpdb->update() (not raw prepare/query) so that null extra_data is emitted
+				// as SQL NULL rather than '' — wpdb->prepare('%s', null) coerces null to ''.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Direct update; caching not required for a write operation.
+				$wpdb->update(
+					$table_name,
+					[
+						'recordcheck'       => 1,
+						'landmark'          => $rule_data['landmark'],
+						'landmark_selector' => $rule_data['landmark_selector'],
+						'object'            => $rule_data['object'],
+						'ancestry'          => $rule_data['ancestry'],
+						'xpath'             => $rule_data['xpath'],
+						'ignre'             => $rule_data['ignre'],
+						'extra_data'        => self::encode_extra_data( is_array( $rule_data['extra_data'] ) ? $rule_data['extra_data'] : null ),
+					],
+					[
+						'siteid'   => $rule_data['siteid'],
+						'postid'   => $rule_data['postid'],
+						'rule'     => $rule_data['rule'],
+						'selector' => $rule_data['selector'],
+						'type'     => $rule_data['type'],
+					]
 				);
 
 			}
@@ -148,6 +151,13 @@ class Insert_Rule_Data {
 			 */
 			$rule_data = apply_filters( 'edac_filter_insert_rule_data', $rule_data );
 
+			// Resolve extra_data: keep raw array from this method, but a filter may have set it
+			// to a JSON string — decode in that case before re-encoding through encode_extra_data().
+			$extra_data_raw = $rule_data['extra_data'] ?? null;
+			if ( is_string( $extra_data_raw ) ) {
+				$extra_data_raw = json_decode( $extra_data_raw, true );
+			}
+
 			// Sanitize rule data since it is filtered, and we can't be sure
 			// the data is still as valid as it was when it was first set.
 			// Sanitize the filtered data.
@@ -163,7 +173,7 @@ class Insert_Rule_Data {
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
 				'object'            => esc_attr( $rule_data['object'] ),
-				'extra_data'        => isset( $rule_data['extra_data'] ) ? self::encode_extra_data( json_decode( $rule_data['extra_data'], true ) ) : null,
+				'extra_data'        => self::encode_extra_data( is_array( $extra_data_raw ) ? $extra_data_raw : null ),
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -63,6 +63,7 @@ class Update_Database {
 				rule text NOT NULL,
 				ruletype text NOT NULL,
 				object mediumtext NOT NULL,
+				extra_data text NULL,
 				recordcheck mediumint(9) NOT NULL,
 				created timestamp NOT NULL default CURRENT_TIMESTAMP,
 				user bigint(20) NOT NULL,
@@ -87,6 +88,12 @@ class Update_Database {
 			// Migrate free plugin license key to shared option key used by both free and pro.
 			if ( version_compare( $db_version, '1.0.7', '<' ) ) {
 				$this->migrate_license_key_to_shared_option();
+			}
+
+			// Add extra_data column for storing arbitrary JSON metadata alongside issues.
+			if ( version_compare( $db_version, '1.0.8', '<' ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder -- One-time schema migration; %i is a valid identifier placeholder since WP 6.2.
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN IF NOT EXISTS extra_data text NULL', $table_name ) );
 			}
 		}
 

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -89,12 +89,6 @@ class Update_Database {
 			if ( version_compare( $db_version, '1.0.7', '<' ) ) {
 				$this->migrate_license_key_to_shared_option();
 			}
-
-			// Add extra_data column for storing arbitrary JSON metadata alongside issues.
-			if ( version_compare( $db_version, '1.0.8', '<' ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder -- One-time schema migration; %i is a valid identifier placeholder since WP 6.2.
-				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN IF NOT EXISTS extra_data text NULL', $table_name ) );
-			}
 		}
 
 		// Update database version option.

--- a/admin/class-update-database.php
+++ b/admin/class-update-database.php
@@ -89,6 +89,9 @@ class Update_Database {
 			if ( version_compare( $db_version, '1.0.7', '<' ) ) {
 				$this->migrate_license_key_to_shared_option();
 			}
+
+			// 1.0.8: Added extra_data column. dbDelta() handles ADD COLUMN automatically
+			// when the column appears in the CREATE TABLE DDL above; no data migration required.
 		}
 
 		// Update database version option.

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -547,12 +547,14 @@ class REST_Api {
 						$landmark          = $violation['landmark'] ?? null;
 						$landmark_selector = $violation['landmarkSelector'] ?? null;
 
-						$selectors = [
+						$selectors  = [
 							'selector' => $violation['selector'] ?? [],
 							'ancestry' => $violation['ancestry'] ?? [],
 							'xpath'    => $violation['xpath'] ?? [],
 						];
-						( new Insert_Rule_Data() )->insert( $post, $actual_rule_id, $impact, $html, $landmark, $landmark_selector, $selectors );
+						$extra_data = isset( $violation['extraData'] ) && is_array( $violation['extraData'] ) ? $violation['extraData'] : null;
+
+						( new Insert_Rule_Data() )->insert( $post, $actual_rule_id, $impact, $html, $landmark, $landmark_selector, $selectors, $extra_data );
 
 						/**
 						 * Fires after a rule is run against the content.

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -397,6 +397,7 @@ function processViolation( violation, item ) {
 		landmarkSelector: landmark.selector,
 	};
 
+	// item.id matches the plugin rule ID defined in src/pageScanner/rules/color-contrast-failure.js
 	if ( item.id === 'color_contrast_failure' ) {
 		const check = violation.any?.find( ( c ) => c.id === 'color-contrast' );
 		if ( check?.data ) {
@@ -408,6 +409,9 @@ function processViolation( violation, item ) {
 				fontSize: check.data.fontSize,
 				fontWeight: check.data.fontWeight,
 			};
+		} else if ( check ) {
+			// eslint-disable-next-line no-console
+			console.warn( '[accessibility-checker] color-contrast check returned no data for node:', violation.node.selector );
 		}
 	}
 

--- a/src/pageScanner/index.js
+++ b/src/pageScanner/index.js
@@ -384,7 +384,8 @@ function processViolation( violation, item ) {
 	const ancestry = violation.node.ancestry || [];
 	const xpath = violation.node.xpath || [];
 	const html = document.querySelector( selector )?.outerHTML;
-	return {
+
+	const result = {
 		selector,
 		ancestry,
 		xpath,
@@ -395,4 +396,20 @@ function processViolation( violation, item ) {
 		landmark: landmark.type,
 		landmarkSelector: landmark.selector,
 	};
+
+	if ( item.id === 'color_contrast_failure' ) {
+		const check = violation.any?.find( ( c ) => c.id === 'color-contrast' );
+		if ( check?.data ) {
+			result.extraData = {
+				fgColor: check.data.fgColor,
+				bgColor: check.data.bgColor,
+				contrastRatio: check.data.contrastRatio,
+				expectedContrastRatio: check.data.expectedContrastRatio,
+				fontSize: check.data.fontSize,
+				fontWeight: check.data.fontWeight,
+			};
+		}
+	}
+
+	return result;
 }


### PR DESCRIPTION
## Summary

- Bumps DB schema to 1.0.8 and adds `extra_data text NULL` column to `wp_accessibility_checker`
- Extends `Insert_Rule_Data::insert()` with an optional `$extra_data` array parameter; JSON-encoded before storage, updated on rescans
- Page scanner now extracts color contrast metadata (fg/bg color, contrast ratio, font size/weight) from axe-core results for `color_contrast_failure` violations and sends it as `extraData` in the scan payload
- REST API `set_post_scan_results()` reads `violation['extraData']` and passes it through to `insert()`

**Intentionally excluded** from this PR (remains in PR #1589):
- Highlighter color swatch display (`src/frontendHighlighterApp/index.js`, `.scss`)
- `data-extra-data` HTML attribute output (`admin/class-ajax.php`, `admin/class-frontend-highlight.php`)
- `IssueDetailsModal` changes

This is a prerequisite for the Manual Issues feature, which will store its user-authored fields (`manual_title`, `manual_description`, `manual_why_it_matters`, `manual_how_to_fix`, `screenshot_id`) as JSON keys inside `extra_data` rather than adding dedicated columns.

## Test plan

- [ ] Activate plugin on a site running MySQL 5.7+ — confirm `extra_data` column is added on plugin load
- [ ] Run a page scan that includes a color contrast failure — confirm `extra_data` column is populated with JSON containing `fgColor`, `bgColor`, `contrastRatio`, `expectedContrastRatio`, `fontSize`, `fontWeight`
- [ ] Rescan the same page — confirm `extra_data` is updated, not duplicated
- [ ] Confirm non-contrast issues have `extra_data = NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Color contrast failure results can now include additional contrast and font-related metadata when available.
  * Scan records now support optional per-violation extra metadata, which is captured for richer issue reporting.
* **Bug Fixes**
  * Updated database versioning and added persistent storage for the new per-violation extra metadata, ensuring it’s correctly saved and maintained during updates/upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->