### PR TITLE
fix: expose pro status in edac_script_vars and widen isPro checks in DismissPanel

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -93,6 +93,7 @@ class Enqueue_Admin {
 					'proUrl'                   => esc_url_raw( edac_generate_link_type( [ 'utm_content' => '__name__' ] ) ),
 					'hasDismissEndpoint'       => method_exists( \EDAC\Inc\REST_Api::class, 'dismiss_issue' ),
 					'showMetaboxInBlockEditor' => ! Helpers::is_block_editor() || (bool) get_option( 'edac_show_metabox_in_block_editor', 1 ),
+					'pro'                      => defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID,
 				]
 			);
 

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -142,7 +142,7 @@ const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceG
 						) }
 						{ isIgnored ? (
 							<>
-								{ ( issue?.user || issue?.ignre_user_name || issue?.ignre_date || issue?.ignre_global ) && (
+								{ ( issue?.user || issue?.ignre_user_name || issue?.ignre_date || isGloballyDismissed ) && (
 									<dl className="edac-analysis__dismissed-meta">
 
 										{ ( issue?.ignre_global === 1 || issue?.ignre_global === '1' ) && (

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -27,7 +27,7 @@ import { getDismissReasonOptions } from '../../sidebar/utils/dismissHelpers';
  * @param {boolean}  props.forceGlobal  - When true, the primary dismiss action targets all pages (global dismiss).
  * @param {boolean}  props.isPro        - Whether the current UI is running in Pro.
  */
-const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceGlobal = false, isPro = typeof window !== 'undefined' && window.edac_editor_app?.pro === '1' } ) => {
+const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceGlobal = false, isPro = typeof window !== 'undefined' && ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) } ) => {
 	const panelRef = useRef( null );
 	const [ comment, setComment ] = useState( issue?.ignre_comment ? decodeEntities( issue.ignre_comment ) : '' );
 	const [ dismissReason, setDismissReason ] = useState( issue?.ignre_reason || 'false_positive' );

--- a/src/issueModal/components/DismissPanel.js
+++ b/src/issueModal/components/DismissPanel.js
@@ -27,7 +27,15 @@ import { getDismissReasonOptions } from '../../sidebar/utils/dismissHelpers';
  * @param {boolean}  props.forceGlobal  - When true, the primary dismiss action targets all pages (global dismiss).
  * @param {boolean}  props.isPro        - Whether the current UI is running in Pro.
  */
-const DismissPanel = ( { issue, isOpen, onToggle, onIgnore, onCloseModal, forceGlobal = false, isPro = typeof window !== 'undefined' && ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) } ) => {
+const DismissPanel = ( {
+	issue,
+	isOpen,
+	onToggle,
+	onIgnore,
+	onCloseModal,
+	forceGlobal = false,
+	isPro = typeof window !== 'undefined' && ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ),
+} ) => {
 	const panelRef = useRef( null );
 	const [ comment, setComment ] = useState( issue?.ignre_comment ? decodeEntities( issue.ignre_comment ) : '' );
 	const [ dismissReason, setDismissReason ] = useState( issue?.ignre_reason || 'false_positive' );

--- a/src/issueModal/components/IssueDetailsModal.js
+++ b/src/issueModal/components/IssueDetailsModal.js
@@ -328,7 +328,7 @@ export const IssueDetailsModal = ( { issue, rule, onClose, isOpen, focusSection,
 					) }
 
 					{ /* How to Fix - Show detailed info for Pro, or just link for Free */ }
-					{ ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) ? (
+					{ ( typeof window !== 'undefined' && ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) ) ? (
 						<div className="edac-analysis__issue-help-accordion">
 							<PanelBody
 								title={ __( 'Show explanation', 'accessibility-checker' ) }
@@ -406,7 +406,6 @@ export const IssueDetailsModal = ( { issue, rule, onClose, isOpen, focusSection,
 							onToggle={ () => setIsDismissPanelOpen( ! isDismissPanelOpen ) }
 							onIgnore={ onIgnore }
 							onCloseModal={ onClose }
-							isPro={ typeof window !== 'undefined' && ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) }
 						/>
 					</div>
 				</div>

--- a/src/issueModal/components/IssueDetailsModal.js
+++ b/src/issueModal/components/IssueDetailsModal.js
@@ -328,7 +328,7 @@ export const IssueDetailsModal = ( { issue, rule, onClose, isOpen, focusSection,
 					) }
 
 					{ /* How to Fix - Show detailed info for Pro, or just link for Free */ }
-					{ window.edac_editor_app?.pro === '1' ? (
+					{ ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) ? (
 						<div className="edac-analysis__issue-help-accordion">
 							<PanelBody
 								title={ __( 'Show explanation', 'accessibility-checker' ) }
@@ -406,7 +406,7 @@ export const IssueDetailsModal = ( { issue, rule, onClose, isOpen, focusSection,
 							onToggle={ () => setIsDismissPanelOpen( ! isDismissPanelOpen ) }
 							onIgnore={ onIgnore }
 							onCloseModal={ onClose }
-							isPro={ typeof window !== 'undefined' && window.edac_editor_app?.pro === '1' }
+							isPro={ typeof window !== 'undefined' && ( window.edac_editor_app?.pro === '1' || window.edac_script_vars?.pro === '1' ) }
 						/>
 					</div>
 				</div>

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -126,6 +126,28 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The pro flag in edac_script_vars reflects defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID,
+	 * so non-editor admin pages (e.g. the Issues Explorer) can gate pro-only UI without
+	 * relying on window.edac_editor_app, which is only localized on post.php/post-new.php.
+	 */
+	public function testLocalizedAdminDataIncludesProFlag(): void {
+		global $wp_scripts;
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$localized_data = (string) $wp_scripts->get_data( 'edac', 'data' );
+		$expected_pro   = defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID;
+
+		// wp_localize_script() stringifies booleans as "1" / "" (matching the
+		// === '1' checks on the JS side), not JSON true/false.
+		$this->assertStringContainsString( '"pro"', $localized_data );
+		$this->assertMatchesRegularExpression(
+			'/"pro"\s*:\s*"' . ( $expected_pro ? '1' : '' ) . '"/',
+			$localized_data
+		);
+	}
+
+	/**
 	 * FixesRestUrl uses the edac/v1 namespace and matches rest_url().
 	 */
 	public function testAdminFixesRestUrlContainsEdacV1Namespace(): void {


### PR DESCRIPTION
## Summary

- Adds `pro` key to `edac_script_vars` in `class-enqueue-admin.php` so pro status is available on all admin pages (not just post edit screens)
- Updates the `isPro` default in `DismissPanel` and both `isPro` references in `IssueDetailsModal` to check `window.edac_script_vars?.pro` as a fallback alongside `window.edac_editor_app?.pro`

## Problem

`window.edac_editor_app` is only localized on `post.php`/`post-new.php`. When the issue modal is opened from any other admin context (e.g. the Issues Explorer), that global is `undefined`. As a result:

- The global dismiss dropdown arrow was never shown in the `InstanceDrawer`
- `GlobalDismissModal` was silently passing `isGlobal=false` to the API despite `forceGlobal=true`, because `canDismissGlobally = isPro = false`

## Test plan

- [ ] On a post edit screen with Pro active: confirm the dismiss dropdown still shows (edac_editor_app path)
- [ ] In the Issues Explorer with Pro active: confirm the dismiss dropdown now shows in the instance drawer
- [ ] With Pro inactive: confirm no dropdown appears in either context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pro status detection by passing a server-derived Pro flag to the client and using it consistently across the editor and issue details UI.
  * Restored correct behavior for Pro-gated content and global dismiss controls, including safer handling when browser globals aren’t available.
  * Updated the dismissed-state rendering logic to reflect the newly computed globally dismissed condition.

* **Tests**
  * Added a PHPUnit test to verify the localized admin script payload includes the expected Pro flag value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->