### PR TITLE
Add edac_after_global_ignore_change action hook to dismiss_issue endpoint

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1328,16 +1328,34 @@ class REST_Api {
 		}
 
 		/**
-		 * Fires after a global ignore state change succeeds.
+		 * Fires after an ignore state change succeeds.
 		 *
-		 * Passes enough context for add-ons to sync their own storage (e.g. a
-		 * separate global-ignores table) without requiring changes to this plugin.
-		 *
-		 * @param int  $issue_id     The representative issue row ID from the request.
-		 * @param int  $ignre_global 1 when the issue is now globally dismissed, 0 when reopened.
-		 * @param int  $site_id      Current blog ID.
+		 * @param array $data {
+		 *     @type int    $issue_id     The representative issue row ID from the request.
+		 *     @type string $action       The action string from the request (e.g. 'dismiss', 'undismiss').
+		 *     @type int    $ignre        1 when the issue is now dismissed, 0 when reopened.
+		 *     @type int    $ignre_global 1 when the change is a global dismiss/reopen, 0 otherwise.
+		 *     @type int    $ignre_user   User ID of the actor, or null when reopening.
+		 *     @type string $ignre_reason Dismissal reason, or null when reopening.
+		 *     @type string $ignre_comment Dismissal comment, or null when reopening.
+		 *     @type bool   $large_batch  True when all instances of the same snippet were updated.
+		 *     @type int    $site_id      Current blog ID.
+		 * }
 		 */
-		do_action( 'edac_after_global_ignore_change', $issue_id, $ignre_global, $site_id );
+		do_action(
+			'edac_after_ignore_change',
+			[
+				'issue_id'      => $issue_id,
+				'action'        => $action,
+				'ignre'         => $ignre,
+				'ignre_global'  => $ignre_global,
+				'ignre_user'    => $ignre_user,
+				'ignre_reason'  => $ignre_reason,
+				'ignre_comment' => $ignre_comment,
+				'large_batch'   => $large_batch,
+				'site_id'       => $site_id,
+			]
+		);
 
 		return new \WP_REST_Response(
 			[

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1327,6 +1327,18 @@ class REST_Api {
 			);
 		}
 
+		/**
+		 * Fires after a global ignore state change succeeds.
+		 *
+		 * Passes enough context for add-ons to sync their own storage (e.g. a
+		 * separate global-ignores table) without requiring changes to this plugin.
+		 *
+		 * @param int  $issue_id     The representative issue row ID from the request.
+		 * @param int  $ignre_global 1 when the issue is now globally dismissed, 0 when reopened.
+		 * @param int  $site_id      Current blog ID.
+		 */
+		do_action( 'edac_after_global_ignore_change', $issue_id, $ignre_global, $site_id );
+
 		return new \WP_REST_Response(
 			[
 				'success'         => true,


### PR DESCRIPTION
## Summary

- Adds a `do_action( 'edac_after_global_ignore_change', $issue_id, $ignre_global, $site_id )` call in `dismiss_issue()` just before the success response is returned.
- Fires on both global dismiss (`ignre_global=1`) and global reopen (`ignre_global=0`), giving add-ons a single reliable hook point to sync their own storage.
- Passes `$issue_id` (the representative row ID from the request), `$ignre_global` (1 or 0), and `$site_id` — enough for add-ons to look up whatever else they need.

## Test plan

- [ ] Globally dismiss an issue via the Issues Explorer. Confirm `edac_after_global_ignore_change` fires with `$ignre_global=1`.
- [ ] Reopen a globally dismissed issue. Confirm the action fires with `$ignre_global=0`.
- [ ] Add a simple `add_action` listener and verify the three params are correct.
- [ ] Confirm no change to existing dismiss/reopen behaviour for non-global actions (action still fires but `$ignre_global=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue dismissal actions are now handled more consistently, including bulk dismissals, so ignore settings update more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->