### PR TITLE
fix: strip leading v from release tag before using as SVN version

### DIFF
--- a/.github/workflows/deploy-on-release-to-dot-org.yml
+++ b/.github/workflows/deploy-on-release-to-dot-org.yml
@@ -50,6 +50,12 @@ jobs:
           npm run dist:dotorg
           echo "::set-output name=zip-path::./dist/${{ github.event.repository.name }}/${{ github.event.repository.name }}.zip"
 
+      - name: Normalize release version for SVN tag
+        id: normalize-version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
       - name: WordPress plugin deploy
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
@@ -57,4 +63,4 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           BUILD_DIR: ./dist/${{ github.event.repository.name }}/
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ steps.normalize-version.outputs.version }}


### PR DESCRIPTION
## Summary
- The WP.org deploy workflow used `github.event.release.tag_name` directly as the SVN tag version, with no normalization.
- A GitHub release tagged `v1.45.0` produced an SVN tag literally named `v1.45.0`, which doesn't match `readme.txt`'s `Stable tag: 1.45.0` — so WordPress.org never picked it up as the live release.
- Had to fix this manually with `svn move tags/v1.45.0 tags/1.45.0` after the fact.

## Fix
Add a step that strips a leading `v` from the release tag before passing it to the deploy action, so both `v1.45.0` and `1.45.0`-style release tags resolve to the correct bare-number SVN tag.

## Test plan
- [ ] Cut a test release tagged `v0.0.0-test` (or similar) via `workflow_dispatch` if feasible, confirm the resulting `VERSION` env going into the deploy step is `0.0.0-test`, not `v0.0.0-test`.
- [ ] Otherwise, verify on the next real dot-org release that the SVN tag created matches `Stable tag` in readme.txt exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing so version tags are handled consistently during WordPress.org deployments.
  * Release versions now use a normalized format, helping avoid issues when tags include a leading `v`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->