### PR TITLE
PRO-1168: fix: don't flag .ogg audio as video content in video_present rule

### DIFF
--- a/src/pageScanner/checks/is-video-detected.js
+++ b/src/pageScanner/checks/is-video-detected.js
@@ -33,14 +33,27 @@ export default {
 			}
 		}
 
+		// .ogg is the Ogg Vorbis audio extension, but the Ogg container can also carry
+		// Theora video, so it stays in videoExtensions. To avoid flagging ordinary Ogg
+		// Vorbis audio (e.g. the Gutenberg Audio block), only count a .ogg match as video
+		// when it isn't attached to an <audio> element or one of its <source> children.
+		const parentTag = node.parentNode ? node.parentNode.nodeName.toLowerCase() : '';
+		const isInAudioContainer = tag === 'audio' || ( tag === 'source' && parentTag === 'audio' );
+
 		const matchesExtension = videoExtensions.some( ( ext ) => {
 			const srcLower = src.toLowerCase();
 			const dataLower = data.toLowerCase();
 			// Check if the extension is at the end of the string or followed by a query parameter
-			return (
+			const matches = (
 				( srcLower.endsWith( ext ) || srcLower.includes( ext + '?' ) ) ||
 				( dataLower.endsWith( ext ) || dataLower.includes( ext + '?' ) )
 			);
+
+			if ( matches && ext === '.ogg' && isInAudioContainer ) {
+				return false;
+			}
+
+			return matches;
 		} );
 
 		const matchesKeyword = videoKeywords.some( ( keyword ) =>

--- a/src/pageScanner/checks/is-video-detected.js
+++ b/src/pageScanner/checks/is-video-detected.js
@@ -37,12 +37,14 @@ export default {
 		// Theora video, so it stays in videoExtensions. To avoid flagging ordinary Ogg
 		// Vorbis audio (e.g. the Gutenberg Audio block), only count a .ogg match as video
 		// when it isn't attached to an <audio> element or one of its <source> children.
-		const parentTag = node.parentNode ? node.parentNode.nodeName.toLowerCase() : '';
-		const isInAudioContainer = tag === 'audio' || ( tag === 'source' && parentTag === 'audio' );
+		const isInAudioContainer = tag === 'audio' || ( tag === 'source' &&
+			node.parentNode &&
+			node.parentNode.nodeName.toLowerCase() === 'audio' );
+
+		const srcLower = src.toLowerCase();
+		const dataLower = data.toLowerCase();
 
 		const matchesExtension = videoExtensions.some( ( ext ) => {
-			const srcLower = src.toLowerCase();
-			const dataLower = data.toLowerCase();
 			// Check if the extension is at the end of the string or followed by a query parameter
 			const matches = (
 				( srcLower.endsWith( ext ) || srcLower.includes( ext + '?' ) ) ||
@@ -57,7 +59,7 @@ export default {
 		} );
 
 		const matchesKeyword = videoKeywords.some( ( keyword ) =>
-			src.toLowerCase().includes( keyword )
+			srcLower.includes( keyword )
 		);
 
 		const matchesType = type.toLowerCase().startsWith( 'video/' );

--- a/tests/jest/rules/videoElementPresent.test.js
+++ b/tests/jest/rules/videoElementPresent.test.js
@@ -101,6 +101,16 @@ describe( 'video_present rule', () => {
 			html: '<video><source src="movie.MP4"></video>',
 			shouldPass: false,
 		},
+		{
+			name: 'detects .ogg file used as a native <video> element src',
+			html: '<video src="movie.ogg" controls></video>',
+			shouldPass: false,
+		},
+		{
+			name: 'detects .ogg source that is not inside an <audio> element',
+			html: '<source src="clip.ogg">',
+			shouldPass: false,
+		},
 
 		// Should not trigger violations
 		{
@@ -133,6 +143,26 @@ describe( 'video_present rule', () => {
 		{
 			name: 'does not detect source element with audio inside audio tag',
 			html: '<audio controls><source src="sound.mp3" type="audio/mpeg"></audio>',
+			shouldPass: true,
+		},
+		{
+			// Direct/minimal case: the <audio> element itself has a .ogg src, exercising the
+			// `tag === 'audio'` path in is-video-detected.js without any wrapping markup.
+			name: 'does not detect a plain <audio> element with a .ogg src',
+			html: '<audio controls src="simple-guitar-melody.ogg"></audio>',
+			shouldPass: true,
+		},
+		{
+			// Regression test for https://github.com/equalizedigital/accessibility-checker/issues/1816 (PRO-1168).
+			// The Gutenberg Audio block's default sample audio is an .ogg (Ogg Vorbis) file, which was
+			// being misidentified as video content because .ogg is also a valid Ogg Theora video extension.
+			name: 'does not detect .ogg audio file in a <figure class="wp-block-audio"> Audio block',
+			html: '<figure class="wp-block-audio"><audio controls src="simple-guitar-melody.ogg"></audio><figcaption>Simple Guitar Melody</figcaption></figure>',
+			shouldPass: true,
+		},
+		{
+			name: 'does not detect .ogg source element inside an <audio> element',
+			html: '<audio controls><source src="simple-guitar-melody.ogg" type="audio/ogg"></audio>',
 			shouldPass: true,
 		},
 		{


### PR DESCRIPTION
## Summary
- The Gutenberg Audio block's Ogg Vorbis sample file (`.ogg`) was being detected as video content by the `video_present` rule, because `.ogg` is also a valid Ogg Theora video extension.
- `.ogg` stays in `videoExtensions` (Ogg can still carry Theora video), but a `.ogg` match is now only counted as video when it isn't attached to an `<audio>` element or one of its `<source>` children.

## Test plan
- [x] Added regression tests reproducing the bug (plain `<audio src="....ogg">`, the real `wp-block-audio` figure markup, and a `<source>` inside `<audio>`) — confirmed these failed before the fix.
- [x] Added tests locking in that `.ogg` still triggers the rule outside an audio container (native `<video>`, standalone `<source>`).
- [x] `npx jest --config=./tests/jest/jest.config.js` — 847/847 passing, no regressions.

Fixes #1816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video detection to avoid falsely flagging `.ogg` sources that appear within audio contexts (such as audio elements and audio block structures).
  * Continued to flag `.ogg` when it’s used in actual video-related scenarios, including standalone video sources and `<video>` elements.
* **Tests**
  * Expanded rule coverage with additional `.ogg` cases to confirm both violations and non-violations across relevant HTML structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->