### PR TITLE
Fix settings page logo/heading overlap on RTL sites

### DIFF
--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1728,6 +1728,7 @@
   .edac-welcome-header {
     display: grid;
     justify-items: stretch;
+    direction: ltr;
 
     .edac-welcome-header-right {
       text-align: right;

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1031,9 +1031,9 @@
 
     &-left {
       grid-row: 1;
+      grid-column: 1 / 2;
     }
 
-  &-left,
   &-notices {
     grid-column: 1 / -1;
   }
@@ -1728,7 +1728,6 @@
   .edac-welcome-header {
     display: grid;
     justify-items: stretch;
-    direction: ltr;
 
     .edac-welcome-header-right {
       text-align: right;


### PR DESCRIPTION
The .edac-welcome-header grid places the title in column 1 and the
logo in column 2 using explicit grid-column line numbers. Under
dir="rtl" (e.g. Hebrew admin language), CSS Grid resolves column
lines in inline-start-to-end order, so the columns swap sides and
the logo ends up overlapping the title/version text instead of
sitting to its right.

Force direction: ltr on the header so this branding element keeps
its intended layout regardless of the site's admin language.

Fixes #1809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the welcome header responsive layout so the left section uses an explicit grid column, improving alignment and readability at that breakpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->