### PR TITLE
Fix settings page logo/heading overlap on RTL sites

### DIFF
--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1728,6 +1728,7 @@
   .edac-welcome-header {
     display: grid;
     justify-items: stretch;
+    direction: ltr;
 
     .edac-welcome-header-right {
       text-align: right;

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1735,6 +1735,10 @@
       img {
         width: 200px;
       }
+
+      [dir="rtl"] & {
+        text-align: left;
+      }
     }
 
     @media screen and (max-width: variables.$small-screen-width ) {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1031,9 +1031,9 @@
 
     &-left {
       grid-row: 1;
+      grid-column: 1 / 2;
     }
 
-  &-left,
   &-notices {
     grid-column: 1 / -1;
   }
@@ -1728,7 +1728,6 @@
   .edac-welcome-header {
     display: grid;
     justify-items: stretch;
-    direction: ltr;
 
     .edac-welcome-header-right {
       text-align: right;


### PR DESCRIPTION
The `.edac-welcome-header` grid placed the title in a cell spanning both columns (`grid-column: 1 / -1`) while the logo occupied column 2 (`grid-column: 2 / 3`). Under `dir="rtl"` (e.g. Hebrew admin language), CSS Grid resolves column lines in inline-start-to-end order, so the columns swap sides and the logo ends up overlapping the title/version text instead of sitting to its right.

## Fix

Constrained `.edac-welcome-header-left` to `grid-column: 1 / 2` so the title and logo occupy separate grid cells. Columns now naturally swap sides under RTL (title right, logo left) without overlapping, and without forcing `direction: ltr` (which would have broken RTL text rendering for the translated title/notices).

Fixes #1809
Linear: PRO-1124

Supersedes #1818 (branch renamed to match Linear's naming convention).

<img width="1846" height="210" alt="Screenshot 2026-07-05 at 4 49 00 PM" src="https://github.com/user-attachments/assets/e15d6b83-91c3-4540-a1d2-1da08ba39ca2" />


---
_Generated by [Claude Code](https://claude.ai/code/session_019sAHXroNky9KzbBQKGH1Tn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the admin welcome header layout so the left section consistently appears in the first column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->