### PR TITLE
fix: convey summary status in Reading Level card accessible name

### DIFF
--- a/src/sidebar/components/Panels/AccessibilityStatus.js
+++ b/src/sidebar/components/Panels/AccessibilityStatus.js
@@ -248,10 +248,19 @@ const AccessibilityStatus = () => {
 						onClick={ handleReadingLevelClick }
 						role="button"
 						tabIndex={ 0 }
-						aria-label={ sprintf(
-							__( 'View reading level details: %s', 'accessibility-checker' ),
-							readingLevelText,
-						) }
+						aria-label={ summaryStatus
+							? sprintf(
+								/* translators: 1: reading level, 2: simplified summary status. */
+								__( 'View reading level details: %1$s, %2$s', 'accessibility-checker' ),
+								readingLevelText,
+								summaryStatus,
+							)
+							: sprintf(
+								/* translators: %s: reading level. */
+								__( 'View reading level details: %s', 'accessibility-checker' ),
+								readingLevelText,
+							)
+						}
 						onKeyDown={ ( e ) => {
 							if ( e.key === 'Enter' || e.key === ' ' ) {
 								if ( e.key === ' ' ) {


### PR DESCRIPTION
The Reading Level summary card visually displays a status such as
'Summary required', but its aria-label only announced the reading
level (e.g. 'View reading level details: 12th'), so screen reader
users never received the visible status. Include the summary status
in the card's accessible name when one is displayed.

Fixes #1765

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UNWw6kF1g1nyCpeDyXRb6L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved the “Reading Level” status card’s accessible label to announce both the reading level and the simplified summary status when available.
  * Preserved the previous accessible label format when simplified summary status isn’t present.
  * Added a new translatable string for the enhanced reading level details announcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->