### PR TITLE
Fix: keep sidebar actions menu button out of the header heading

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -90,15 +90,23 @@ function AccessibilityCheckerSidebar() {
 	return (
 		<PluginSidebar
 			name="accessibility-checker-sidebar"
-			title={
-				<span className="edac-sidebar__title">
-					{ __( 'Accessibility Checker', 'accessibility-checker' ) }
+			title={ __( 'Accessibility Checker', 'accessibility-checker' ) }
+			header={
+				// A custom header keeps the actions menu and spinner outside
+				// the header's <h2>, so screen readers don't announce the menu
+				// button as a heading. The plain-text `title` is still used by
+				// the small-screen header and the Plugins menu, and is the
+				// rendered fallback if `header` is ever unsupported.
+				<div className="edac-sidebar__header">
+					<h2 className="edac-sidebar__header-title">
+						{ __( 'Accessibility Checker', 'accessibility-checker' ) }
+					</h2>
 					{ backgroundRefresh && <Spinner className="edac-sidebar__title-spinner" /> }
 					<SidebarTitleMenu
 						postId={ postId }
 						refetchData={ refetchData }
 					/>
-				</span>
+				</div>
 			}
 			icon={ <AccessibilityCheckerIcon style={ { width: '24px', height: '24px' } } /> }
 		>

--- a/src/sidebar/sass/sidebar.scss
+++ b/src/sidebar/sass/sidebar.scss
@@ -40,22 +40,25 @@
 	}
 }
 
-.components-panel__header-title:has(.edac-sidebar__title) {
-	display: flex;
-	width: 100%;
-}
-
-.interface-complementary-area-header__title:has(.edac-sidebar__title) {
-	width: 100%;
-}
-
-.edac-sidebar__title {
+.edac-sidebar__header {
 	display: flex;
 	align-items: center;
 	gap: 8px;
 	width: 100%;
 	flex: 1 1 auto;
 	min-width: 0;
+}
+
+.edac-sidebar__header-title {
+	// Own the title styles instead of relying on core's
+	// .interface-complementary-area-header__title class, which is not a
+	// public API and could be renamed by Gutenberg.
+	margin: 0;
+	font-size: inherit;
+	color: inherit;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .edac-sidebar__title-spinner {


### PR DESCRIPTION
The Accessibility Checker actions menu button in the editor sidebar was rendered inside the `PluginSidebar` title, which Gutenberg wraps in an `<h2>`, so screen readers announced the button as "heading level 2" in addition to "collapsed menu button" (WCAG 1.3.1 Info and Relationships).

This PR passes a custom `header` to `PluginSidebar` instead: the `<h2>` now contains only the "Accessibility Checker" title text, with the busy spinner and the actions menu rendered as siblings outside the heading. The plain-text `title` prop is kept for the small-screen header, the Plugins menu entry, and as the rendered fallback if the `header` pass-through were ever removed. Title styles are now owned by the plugin (`.edac-sidebar__header-title`) instead of relying on core's internal `interface-complementary-area-header__title` class, which also let the two `:has()` overrides targeting core header classes be removed.

Fixes #1763

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes — no existing JS test coverage for the sidebar registration component; verified via ESLint, webpack build, and the full Jest suite (842 tests passing). Worth a manual screen-reader check that the button no longer announces as "heading level 2".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UoDxFBdso3isbuZXnm1hw

---
_Generated by [Claude Code](https://claude.ai/code/session_013UoDxFBdso3isbuZXnm1hw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar header rendering for a cleaner, more consistent layout.
  * Ensured the sidebar title displays correctly with the loading indicator and action menu.
  * Updated title styling so long text is neatly truncated instead of wrapping awkwardly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->