### PR TITLE
Fix inaccurate accessible name on settings navigation landmark

### DIFF
--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -112,7 +112,7 @@ if ( 'accessibility-reports' === $edac_settings_tab ) {
 
 	<?php
 	if ( $edac_settings_tab_items ) {
-		echo '<nav class="nav-tab-wrapper" aria-label="Settings Tabs">';
+		echo '<nav class="nav-tab-wrapper" aria-label="Settings">';
 		foreach ( $edac_settings_tab_items as $edac_settings_tab_item ) {
 			$edac_slug      = $edac_settings_tab_item['slug'] ? $edac_settings_tab_item['slug'] : null;
 			$edac_query_var = $edac_slug ? '&tab=' . $edac_slug : '';

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -112,7 +112,7 @@ if ( 'accessibility-reports' === $edac_settings_tab ) {
 
 	<?php
 	if ( $edac_settings_tab_items ) {
-		echo '<nav class="nav-tab-wrapper" aria-label="Accessibility Checker Settings">';
+		echo '<nav class="nav-tab-wrapper" aria-label="' . esc_attr__( 'Accessibility Checker Settings', 'accessibility-checker' ) . '">';
 		foreach ( $edac_settings_tab_items as $edac_settings_tab_item ) {
 			$edac_slug      = $edac_settings_tab_item['slug'] ? $edac_settings_tab_item['slug'] : null;
 			$edac_query_var = $edac_slug ? '&tab=' . $edac_slug : '';

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -112,7 +112,7 @@ if ( 'accessibility-reports' === $edac_settings_tab ) {
 
 	<?php
 	if ( $edac_settings_tab_items ) {
-		echo '<nav class="nav-tab-wrapper" aria-label="Settings">';
+		echo '<nav class="nav-tab-wrapper" aria-label="Accessibility Checker Settings">';
 		foreach ( $edac_settings_tab_items as $edac_settings_tab_item ) {
 			$edac_slug      = $edac_settings_tab_item['slug'] ? $edac_settings_tab_item['slug'] : null;
 			$edac_query_var = $edac_slug ? '&tab=' . $edac_slug : '';


### PR DESCRIPTION
Short description: The settings page nav landmark was labeled `aria-label="Settings Tabs"` even though it contains plain navigation links, not an ARIA tabs widget (no `role="tablist"`/`role="tab"`). This mislabeling can mislead assistive technology users about the nature of the control. Changed the label to `"Settings"`.

Fixes #1756

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes (not applicable — single string label change, no new logic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the settings page navigation label so screen readers announce clearer, more accurate text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->