### PR TITLE
Fix incorrect heading order summary to not claim specific heading levels

### DIFF
--- a/includes/classes/Rules/Rule/IncorrectHeadingOrderRule.php
+++ b/includes/classes/Rules/Rule/IncorrectHeadingOrderRule.php
@@ -25,12 +25,7 @@ class IncorrectHeadingOrderRule implements RuleInterface {
 			'info_url'              => 'https://a11ychecker.com/help1940',
 			'slug'                  => 'incorrect_heading_order',
 			'rule_type'             => 'error',
-			'summary'               => sprintf(
-			// translators: %1$s is the found heading level (e.g., <h3>), %2$s is the previous heading level (e.g., <h1>.
-				esc_html__( 'This page uses headings out of order. This is an %1$s after an %2$s, skipping one or more heading levels.', 'accessibility-checker' ),
-				'<code>&lt;h3&gt;</code>',
-				'<code>&lt;h1&gt;</code>'
-			),
+			'summary'               => esc_html__( 'This page uses headings out of order, skipping one or more heading levels.', 'accessibility-checker' ),
 			'summary_plural'        => sprintf(
 			// translators: %1$s is <code>&lt;h1&gt;</code>, %2$s is <code>&lt;h3&gt;</code>, %3$s is <code>&lt;h2&gt;</code.
 				esc_html__( 'These pages use headings out of order, skipping one or more heading levels, such as going from %1$s to %2$s without an %3$s between.', 'accessibility-checker' ),


### PR DESCRIPTION
The singular summary hardcoded <h3> after <h1> regardless of the
actual heading levels involved, which is misleading. Per pattonwebz's
comment on #1561, reword to a generic statement since there's
currently no way to pass the actual heading levels into the summary
text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the wording of a heading-order warning so it is clearer and easier to understand when headings skip levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->