### PR TITLE
Render SVG code snippets in the Accessibility Analysis panel as images

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -526,7 +526,15 @@ class Ajax {
 								)
 							) . '" />';
 						} elseif ( $object_svg ) {
-							$html .= $object_svg;
+							// Rendered as an <img> via a data URI, not injected as inline markup -
+							// see edac_svg_markup_to_data_uri()'s docblock for why.
+							$html .= '<img src="' . esc_url( edac_svg_markup_to_data_uri( $object_svg ), [ 'data', 'http', 'https' ] ) . '" alt="' . esc_attr(
+								sprintf(
+									/* translators: %d: issue ID number */
+									__( 'image for issue %d', 'accessibility-checker' ),
+									$id
+								)
+							) . '" />';
 						}
 
 						$html .= '</div>';

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -789,6 +789,26 @@ function edac_parse_html_for_media( $html ) {
 }
 
 /**
+ * Convert raw SVG markup into a data: URI safe for use as an <img> src.
+ *
+ * The source markup comes from scanned page code stored in the issues
+ * table, which can contain arbitrary attributes/children (e.g. <script>,
+ * on* handlers, <foreignObject>). Encoding it into a data URI and only
+ * ever placing that URI in an <img> src means the browser treats it as an
+ * image resource, not as markup to parse for scripting - the same
+ * technique already used for untrusted SVGs in the issue modal's image
+ * finder (see src/issueModal/components/IssueImage.js).
+ *
+ * @since x.x.x
+ *
+ * @param string $svg_markup Raw SVG markup.
+ * @return string Data URI string (unescaped - callers must esc_url()/esc_attr() it before output).
+ */
+function edac_svg_markup_to_data_uri( $svg_markup ) {
+	return 'data:image/svg+xml,' . rawurlencode( $svg_markup );
+}
+
+/**
  * Remove corrected posts
  *
  * @param int    $post_ID The ID of the post.

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -789,22 +789,20 @@ function edac_parse_html_for_media( $html ) {
 }
 
 /**
- * Convert raw SVG markup into a data: URI safe for use as an <img> src.
- *
- * The source markup comes from scanned page code stored in the issues
- * table, which can contain arbitrary attributes/children (e.g. <script>,
- * on* handlers, <foreignObject>). Encoding it into a data URI and only
- * ever placing that URI in an <img> src means the browser treats it as an
- * image resource, not as markup to parse for scripting - the same
- * technique already used for untrusted SVGs in the issue modal's image
- * finder (see src/issueModal/components/IssueImage.js).
+ * Convert raw SVG markup into a data: URI, safe as an <img> src - browsers
+ * don't execute scripts or event handlers in SVGs loaded as images. Returns
+ * a bare (payload-less) data URI if given anything other than a string.
  *
  * @since x.x.x
  *
- * @param string $svg_markup Raw SVG markup.
- * @return string Data URI string (unescaped - callers must esc_url()/esc_attr() it before output).
+ * @param mixed $svg_markup Raw SVG markup - expected to be a string.
+ * @return string Unescaped data URI - callers must esc_url() it before output.
  */
-function edac_svg_markup_to_data_uri( $svg_markup ) {
+function edac_svg_markup_to_data_uri( $svg_markup ): string {
+	if ( ! is_string( $svg_markup ) ) {
+		return 'data:image/svg+xml,';
+	}
+
 	return 'data:image/svg+xml,' . rawurlencode( $svg_markup );
 }
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -796,7 +796,10 @@ function edac_parse_html_for_media( $html ) {
  * @since x.x.x
  *
  * @param mixed $svg_markup Raw SVG markup - expected to be a string.
- * @return string Unescaped data URI - callers must esc_url() it before output.
+ * @return string Unescaped data URI - callers must esc_url() it before output,
+ *                passing a protocols list that includes 'data' (e.g.
+ *                esc_url( $uri, [ 'data', 'http', 'https' ] )); with the
+ *                default protocols esc_url() rejects data: URIs and returns ''.
  */
 function edac_svg_markup_to_data_uri( $svg_markup ): string {
 	if ( ! is_string( $svg_markup ) ) {

--- a/tests/phpunit/helper-functions/SvgMarkupToDataUriTest.php
+++ b/tests/phpunit/helper-functions/SvgMarkupToDataUriTest.php
@@ -51,11 +51,55 @@ class SvgMarkupToDataUriTest extends WP_UnitTestCase {
 	 */
 	public function malicious_svg_data() {
 		return [
-			'onload handler'    => [ '<svg onload="alert(document.cookie)"></svg>' ],
-			'script child'      => [ '<svg><script>alert(1)</script></svg>' ],
-			'foreignObject'     => [ '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>' ],
-			'javascript: xlink' => [ '<svg><a xlink:href="javascript:alert(1)"><text>click</text></a></svg>' ],
-			'animate onbegin'   => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>' ],
+			'onload handler'      => [ '<svg onload="alert(document.cookie)"></svg>' ],
+			'script child'        => [ '<svg><script>alert(1)</script></svg>' ],
+			'foreignObject'       => [ '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>' ],
+			'javascript: xlink'   => [ '<svg><a xlink:href="javascript:alert(1)"><text>click</text></a></svg>' ],
+			'animate onbegin'     => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>' ],
+			'combined all-in-one' => [
+				'<svg onload="alert(1)"><script>alert(2)</script><a onclick="alert(3)"><foreignObject><body>hi</body></foreignObject></a></svg>',
+			],
+		];
+	}
+
+	/**
+	 * Tests that the combined-vector SVG's dangerous constructs survive
+	 * encoding intact (this function encodes, it does not sanitize - the
+	 * caller's <img src> context is what neutralizes them, not this string).
+	 */
+	public function test_combined_vector_payload_is_preserved_not_stripped() {
+		$svg     = '<svg onload="alert(1)"><script>alert(2)</script><a onclick="alert(3)"><foreignObject><body>hi</body></foreignObject></a></svg>';
+		$decoded = rawurldecode( substr( edac_svg_markup_to_data_uri( $svg ), strlen( 'data:image/svg+xml,' ) ) );
+
+		$this->assertSame( $svg, $decoded );
+		$this->assertStringContainsString( 'onload="alert(1)"', $decoded );
+		$this->assertStringContainsString( '<script>alert(2)</script>', $decoded );
+		$this->assertStringContainsString( 'onclick="alert(3)"', $decoded );
+		$this->assertStringContainsString( '<foreignObject>', $decoded );
+	}
+
+	/**
+	 * Tests that non-string input never fatals and always yields a bare,
+	 * payload-less data URI rather than attempting to encode it.
+	 *
+	 * @dataProvider non_string_data
+	 *
+	 * @param mixed $value A non-string value.
+	 */
+	public function test_non_string_input_returns_bare_data_uri( $value ) {
+		$this->assertSame( 'data:image/svg+xml,', edac_svg_markup_to_data_uri( $value ) );
+	}
+
+	/**
+	 * Data provider of non-string values.
+	 */
+	public function non_string_data() {
+		return [
+			'null'   => [ null ],
+			'array'  => [ [ '<svg onload="alert(1)"></svg>' ] ],
+			'int'    => [ 42 ],
+			'bool'   => [ true ],
+			'object' => [ (object) [ 'markup' => '<svg></svg>' ] ],
 		];
 	}
 }

--- a/tests/phpunit/helper-functions/SvgMarkupToDataUriTest.php
+++ b/tests/phpunit/helper-functions/SvgMarkupToDataUriTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Class SvgMarkupToDataUriTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Test cases for edac_svg_markup_to_data_uri() function.
+ */
+class SvgMarkupToDataUriTest extends WP_UnitTestCase {
+
+	/**
+	 * Tests that the function returns a data URI with the markup percent-encoded.
+	 */
+	public function test_encodes_markup_as_data_uri() {
+		$svg = '<svg width="100" height="100"><circle cx="50" cy="50" r="40" /></svg>';
+
+		$this->assertSame(
+			'data:image/svg+xml,' . rawurlencode( $svg ),
+			edac_svg_markup_to_data_uri( $svg )
+		);
+	}
+
+	/**
+	 * Tests that no raw markup characters survive encoding - the whole point
+	 * is that the string is inert HTML once placed in an <img src> attribute.
+	 *
+	 * @dataProvider malicious_svg_data
+	 *
+	 * @param string $svg The malicious SVG markup to encode.
+	 */
+	public function test_strips_no_bytes_but_leaves_no_raw_markup_characters( $svg ) {
+		$data_uri = edac_svg_markup_to_data_uri( $svg );
+
+		$this->assertStringStartsWith( 'data:image/svg+xml,', $data_uri );
+		$this->assertStringNotContainsString( '<', $data_uri );
+		$this->assertStringNotContainsString( '>', $data_uri );
+		$this->assertStringNotContainsString( '"', $data_uri );
+		$this->assertStringNotContainsString( "'", $data_uri );
+
+		// The encoded payload still round-trips back to the original markup.
+		$this->assertSame(
+			$svg,
+			rawurldecode( substr( $data_uri, strlen( 'data:image/svg+xml,' ) ) )
+		);
+	}
+
+	/**
+	 * Data provider of SVG markup containing common XSS vectors.
+	 */
+	public function malicious_svg_data() {
+		return [
+			'onload handler'    => [ '<svg onload="alert(document.cookie)"></svg>' ],
+			'script child'      => [ '<svg><script>alert(1)</script></svg>' ],
+			'foreignObject'     => [ '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>' ],
+			'javascript: xlink' => [ '<svg><a xlink:href="javascript:alert(1)"><text>click</text></a></svg>' ],
+			'animate onbegin'   => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>' ],
+		];
+	}
+}


### PR DESCRIPTION
## Summary
- The metabox's Accessibility Analysis details panel showed an issue's SVG code snippet by inserting it directly into the panel's markup. It's now encoded as a `data:` URI and rendered through a normal `<img>` tag instead - the same approach already used for inline SVGs in the issue modal's image finder (`src/issueModal/components/IssueImage.js`), so the two surfaces behave consistently.
- Added `edac_svg_markup_to_data_uri()` (`includes/helper-functions.php`) and wired it into `Ajax::details()` (`admin/class-ajax.php`) in place of the raw markup concatenation.
- Added PHPUnit coverage (`tests/phpunit/helper-functions/SvgMarkupToDataUriTest.php`).

## Test plan
- [x] `npm run test:php` - full suite passes (879 tests, 0 failures)
- [x] `./vendor/bin/phpcs` clean on all changed files
- [ ] On a post with a scanned issue whose code snippet contains an inline `<svg>`, confirm the metabox's Accessibility Analysis panel now renders it as an `<img>` and looks the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for scanned SVG/HTML by sanitizing scanned object content before storage and rendering it via a safe image data-URI approach.
  * Added stricter SVG sanitization with an allow-list for safe SVG elements/attributes, stripping scripts/event handlers and dangerous links.
  * Preserves key safe SVG features and restores case-sensitive SVG attribute naming where needed.
* **Tests**
  * Added/expanded PHPUnit coverage for SVG-to-data-URI encoding and scanned HTML/SVG sanitization, including malicious and non-string inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->