### PR TITLE
Sanitize scanned object HTML at save time

### DIFF
--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -163,7 +163,7 @@ class Insert_Rule_Data {
 				'xpath'             => sanitize_text_field( $rule_data['xpath'] ?? '' ),
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
-				'object'            => esc_attr( $rule_data['object'] ),
+				'object'            => esc_attr( edac_sanitize_scanned_html( $rule_data['object'] ) ),
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -163,7 +163,12 @@ class Insert_Rule_Data {
 				'xpath'             => sanitize_text_field( $rule_data['xpath'] ?? '' ),
 				'rule'              => sanitize_text_field( $rule_data['rule'] ),
 				'ruletype'          => sanitize_text_field( $rule_data['ruletype'] ),
-				'object'            => esc_attr( edac_sanitize_scanned_html( $rule_data['object'] ) ),
+				// Re-sanitize after the filter: a callback may have replaced
+				// 'object' with raw markup, or unset it entirely (hence ?? '').
+				// edac_sanitize_scanned_html() decodes first, so re-running it on
+				// the already-escaped line-72 value is idempotent for real content
+				// and does not double-encode.
+				'object'            => esc_attr( edac_sanitize_scanned_html( $rule_data['object'] ?? '' ) ),
 				'recordcheck'       => absint( $rule_data['recordcheck'] ),
 				'user'              => absint( $rule_data['user'] ),
 				'ignre'             => absint( $rule_data['ignre'] ),

--- a/admin/class-insert-rule-data.php
+++ b/admin/class-insert-rule-data.php
@@ -65,7 +65,11 @@ class Insert_Rule_Data {
 			'xpath'             => $selectors['xpath'][0] ?? null,
 			'rule'              => $rule,
 			'ruletype'          => $ruletype,
-			'object'            => esc_attr( $rule_obj ),
+			// Sanitize before esc_attr(): the scanned object HTML/SVG is
+			// untrusted (submitted by any user who can edit the post, via
+			// the JS scan-results REST route) and is later html_entity_decode()d
+			// and re-parsed for display - see edac_sanitize_scanned_html().
+			'object'            => esc_attr( edac_sanitize_scanned_html( $rule_obj ) ),
 			'recordcheck'       => 1,
 			'user'              => get_current_user_id(),
 			'ignre'             => 0,

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -790,10 +790,13 @@ function edac_parse_html_for_media( $html ) {
 
 /**
  * Allowed tags/attributes for edac_sanitize_scanned_html() - wp_kses_allowed_html( 'post' )
- * plus a broad, non-scripting SVG vocabulary. Deliberately excludes <script>,
- * <foreignObject>, <image>, and <a> (SVG's own href-based link element -
- * ordinary post-content links are still allowed via the 'post' base list),
- * and never lists any on* attribute for anything.
+ * plus the non-scripting SVG vocabulary actually likely to appear in a
+ * flagged icon/logo/decorative graphic: structure, shapes, text, and basic
+ * gradients/patterns/masks. Deliberately excludes <script>, <foreignObject>,
+ * <image>, <a> (SVG's own href-based link element - ordinary post-content
+ * links are still allowed via the 'post' base list), SMIL animation
+ * elements, and filter primitives - none of which this plugin's real-world
+ * content needs, and never lists any on* attribute for anything.
  *
  * @since x.x.x
  *
@@ -991,191 +994,9 @@ function edac_scanned_html_allowed_tags(): array {
 		],
 		'title'          => $common,
 		'desc'           => $common,
-		'metadata'       => $common,
 	];
 
-	// Filter primitives are non-scripting image-processing instructions -
-	// safe to allow broadly. feImage is excluded (it loads an external
-	// resource via href, an SSRF/tracking-pixel vector unrelated to script
-	// execution but still worth not opening up here).
-	$filter_attrs      = $common + [
-		'x'              => true,
-		'y'              => true,
-		'width'          => true,
-		'height'         => true,
-		'filterunits'    => true,
-		'primitiveunits' => true,
-		'in'             => true,
-		'in2'            => true,
-		'result'         => true,
-	];
-	$filter_primitives = [
-		'fegaussianblur'      => $filter_attrs + [ 'stddeviation' => true ],
-		'feoffset'            => $filter_attrs + [
-			'dx' => true,
-			'dy' => true,
-		],
-		'feblend'             => $filter_attrs + [ 'mode' => true ],
-		'fecolormatrix'       => $filter_attrs + [
-			'type'   => true,
-			'values' => true,
-		],
-		'fecomponenttransfer' => $filter_attrs,
-		'fefuncr'             => $common + [
-			'type'        => true,
-			'tablevalues' => true,
-			'slope'       => true,
-			'intercept'   => true,
-			'amplitude'   => true,
-			'exponent'    => true,
-			'offset'      => true,
-		],
-		'fefuncg'             => $common + [
-			'type'        => true,
-			'tablevalues' => true,
-			'slope'       => true,
-			'intercept'   => true,
-			'amplitude'   => true,
-			'exponent'    => true,
-			'offset'      => true,
-		],
-		'fefuncb'             => $common + [
-			'type'        => true,
-			'tablevalues' => true,
-			'slope'       => true,
-			'intercept'   => true,
-			'amplitude'   => true,
-			'exponent'    => true,
-			'offset'      => true,
-		],
-		'fefunca'             => $common + [
-			'type'        => true,
-			'tablevalues' => true,
-			'slope'       => true,
-			'intercept'   => true,
-			'amplitude'   => true,
-			'exponent'    => true,
-			'offset'      => true,
-		],
-		'fecomposite'         => $filter_attrs + [
-			'operator' => true,
-			'k1'       => true,
-			'k2'       => true,
-			'k3'       => true,
-			'k4'       => true,
-		],
-		'feflood'             => $filter_attrs + [
-			'flood-color'   => true,
-			'flood-opacity' => true,
-		],
-		'femerge'             => $filter_attrs,
-		'femergenode'         => $common + [ 'in' => true ],
-		'femorphology'        => $filter_attrs + [
-			'operator' => true,
-			'radius'   => true,
-		],
-		'fetile'              => $filter_attrs,
-		'feturbulence'        => $filter_attrs + [
-			'basefrequency' => true,
-			'numoctaves'    => true,
-			'seed'          => true,
-			'stitchtiles'   => true,
-			'type'          => true,
-		],
-		'fedropshadow'        => $filter_attrs + [
-			'dx'            => true,
-			'dy'            => true,
-			'stddeviation'  => true,
-			'flood-color'   => true,
-			'flood-opacity' => true,
-		],
-		'fedisplacementmap'   => $filter_attrs + [
-			'scale'            => true,
-			'xchannelselector' => true,
-			'ychannelselector' => true,
-		],
-		'feconvolvematrix'    => $filter_attrs + [
-			'order'         => true,
-			'kernelmatrix'  => true,
-			'divisor'       => true,
-			'bias'          => true,
-			'targetx'       => true,
-			'targety'       => true,
-			'edgemode'      => true,
-			'preservealpha' => true,
-		],
-		'fediffuselighting'   => $filter_attrs + [
-			'surfacescale'    => true,
-			'diffuseconstant' => true,
-			'lighting-color'  => true,
-		],
-		'fespecularlighting'  => $filter_attrs + [
-			'surfacescale'     => true,
-			'specularconstant' => true,
-			'specularexponent' => true,
-			'lighting-color'   => true,
-		],
-		'fedistantlight'      => $common + [
-			'azimuth'   => true,
-			'elevation' => true,
-		],
-		'fepointlight'        => $common + [
-			'x' => true,
-			'y' => true,
-			'z' => true,
-		],
-		'fespotlight'         => $common + [
-			'x'                 => true,
-			'y'                 => true,
-			'z'                 => true,
-			'pointsatx'         => true,
-			'pointsaty'         => true,
-			'pointsatz'         => true,
-			'specularexponent'  => true,
-			'limitingconeangle' => true,
-		],
-	];
-	$filter_container  = [
-		'filter' => $filter_attrs,
-	];
-
-	// SMIL animation elements - freely allowed since the danger was always
-	// in on*/onbegin/onend-style event attributes, none of which appear here.
-	$animation_attrs = [
-		'attributename' => true,
-		'attributetype' => true,
-		'begin'         => true,
-		'dur'           => true,
-		'end'           => true,
-		'min'           => true,
-		'max'           => true,
-		'restart'       => true,
-		'repeatcount'   => true,
-		'repeatdur'     => true,
-		'fill'          => true,
-		'calcmode'      => true,
-		'values'        => true,
-		'keytimes'      => true,
-		'keysplines'    => true,
-		'from'          => true,
-		'to'            => true,
-		'by'            => true,
-		'additive'      => true,
-		'accumulate'    => true,
-	];
-	$animation_tags  = [
-		'animate'          => $common + $animation_attrs,
-		'animatetransform' => $common + $animation_attrs + [ 'type' => true ],
-		'animatemotion'    => $common + $animation_attrs + [
-			'path'      => true,
-			'keypoints' => true,
-			'rotate'    => true,
-		],
-		'set'              => $common + $animation_attrs,
-		'mpath'            => $common + $href,
-	];
-
-	foreach ( array_merge( $svg_tags, $filter_container, $filter_primitives, $animation_tags ) as $tag => $attrs ) {
+	foreach ( $svg_tags as $tag => $attrs ) {
 		$allowed[ $tag ] = $attrs;
 	}
 
@@ -1211,36 +1032,6 @@ function edac_svg_case_sensitive_attributes(): array {
 		'markerunits'         => 'markerUnits',
 		'refx'                => 'refX',
 		'refy'                => 'refY',
-		'filterunits'         => 'filterUnits',
-		'primitiveunits'      => 'primitiveUnits',
-		'stddeviation'        => 'stdDeviation',
-		'tablevalues'         => 'tableValues',
-		'xchannelselector'    => 'xChannelSelector',
-		'ychannelselector'    => 'yChannelSelector',
-		'basefrequency'       => 'baseFrequency',
-		'numoctaves'          => 'numOctaves',
-		'stitchtiles'         => 'stitchTiles',
-		'surfacescale'        => 'surfaceScale',
-		'diffuseconstant'     => 'diffuseConstant',
-		'specularconstant'    => 'specularConstant',
-		'specularexponent'    => 'specularExponent',
-		'pointsatx'           => 'pointsAtX',
-		'pointsaty'           => 'pointsAtY',
-		'pointsatz'           => 'pointsAtZ',
-		'limitingconeangle'   => 'limitingConeAngle',
-		'kernelmatrix'        => 'kernelMatrix',
-		'targetx'             => 'targetX',
-		'targety'             => 'targetY',
-		'edgemode'            => 'edgeMode',
-		'preservealpha'       => 'preserveAlpha',
-		'attributename'       => 'attributeName',
-		'attributetype'       => 'attributeType',
-		'repeatcount'         => 'repeatCount',
-		'repeatdur'           => 'repeatDur',
-		'calcmode'            => 'calcMode',
-		'keytimes'            => 'keyTimes',
-		'keysplines'          => 'keySplines',
-		'keypoints'           => 'keyPoints',
 		'startoffset'         => 'startOffset',
 	];
 }
@@ -1275,7 +1066,7 @@ function edac_restore_svg_attribute_case( string $sanitized_html ): string {
  * (the scanned element's outerHTML) - strips constructs that could execute
  * as script (script tags, on* event handler attributes, <foreignObject>)
  * while leaving ordinary post-content HTML and non-scripting SVG markup
- * (shapes, gradients, filters, text, animation) unmodified.
+ * (shapes, gradients, text) unmodified.
  *
  * @since x.x.x
  *

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -898,15 +898,28 @@ function edac_restore_svg_attribute_case( string $sanitized_html ): string {
 		return $sanitized_html;
 	}
 
-	foreach ( edac_svg_case_sensitive_attributes() as $lowercased => $correct ) {
-		$sanitized_html = preg_replace(
-			'/(<[^>]*?[\s])' . preg_quote( $lowercased, '/' ) . '(\s*=)/i',
-			'$1' . $correct . '$2',
-			$sanitized_html
-		);
-	}
+	$replacements = edac_svg_case_sensitive_attributes();
+	$names        = implode( '|', array_map( 'preg_quote', array_keys( $replacements ) ) );
 
-	return $sanitized_html;
+	// Restore every case-sensitive attribute in one outer pass over the tags:
+	// match each tag, then fix all matching attribute names inside it. A flat
+	// preg_replace_callback with alternation cannot do this because it consumes
+	// the opening "<", leaving later attributes on the same tag unanchored.
+	$restored = preg_replace_callback(
+		'/<[^>]+>/',
+		static function ( array $tag ) use ( $replacements, $names ): string {
+			return preg_replace_callback(
+				'/(\s)(' . $names . ')(\s*=)/i',
+				static function ( array $attr ) use ( $replacements ): string {
+					return $attr[1] . ( $replacements[ strtolower( $attr[2] ) ] ?? $attr[2] ) . $attr[3];
+				},
+				$tag[0]
+			);
+		},
+		$sanitized_html
+	);
+
+	return null === $restored ? $sanitized_html : $restored;
 }
 
 /**
@@ -916,6 +929,16 @@ function edac_restore_svg_attribute_case( string $sanitized_html ): string {
  * while leaving ordinary post-content HTML and non-scripting SVG markup
  * (shapes, gradients, text) unmodified.
  *
+ * The stored value is later html_entity_decode()d and re-parsed for display
+ * (see edac_parse_html_for_media() and the Frontend_Highlight AJAX handler).
+ * That downstream decode is why we decode here first: entity-encoded markup
+ * such as `&lt;img src=x onerror=alert(1)&gt;` is inert *text* to wp_kses()
+ * (nothing to strip), but the display-side decode would revive it into a live
+ * tag - a sanitizer bypass. Decoding to a fixed point up front (so multiply
+ * -encoded payloads like `&amp;lt;...` collapse too) means wp_kses() sees the
+ * exact markup a browser will ultimately parse, and its decision is the one
+ * that sticks.
+ *
  * @since x.x.x
  *
  * @param mixed $html Raw HTML snippet - expected to be a string.
@@ -924,6 +947,17 @@ function edac_restore_svg_attribute_case( string $sanitized_html ): string {
 function edac_sanitize_scanned_html( $html ): string {
 	if ( ! is_string( $html ) || '' === $html ) {
 		return '';
+	}
+
+	// Fully decode entities before sanitizing - see docblock. html_entity_decode()
+	// only ever contracts (entities -> single chars), so this cannot expand the
+	// input; the guard just bounds pathological deep nesting.
+	$previous     = null;
+	$decode_guard = 0;
+	while ( $html !== $previous && $decode_guard < 10 ) {
+		$previous = $html;
+		$html     = html_entity_decode( $html, ENT_QUOTES | ENT_HTML5 );
+		++$decode_guard;
 	}
 
 	// xlink:href isn't in core's wp_kses_uri_attributes() list (that list

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -790,217 +790,74 @@ function edac_parse_html_for_media( $html ) {
 
 /**
  * Allowed tags/attributes for edac_sanitize_scanned_html() - wp_kses_allowed_html( 'post' )
- * plus the non-scripting SVG vocabulary actually likely to appear in a
- * flagged icon/logo/decorative graphic: structure, shapes, text, and basic
- * gradients/patterns/masks. Deliberately excludes <script>, <foreignObject>,
- * <image>, <a> (SVG's own href-based link element - ordinary post-content
- * links are still allowed via the 'post' base list), SMIL animation
- * elements, and filter primitives - none of which this plugin's real-world
- * content needs, and never lists any on* attribute for anything.
+ * plus the minimal SVG vocabulary a flagged icon/logo/decorative graphic
+ * actually uses: container, grouping, basic shapes, gradients, text, and the
+ * accessible-name elements (<title>/<desc>). Deliberately excludes <script>,
+ * <foreignObject>, <image>, <a> (SVG's own href-based link element -
+ * ordinary post-content links are still allowed via the 'post' base list),
+ * SMIL animation, filter primitives, and rarely-used structural extras
+ * (<pattern>, <mask>, <marker>, <switch>, <textPath>) - none of which this
+ * plugin's real-world content needs. Never lists any on* attribute for
+ * anything.
+ *
+ * Every allowed SVG element shares one attribute set: wp_kses() only needs
+ * attribute names allow-listed, not semantically scoped per tag, and a
+ * geometry/paint attribute on a tag that ignores it is harmless. The only
+ * exception is href/xlink:href, which stays scoped to <use> (the icon-sprite
+ * pattern) and is protocol-validated - see edac_sanitize_scanned_html().
  *
  * @since x.x.x
  *
  * @return array<string, array<string, bool>>
  */
 function edac_scanned_html_allowed_tags(): array {
-	$allowed = wp_kses_allowed_html( 'post' );
+	$identity = [ 'id', 'class', 'style', 'transform', 'role', 'focusable' ];
+	$aria     = [ 'aria-hidden', 'aria-label', 'aria-labelledby', 'aria-describedby' ];
+	$root     = [ 'xmlns', 'xmlns:xlink', 'version', 'viewbox', 'preserveaspectratio' ];
+	$geometry = [ 'x', 'y', 'width', 'height', 'cx', 'cy', 'r', 'rx', 'ry', 'x1', 'y1', 'x2', 'y2', 'fx', 'fy', 'd', 'points', 'dx', 'dy' ];
+	$paint    = [ 'fill', 'fill-rule', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-opacity', 'stroke-miterlimit', 'opacity', 'clip-path', 'clip-rule' ];
+	$gradient = [ 'gradientunits', 'gradienttransform', 'spreadmethod', 'offset', 'stop-color', 'stop-opacity' ];
+	$text     = [ 'text-anchor', 'font-family', 'font-size', 'font-weight', 'font-style' ];
 
-	// Shared by (almost) every SVG element - core presentation attributes
-	// plus the accessibility attributes this plugin most cares about.
-	$common = [
-		'id'               => true,
-		'class'            => true,
-		'style'            => true,
-		'transform'        => true,
-		'role'             => true,
-		'aria-hidden'      => true,
-		'aria-label'       => true,
-		'aria-labelledby'  => true,
-		'aria-describedby' => true,
-		'focusable'        => true,
-		'tabindex'         => true,
-		'lang'             => true,
-		'xml:lang'         => true,
-		'xml:space'        => true,
+	$svg_attributes = array_fill_keys(
+		array_merge( $identity, $aria, $root, $geometry, $paint, $gradient, $text ),
+		true
+	);
+
+	$svg_elements = [
+		'svg',
+		'g',
+		'defs',
+		'symbol',
+		'use',
+		'path',
+		'rect',
+		'circle',
+		'ellipse',
+		'line',
+		'polyline',
+		'polygon',
+		'lineargradient',
+		'radialgradient',
+		'stop',
+		'clippath',
+		'text',
+		'tspan',
+		'title',
+		'desc',
 	];
 
-	// Paint/stroke/fill presentation attributes - valid on most shape and
-	// container elements per the SVG spec; wp_kses doesn't need them to be
-	// semantically scoped per tag, only explicitly allow-listed.
-	$paint = [
-		'fill'              => true,
-		'fill-rule'         => true,
-		'fill-opacity'      => true,
-		'stroke'            => true,
-		'stroke-width'      => true,
-		'stroke-linecap'    => true,
-		'stroke-linejoin'   => true,
-		'stroke-dasharray'  => true,
-		'stroke-dashoffset' => true,
-		'stroke-opacity'    => true,
-		'stroke-miterlimit' => true,
-		'opacity'           => true,
-		'color'             => true,
-		'clip-path'         => true,
-		'clip-rule'         => true,
-		'mask'              => true,
-		'filter'            => true,
-		'marker-start'      => true,
-		'marker-mid'        => true,
-		'marker-end'        => true,
-		'vector-effect'     => true,
-		'shape-rendering'   => true,
-	];
+	$svg = array_fill_keys( $svg_elements, $svg_attributes );
 
-	$common_paint = $common + $paint;
+	// Local same-document fragment reference (#id) for the icon-sprite
+	// pattern. edac_sanitize_scanned_html() registers xlink:href with
+	// wp_kses_uri_attributes() for the duration of the call, so both get
+	// the same bad-protocol/URI validation core already applies to the
+	// plain 'href' attribute.
+	$svg['use']['href']       = true;
+	$svg['use']['xlink:href'] = true;
 
-	// href/xlink:href only ever added to elements whose sole use is a local
-	// same-document fragment reference (#id) - edac_sanitize_scanned_html()
-	// registers xlink:href with wp_kses_uri_attributes() for the duration
-	// of the call, so both get the same bad-protocol/URI validation core
-	// already applies to the plain 'href' attribute.
-	$href = [
-		'href'       => true,
-		'xlink:href' => true,
-	];
-
-	$svg_tags = [
-		'svg'            => $common + [
-			'xmlns'               => true,
-			'xmlns:xlink'         => true,
-			'version'             => true,
-			'viewbox'             => true,
-			'width'               => true,
-			'height'              => true,
-			'preserveaspectratio' => true,
-		],
-		'g'              => $common_paint,
-		'defs'           => $common,
-		'symbol'         => $common + [
-			'viewbox'             => true,
-			'preserveaspectratio' => true,
-		],
-		'switch'         => $common,
-		'use'            => $common_paint + $href + [
-			'x'      => true,
-			'y'      => true,
-			'width'  => true,
-			'height' => true,
-		],
-		'path'           => $common_paint + [ 'd' => true ],
-		'rect'           => $common_paint + [
-			'x'      => true,
-			'y'      => true,
-			'width'  => true,
-			'height' => true,
-			'rx'     => true,
-			'ry'     => true,
-		],
-		'circle'         => $common_paint + [
-			'cx' => true,
-			'cy' => true,
-			'r'  => true,
-		],
-		'ellipse'        => $common_paint + [
-			'cx' => true,
-			'cy' => true,
-			'rx' => true,
-			'ry' => true,
-		],
-		'line'           => $common_paint + [
-			'x1' => true,
-			'y1' => true,
-			'x2' => true,
-			'y2' => true,
-		],
-		'polyline'       => $common_paint + [ 'points' => true ],
-		'polygon'        => $common_paint + [ 'points' => true ],
-		'text'           => $common_paint + [
-			'x'           => true,
-			'y'           => true,
-			'dx'          => true,
-			'dy'          => true,
-			'text-anchor' => true,
-			'font-family' => true,
-			'font-size'   => true,
-			'font-weight' => true,
-			'font-style'  => true,
-		],
-		'tspan'          => $common_paint + [
-			'x'  => true,
-			'y'  => true,
-			'dx' => true,
-			'dy' => true,
-		],
-		'textpath'       => $common_paint + $href + [
-			'startoffset' => true,
-			'method'      => true,
-			'spacing'     => true,
-			'side'        => true,
-		],
-		'lineargradient' => $common + $href + [
-			'x1'                => true,
-			'y1'                => true,
-			'x2'                => true,
-			'y2'                => true,
-			'gradientunits'     => true,
-			'gradienttransform' => true,
-			'spreadmethod'      => true,
-		],
-		'radialgradient' => $common + $href + [
-			'cx'                => true,
-			'cy'                => true,
-			'r'                 => true,
-			'fx'                => true,
-			'fy'                => true,
-			'fr'                => true,
-			'gradientunits'     => true,
-			'gradienttransform' => true,
-			'spreadmethod'      => true,
-		],
-		'stop'           => $common + [
-			'offset'       => true,
-			'stop-color'   => true,
-			'stop-opacity' => true,
-		],
-		'pattern'        => $common + $href + [
-			'x'                   => true,
-			'y'                   => true,
-			'width'               => true,
-			'height'              => true,
-			'patternunits'        => true,
-			'patterncontentunits' => true,
-			'patterntransform'    => true,
-			'viewbox'             => true,
-		],
-		'clippath'       => $common + [ 'clippathunits' => true ],
-		'mask'           => $common + [
-			'x'                => true,
-			'y'                => true,
-			'width'            => true,
-			'height'           => true,
-			'maskunits'        => true,
-			'maskcontentunits' => true,
-		],
-		'marker'         => $common + [
-			'markerwidth'         => true,
-			'markerheight'        => true,
-			'markerunits'         => true,
-			'refx'                => true,
-			'refy'                => true,
-			'orient'              => true,
-			'viewbox'             => true,
-			'preserveaspectratio' => true,
-		],
-		'title'          => $common,
-		'desc'           => $common,
-	];
-
-	foreach ( $svg_tags as $tag => $attrs ) {
-		$allowed[ $tag ] = $attrs;
-	}
-
-	return $allowed;
+	return array_merge( wp_kses_allowed_html( 'post' ), $svg );
 }
 
 /**
@@ -1008,7 +865,8 @@ function edac_scanned_html_allowed_tags(): array {
  * gradientTransform), but wp_kses() - built for case-insensitive HTML -
  * lowercases every attribute name it outputs. Left alone, that silently
  * breaks otherwise-safe SVGs (a lowercased viewbox is simply ignored by
- * browsers). Keyed by the lowercased name wp_kses() produces.
+ * browsers). Keyed by the lowercased name wp_kses() produces. Must stay in
+ * sync with the camelCase attributes in edac_scanned_html_allowed_tags().
  *
  * @since x.x.x
  *
@@ -1021,18 +879,6 @@ function edac_svg_case_sensitive_attributes(): array {
 		'gradientunits'       => 'gradientUnits',
 		'gradienttransform'   => 'gradientTransform',
 		'spreadmethod'        => 'spreadMethod',
-		'patternunits'        => 'patternUnits',
-		'patterncontentunits' => 'patternContentUnits',
-		'patterntransform'    => 'patternTransform',
-		'clippathunits'       => 'clipPathUnits',
-		'maskunits'           => 'maskUnits',
-		'maskcontentunits'    => 'maskContentUnits',
-		'markerwidth'         => 'markerWidth',
-		'markerheight'        => 'markerHeight',
-		'markerunits'         => 'markerUnits',
-		'refx'                => 'refX',
-		'refy'                => 'refY',
-		'startoffset'         => 'startOffset',
 	];
 }
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -793,12 +793,13 @@ function edac_parse_html_for_media( $html ) {
  * plus the minimal SVG vocabulary a flagged icon/logo/decorative graphic
  * actually uses: container, grouping, basic shapes, gradients, text, and the
  * accessible-name elements (<title>/<desc>). Deliberately excludes <script>,
- * <foreignObject>, <image>, <a> (SVG's own href-based link element -
- * ordinary post-content links are still allowed via the 'post' base list),
- * SMIL animation, filter primitives, and rarely-used structural extras
- * (<pattern>, <mask>, <marker>, <switch>, <textPath>) - none of which this
- * plugin's real-world content needs. Never lists any on* attribute for
- * anything.
+ * <foreignObject>, <image>, SMIL animation, filter primitives, and
+ * rarely-used structural extras (<pattern>, <mask>, <marker>, <switch>,
+ * <textPath>) - none of which this plugin's real-world content needs. Note
+ * that <a> IS allowed, via the 'post' base list: wp_kses() has no namespace
+ * awareness, so that entry also matches <a> inside <svg> markup. That's safe
+ * because no on* attribute is ever allowed on anything and href values get
+ * core's bad-protocol validation.
  *
  * Every allowed SVG element shares one attribute set: wp_kses() only needs
  * attribute names allow-listed, not semantically scoped per tag, and a
@@ -865,8 +866,9 @@ function edac_scanned_html_allowed_tags(): array {
  * gradientTransform), but wp_kses() - built for case-insensitive HTML -
  * lowercases every attribute name it outputs. Left alone, that silently
  * breaks otherwise-safe SVGs (a lowercased viewbox is simply ignored by
- * browsers). Keyed by the lowercased name wp_kses() produces. Must stay in
- * sync with the camelCase attributes in edac_scanned_html_allowed_tags().
+ * browsers). Keyed by the lowercased name wp_kses() produces. Every SVG
+ * attribute with a case-sensitive canonical spelling that appears (lowercased)
+ * in edac_scanned_html_allowed_tags() must have an entry here.
  *
  * @since x.x.x
  *

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -789,6 +789,522 @@ function edac_parse_html_for_media( $html ) {
 }
 
 /**
+ * Allowed tags/attributes for edac_sanitize_scanned_html() - wp_kses_allowed_html( 'post' )
+ * plus a broad, non-scripting SVG vocabulary. Deliberately excludes <script>,
+ * <foreignObject>, <image>, and <a> (SVG's own href-based link element -
+ * ordinary post-content links are still allowed via the 'post' base list),
+ * and never lists any on* attribute for anything.
+ *
+ * @since x.x.x
+ *
+ * @return array<string, array<string, bool>>
+ */
+function edac_scanned_html_allowed_tags(): array {
+	$allowed = wp_kses_allowed_html( 'post' );
+
+	// Shared by (almost) every SVG element - core presentation attributes
+	// plus the accessibility attributes this plugin most cares about.
+	$common = [
+		'id'               => true,
+		'class'            => true,
+		'style'            => true,
+		'transform'        => true,
+		'role'             => true,
+		'aria-hidden'      => true,
+		'aria-label'       => true,
+		'aria-labelledby'  => true,
+		'aria-describedby' => true,
+		'focusable'        => true,
+		'tabindex'         => true,
+		'lang'             => true,
+		'xml:lang'         => true,
+		'xml:space'        => true,
+	];
+
+	// Paint/stroke/fill presentation attributes - valid on most shape and
+	// container elements per the SVG spec; wp_kses doesn't need them to be
+	// semantically scoped per tag, only explicitly allow-listed.
+	$paint = [
+		'fill'              => true,
+		'fill-rule'         => true,
+		'fill-opacity'      => true,
+		'stroke'            => true,
+		'stroke-width'      => true,
+		'stroke-linecap'    => true,
+		'stroke-linejoin'   => true,
+		'stroke-dasharray'  => true,
+		'stroke-dashoffset' => true,
+		'stroke-opacity'    => true,
+		'stroke-miterlimit' => true,
+		'opacity'           => true,
+		'color'             => true,
+		'clip-path'         => true,
+		'clip-rule'         => true,
+		'mask'              => true,
+		'filter'            => true,
+		'marker-start'      => true,
+		'marker-mid'        => true,
+		'marker-end'        => true,
+		'vector-effect'     => true,
+		'shape-rendering'   => true,
+	];
+
+	$common_paint = $common + $paint;
+
+	// href/xlink:href only ever added to elements whose sole use is a local
+	// same-document fragment reference (#id) - edac_sanitize_scanned_html()
+	// registers xlink:href with wp_kses_uri_attributes() for the duration
+	// of the call, so both get the same bad-protocol/URI validation core
+	// already applies to the plain 'href' attribute.
+	$href = [
+		'href'       => true,
+		'xlink:href' => true,
+	];
+
+	$svg_tags = [
+		'svg'            => $common + [
+			'xmlns'               => true,
+			'xmlns:xlink'         => true,
+			'version'             => true,
+			'viewbox'             => true,
+			'width'               => true,
+			'height'              => true,
+			'preserveaspectratio' => true,
+		],
+		'g'              => $common_paint,
+		'defs'           => $common,
+		'symbol'         => $common + [
+			'viewbox'             => true,
+			'preserveaspectratio' => true,
+		],
+		'switch'         => $common,
+		'use'            => $common_paint + $href + [
+			'x'      => true,
+			'y'      => true,
+			'width'  => true,
+			'height' => true,
+		],
+		'path'           => $common_paint + [ 'd' => true ],
+		'rect'           => $common_paint + [
+			'x'      => true,
+			'y'      => true,
+			'width'  => true,
+			'height' => true,
+			'rx'     => true,
+			'ry'     => true,
+		],
+		'circle'         => $common_paint + [
+			'cx' => true,
+			'cy' => true,
+			'r'  => true,
+		],
+		'ellipse'        => $common_paint + [
+			'cx' => true,
+			'cy' => true,
+			'rx' => true,
+			'ry' => true,
+		],
+		'line'           => $common_paint + [
+			'x1' => true,
+			'y1' => true,
+			'x2' => true,
+			'y2' => true,
+		],
+		'polyline'       => $common_paint + [ 'points' => true ],
+		'polygon'        => $common_paint + [ 'points' => true ],
+		'text'           => $common_paint + [
+			'x'           => true,
+			'y'           => true,
+			'dx'          => true,
+			'dy'          => true,
+			'text-anchor' => true,
+			'font-family' => true,
+			'font-size'   => true,
+			'font-weight' => true,
+			'font-style'  => true,
+		],
+		'tspan'          => $common_paint + [
+			'x'  => true,
+			'y'  => true,
+			'dx' => true,
+			'dy' => true,
+		],
+		'textpath'       => $common_paint + $href + [
+			'startoffset' => true,
+			'method'      => true,
+			'spacing'     => true,
+			'side'        => true,
+		],
+		'lineargradient' => $common + $href + [
+			'x1'                => true,
+			'y1'                => true,
+			'x2'                => true,
+			'y2'                => true,
+			'gradientunits'     => true,
+			'gradienttransform' => true,
+			'spreadmethod'      => true,
+		],
+		'radialgradient' => $common + $href + [
+			'cx'                => true,
+			'cy'                => true,
+			'r'                 => true,
+			'fx'                => true,
+			'fy'                => true,
+			'fr'                => true,
+			'gradientunits'     => true,
+			'gradienttransform' => true,
+			'spreadmethod'      => true,
+		],
+		'stop'           => $common + [
+			'offset'       => true,
+			'stop-color'   => true,
+			'stop-opacity' => true,
+		],
+		'pattern'        => $common + $href + [
+			'x'                   => true,
+			'y'                   => true,
+			'width'               => true,
+			'height'              => true,
+			'patternunits'        => true,
+			'patterncontentunits' => true,
+			'patterntransform'    => true,
+			'viewbox'             => true,
+		],
+		'clippath'       => $common + [ 'clippathunits' => true ],
+		'mask'           => $common + [
+			'x'                => true,
+			'y'                => true,
+			'width'            => true,
+			'height'           => true,
+			'maskunits'        => true,
+			'maskcontentunits' => true,
+		],
+		'marker'         => $common + [
+			'markerwidth'         => true,
+			'markerheight'        => true,
+			'markerunits'         => true,
+			'refx'                => true,
+			'refy'                => true,
+			'orient'              => true,
+			'viewbox'             => true,
+			'preserveaspectratio' => true,
+		],
+		'title'          => $common,
+		'desc'           => $common,
+		'metadata'       => $common,
+	];
+
+	// Filter primitives are non-scripting image-processing instructions -
+	// safe to allow broadly. feImage is excluded (it loads an external
+	// resource via href, an SSRF/tracking-pixel vector unrelated to script
+	// execution but still worth not opening up here).
+	$filter_attrs      = $common + [
+		'x'              => true,
+		'y'              => true,
+		'width'          => true,
+		'height'         => true,
+		'filterunits'    => true,
+		'primitiveunits' => true,
+		'in'             => true,
+		'in2'            => true,
+		'result'         => true,
+	];
+	$filter_primitives = [
+		'fegaussianblur'      => $filter_attrs + [ 'stddeviation' => true ],
+		'feoffset'            => $filter_attrs + [
+			'dx' => true,
+			'dy' => true,
+		],
+		'feblend'             => $filter_attrs + [ 'mode' => true ],
+		'fecolormatrix'       => $filter_attrs + [
+			'type'   => true,
+			'values' => true,
+		],
+		'fecomponenttransfer' => $filter_attrs,
+		'fefuncr'             => $common + [
+			'type'        => true,
+			'tablevalues' => true,
+			'slope'       => true,
+			'intercept'   => true,
+			'amplitude'   => true,
+			'exponent'    => true,
+			'offset'      => true,
+		],
+		'fefuncg'             => $common + [
+			'type'        => true,
+			'tablevalues' => true,
+			'slope'       => true,
+			'intercept'   => true,
+			'amplitude'   => true,
+			'exponent'    => true,
+			'offset'      => true,
+		],
+		'fefuncb'             => $common + [
+			'type'        => true,
+			'tablevalues' => true,
+			'slope'       => true,
+			'intercept'   => true,
+			'amplitude'   => true,
+			'exponent'    => true,
+			'offset'      => true,
+		],
+		'fefunca'             => $common + [
+			'type'        => true,
+			'tablevalues' => true,
+			'slope'       => true,
+			'intercept'   => true,
+			'amplitude'   => true,
+			'exponent'    => true,
+			'offset'      => true,
+		],
+		'fecomposite'         => $filter_attrs + [
+			'operator' => true,
+			'k1'       => true,
+			'k2'       => true,
+			'k3'       => true,
+			'k4'       => true,
+		],
+		'feflood'             => $filter_attrs + [
+			'flood-color'   => true,
+			'flood-opacity' => true,
+		],
+		'femerge'             => $filter_attrs,
+		'femergenode'         => $common + [ 'in' => true ],
+		'femorphology'        => $filter_attrs + [
+			'operator' => true,
+			'radius'   => true,
+		],
+		'fetile'              => $filter_attrs,
+		'feturbulence'        => $filter_attrs + [
+			'basefrequency' => true,
+			'numoctaves'    => true,
+			'seed'          => true,
+			'stitchtiles'   => true,
+			'type'          => true,
+		],
+		'fedropshadow'        => $filter_attrs + [
+			'dx'            => true,
+			'dy'            => true,
+			'stddeviation'  => true,
+			'flood-color'   => true,
+			'flood-opacity' => true,
+		],
+		'fedisplacementmap'   => $filter_attrs + [
+			'scale'            => true,
+			'xchannelselector' => true,
+			'ychannelselector' => true,
+		],
+		'feconvolvematrix'    => $filter_attrs + [
+			'order'         => true,
+			'kernelmatrix'  => true,
+			'divisor'       => true,
+			'bias'          => true,
+			'targetx'       => true,
+			'targety'       => true,
+			'edgemode'      => true,
+			'preservealpha' => true,
+		],
+		'fediffuselighting'   => $filter_attrs + [
+			'surfacescale'    => true,
+			'diffuseconstant' => true,
+			'lighting-color'  => true,
+		],
+		'fespecularlighting'  => $filter_attrs + [
+			'surfacescale'     => true,
+			'specularconstant' => true,
+			'specularexponent' => true,
+			'lighting-color'   => true,
+		],
+		'fedistantlight'      => $common + [
+			'azimuth'   => true,
+			'elevation' => true,
+		],
+		'fepointlight'        => $common + [
+			'x' => true,
+			'y' => true,
+			'z' => true,
+		],
+		'fespotlight'         => $common + [
+			'x'                 => true,
+			'y'                 => true,
+			'z'                 => true,
+			'pointsatx'         => true,
+			'pointsaty'         => true,
+			'pointsatz'         => true,
+			'specularexponent'  => true,
+			'limitingconeangle' => true,
+		],
+	];
+	$filter_container  = [
+		'filter' => $filter_attrs,
+	];
+
+	// SMIL animation elements - freely allowed since the danger was always
+	// in on*/onbegin/onend-style event attributes, none of which appear here.
+	$animation_attrs = [
+		'attributename' => true,
+		'attributetype' => true,
+		'begin'         => true,
+		'dur'           => true,
+		'end'           => true,
+		'min'           => true,
+		'max'           => true,
+		'restart'       => true,
+		'repeatcount'   => true,
+		'repeatdur'     => true,
+		'fill'          => true,
+		'calcmode'      => true,
+		'values'        => true,
+		'keytimes'      => true,
+		'keysplines'    => true,
+		'from'          => true,
+		'to'            => true,
+		'by'            => true,
+		'additive'      => true,
+		'accumulate'    => true,
+	];
+	$animation_tags  = [
+		'animate'          => $common + $animation_attrs,
+		'animatetransform' => $common + $animation_attrs + [ 'type' => true ],
+		'animatemotion'    => $common + $animation_attrs + [
+			'path'      => true,
+			'keypoints' => true,
+			'rotate'    => true,
+		],
+		'set'              => $common + $animation_attrs,
+		'mpath'            => $common + $href,
+	];
+
+	foreach ( array_merge( $svg_tags, $filter_container, $filter_primitives, $animation_tags ) as $tag => $attrs ) {
+		$allowed[ $tag ] = $attrs;
+	}
+
+	return $allowed;
+}
+
+/**
+ * SVG attribute names are case-sensitive per spec (e.g. viewBox,
+ * gradientTransform), but wp_kses() - built for case-insensitive HTML -
+ * lowercases every attribute name it outputs. Left alone, that silently
+ * breaks otherwise-safe SVGs (a lowercased viewbox is simply ignored by
+ * browsers). Keyed by the lowercased name wp_kses() produces.
+ *
+ * @since x.x.x
+ *
+ * @return array<string, string>
+ */
+function edac_svg_case_sensitive_attributes(): array {
+	return [
+		'viewbox'             => 'viewBox',
+		'preserveaspectratio' => 'preserveAspectRatio',
+		'gradientunits'       => 'gradientUnits',
+		'gradienttransform'   => 'gradientTransform',
+		'spreadmethod'        => 'spreadMethod',
+		'patternunits'        => 'patternUnits',
+		'patterncontentunits' => 'patternContentUnits',
+		'patterntransform'    => 'patternTransform',
+		'clippathunits'       => 'clipPathUnits',
+		'maskunits'           => 'maskUnits',
+		'maskcontentunits'    => 'maskContentUnits',
+		'markerwidth'         => 'markerWidth',
+		'markerheight'        => 'markerHeight',
+		'markerunits'         => 'markerUnits',
+		'refx'                => 'refX',
+		'refy'                => 'refY',
+		'filterunits'         => 'filterUnits',
+		'primitiveunits'      => 'primitiveUnits',
+		'stddeviation'        => 'stdDeviation',
+		'tablevalues'         => 'tableValues',
+		'xchannelselector'    => 'xChannelSelector',
+		'ychannelselector'    => 'yChannelSelector',
+		'basefrequency'       => 'baseFrequency',
+		'numoctaves'          => 'numOctaves',
+		'stitchtiles'         => 'stitchTiles',
+		'surfacescale'        => 'surfaceScale',
+		'diffuseconstant'     => 'diffuseConstant',
+		'specularconstant'    => 'specularConstant',
+		'specularexponent'    => 'specularExponent',
+		'pointsatx'           => 'pointsAtX',
+		'pointsaty'           => 'pointsAtY',
+		'pointsatz'           => 'pointsAtZ',
+		'limitingconeangle'   => 'limitingConeAngle',
+		'kernelmatrix'        => 'kernelMatrix',
+		'targetx'             => 'targetX',
+		'targety'             => 'targetY',
+		'edgemode'            => 'edgeMode',
+		'preservealpha'       => 'preserveAlpha',
+		'attributename'       => 'attributeName',
+		'attributetype'       => 'attributeType',
+		'repeatcount'         => 'repeatCount',
+		'repeatdur'           => 'repeatDur',
+		'calcmode'            => 'calcMode',
+		'keytimes'            => 'keyTimes',
+		'keysplines'          => 'keySplines',
+		'keypoints'           => 'keyPoints',
+		'startoffset'         => 'startOffset',
+	];
+}
+
+/**
+ * Restore case-sensitive SVG attribute names that wp_kses() lowercased.
+ *
+ * @since x.x.x
+ *
+ * @param string $sanitized_html HTML already run through wp_kses().
+ * @return string
+ */
+function edac_restore_svg_attribute_case( string $sanitized_html ): string {
+	if ( false === stripos( $sanitized_html, '<svg' ) ) {
+		// Cheap early exit - none of these attributes mean anything outside SVG.
+		return $sanitized_html;
+	}
+
+	foreach ( edac_svg_case_sensitive_attributes() as $lowercased => $correct ) {
+		$sanitized_html = preg_replace(
+			'/(<[^>]*?[\s])' . preg_quote( $lowercased, '/' ) . '(\s*=)/i',
+			'$1' . $correct . '$2',
+			$sanitized_html
+		);
+	}
+
+	return $sanitized_html;
+}
+
+/**
+ * Sanitize an HTML/SVG snippet before it's stored as an issue's "object"
+ * (the scanned element's outerHTML) - strips constructs that could execute
+ * as script (script tags, on* event handler attributes, <foreignObject>)
+ * while leaving ordinary post-content HTML and non-scripting SVG markup
+ * (shapes, gradients, filters, text, animation) unmodified.
+ *
+ * @since x.x.x
+ *
+ * @param mixed $html Raw HTML snippet - expected to be a string.
+ * @return string Sanitized HTML, or '' if given anything other than a string.
+ */
+function edac_sanitize_scanned_html( $html ): string {
+	if ( ! is_string( $html ) || '' === $html ) {
+		return '';
+	}
+
+	// xlink:href isn't in core's wp_kses_uri_attributes() list (that list
+	// predates SVG/XLink awareness), so without this filter a value like
+	// xlink:href="javascript:alert(1)" would pass through unchecked even
+	// though the identical case for the plain 'href' attribute is already
+	// protocol-validated by core. Scoped to this call only.
+	$add_xlink_href = static function ( array $uri_attributes ): array {
+		$uri_attributes[] = 'xlink:href';
+		return $uri_attributes;
+	};
+
+	add_filter( 'wp_kses_uri_attributes', $add_xlink_href );
+	$sanitized = wp_kses( $html, edac_scanned_html_allowed_tags() );
+	remove_filter( 'wp_kses_uri_attributes', $add_xlink_href );
+
+	return edac_restore_svg_attribute_case( $sanitized );
+}
+
+/**
  * Remove corrected posts
  *
  * @param int    $post_ID The ID of the post.

--- a/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
+++ b/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
@@ -63,8 +63,9 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Warning">'
 			. '<title>Warning</title>'
 			. '<defs><linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">'
-			. '<stop offset="0%" stop-color="#fff" /><stop offset="100%" stop-color="#000" /></linearGradient></defs>'
-			. '<g fill="url(#g1)" stroke="#333" stroke-width="1">'
+			. '<stop offset="0%" stop-color="#fff" /><stop offset="100%" stop-color="#000" /></linearGradient>'
+			. '<clipPath id="c1"><rect x="0" y="0" width="24" height="24" /></clipPath></defs>'
+			. '<g fill="url(#g1)" stroke="#333" stroke-width="1" clip-path="url(#c1)">'
 			. '<circle cx="12" cy="12" r="10" />'
 			. '<path d="M12 6v8" />'
 			. '</g>'
@@ -79,11 +80,58 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<linearGradient', $sanitized );
 		$this->assertStringContainsString( '<stop', $sanitized );
 		$this->assertStringContainsString( 'stop-color="#fff"', $sanitized );
+		$this->assertStringContainsString( '<clipPath', $sanitized );
+		$this->assertStringContainsString( 'clip-path="url(#c1)"', $sanitized );
 		$this->assertStringContainsString( '<circle', $sanitized );
 		$this->assertStringContainsString( 'cx="12"', $sanitized );
 		$this->assertStringContainsString( '<path', $sanitized );
 		$this->assertStringContainsString( 'd="M12 6v8"', $sanitized );
 		$this->assertStringContainsString( 'xlink:href="#g1"', $sanitized );
+	}
+
+	/**
+	 * Tests that every case-sensitive SVG attribute still on the allow-list
+	 * comes back out with its correct camelCase name even though wp_kses()
+	 * lowercases attribute names internally.
+	 */
+	public function test_restores_case_sensitive_svg_attribute_names() {
+		$svg = '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid meet">'
+			. '<linearGradient id="g" gradientUnits="userSpaceOnUse" gradientTransform="rotate(45)" spreadMethod="pad">'
+			. '<stop offset="0" stop-color="#fff" /></linearGradient>'
+			. '<rect width="10" height="10" fill="url(#g)" />'
+			. '</svg>';
+
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringContainsString( 'viewBox=', $sanitized );
+		$this->assertStringContainsString( 'preserveAspectRatio=', $sanitized );
+		$this->assertStringContainsString( 'gradientUnits=', $sanitized );
+		$this->assertStringContainsString( 'gradientTransform=', $sanitized );
+		$this->assertStringContainsString( 'spreadMethod=', $sanitized );
+	}
+
+	/**
+	 * Tests that structural SVG elements deliberately left off the allow-list
+	 * (pattern, mask, marker, switch, textPath) are stripped as tags - kses
+	 * removes the tag itself while keeping any benign child shapes.
+	 */
+	public function test_strips_svg_elements_outside_the_allow_list() {
+		$svg = '<svg viewBox="0 0 10 10">'
+			. '<pattern id="p"><circle r="1" /></pattern>'
+			. '<mask id="m"><rect width="10" height="10" /></mask>'
+			. '<marker id="k"><path d="M0 0" /></marker>'
+			. '<switch><text x="0" y="0">Hi</text></switch>'
+			. '<text><textPath href="#p">curved</textPath></text>'
+			. '</svg>';
+
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringNotContainsString( '<pattern', $sanitized );
+		$this->assertStringNotContainsString( '<mask', $sanitized );
+		$this->assertStringNotContainsString( '<marker', $sanitized );
+		$this->assertStringNotContainsString( '<switch', $sanitized );
+		$this->assertStringNotContainsString( '<textPath', $sanitized );
+		$this->assertStringNotContainsString( '<textpath', $sanitized );
 	}
 
 	/**

--- a/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
+++ b/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
@@ -36,6 +36,7 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 			'javascript: xlink'   => [ '<svg><use xlink:href="javascript:alert(1)" /></svg>', 'javascript:' ],
 			'javascript: href'    => [ '<svg><use href="javascript:alert(1)" /></svg>', 'javascript:' ],
 			'onbegin animate'     => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>', 'onbegin' ],
+			'animate element'     => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>', '<animate' ],
 			'onmouseover handler' => [ '<svg onmouseover="alert(1)"><rect width="10" height="10" /></svg>', 'onmouseover' ],
 		];
 	}
@@ -132,6 +133,34 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<switch', $sanitized );
 		$this->assertStringNotContainsString( '<textPath', $sanitized );
 		$this->assertStringNotContainsString( '<textpath', $sanitized );
+	}
+
+	/**
+	 * Tests that non-rendering / scripting-adjacent SVG elements the allow-list
+	 * deliberately omits (raster <image>, the <filter> pipeline and its
+	 * primitives, and SMIL <animate>) are stripped as tags. These are called
+	 * out separately from the structural exclusions above because they are the
+	 * ones with a security or external-fetch rationale, not just "unused."
+	 */
+	public function test_strips_security_sensitive_svg_elements() {
+		$svg = '<svg viewBox="0 0 10 10">'
+			. '<image href="https://evil.example/x.svg" width="10" height="10" />'
+			. '<filter id="f"><feGaussianBlur stdDeviation="1" /><feImage href="https://evil.example/y" /></filter>'
+			. '<animate attributeName="x" from="0" to="10" />'
+			. '<rect width="10" height="10" fill="#000" />'
+			. '</svg>';
+
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringNotContainsStringIgnoringCase( '<image', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( '<filter', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( '<feGaussianBlur', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( '<feImage', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( '<animate', $sanitized );
+
+		// The benign sibling shape must still survive - excluding the above
+		// should not nuke the rest of the graphic.
+		$this->assertStringContainsString( '<rect', $sanitized );
 	}
 
 	/**

--- a/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
+++ b/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Class SanitizeScannedHtmlTest
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Test cases for edac_sanitize_scanned_html() function.
+ */
+class SanitizeScannedHtmlTest extends WP_UnitTestCase {
+
+	/**
+	 * Tests that dangerous constructs are stripped from otherwise-valid SVG markup.
+	 *
+	 * @dataProvider malicious_svg_data
+	 *
+	 * @param string $svg           The malicious SVG markup.
+	 * @param string $must_not_contain A substring that must not survive sanitization.
+	 */
+	public function test_strips_dangerous_constructs( $svg, $must_not_contain ) {
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringNotContainsString( $must_not_contain, $sanitized );
+	}
+
+	/**
+	 * Data provider of SVG markup containing common XSS vectors.
+	 */
+	public function malicious_svg_data() {
+		return [
+			'onload handler'    => [ '<svg onload="alert(document.cookie)"><circle r="5" /></svg>', 'onload' ],
+			'script child'      => [ '<svg><script>alert(1)</script></svg>', '<script' ],
+			'foreignObject'     => [ '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>', 'foreignObject' ],
+			'onclick handler'   => [ '<svg><a onclick="alert(1)"><circle r="5" /></a></svg>', 'onclick' ],
+			'javascript: xlink' => [ '<svg><use xlink:href="javascript:alert(1)" /></svg>', 'javascript:' ],
+			'javascript: href'  => [ '<svg><use href="javascript:alert(1)" /></svg>', 'javascript:' ],
+			'onbegin animate'   => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>', 'onbegin' ],
+			'style expression'  => [ '<svg onmouseover="alert(1)"><rect width="10" height="10" /></svg>', 'onmouseover' ],
+		];
+	}
+
+	/**
+	 * Tests the combined all-in-one payload (script + onload + onclick +
+	 * foreignObject together) has every dangerous construct removed.
+	 */
+	public function test_combined_vector_payload_is_fully_stripped() {
+		$svg       = '<svg onload="alert(1)"><script>alert(2)</script><a onclick="alert(3)"><foreignObject><body>hi</body></foreignObject></a></svg>';
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringNotContainsString( 'onload', $sanitized );
+		$this->assertStringNotContainsString( '<script', $sanitized );
+		$this->assertStringNotContainsString( 'onclick', $sanitized );
+		$this->assertStringNotContainsString( 'foreignObject', $sanitized );
+	}
+
+	/**
+	 * Tests that a realistic, benign icon-style SVG survives sanitization
+	 * with its meaningful content intact - the whole point of a wide
+	 * allow-list is not mangling ordinary safe SVGs.
+	 */
+	public function test_preserves_safe_svg_content() {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Warning">'
+			. '<title>Warning</title>'
+			. '<defs><linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">'
+			. '<stop offset="0%" stop-color="#fff" /><stop offset="100%" stop-color="#000" /></linearGradient></defs>'
+			. '<g fill="url(#g1)" stroke="#333" stroke-width="1">'
+			. '<circle cx="12" cy="12" r="10" />'
+			. '<path d="M12 6v8" />'
+			. '</g>'
+			. '<use xlink:href="#g1" />'
+			. '</svg>';
+
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringContainsString( '<svg', $sanitized );
+		$this->assertStringContainsString( 'viewBox="0 0 24 24"', $sanitized );
+		$this->assertStringContainsString( '<title>Warning</title>', $sanitized );
+		$this->assertStringContainsString( '<linearGradient', $sanitized );
+		$this->assertStringContainsString( '<stop', $sanitized );
+		$this->assertStringContainsString( 'stop-color="#fff"', $sanitized );
+		$this->assertStringContainsString( '<circle', $sanitized );
+		$this->assertStringContainsString( 'cx="12"', $sanitized );
+		$this->assertStringContainsString( '<path', $sanitized );
+		$this->assertStringContainsString( 'd="M12 6v8"', $sanitized );
+		$this->assertStringContainsString( 'xlink:href="#g1"', $sanitized );
+	}
+
+	/**
+	 * Tests that a local same-document fragment reference (the common,
+	 * legitimate icon-sprite pattern) is preserved on both href and
+	 * xlink:href.
+	 */
+	public function test_preserves_local_fragment_references() {
+		$svg = '<svg><use href="#icon-check" /><use xlink:href="#icon-check" /></svg>';
+
+		$sanitized = edac_sanitize_scanned_html( $svg );
+
+		$this->assertStringContainsString( 'href="#icon-check"', $sanitized );
+		$this->assertStringContainsString( 'xlink:href="#icon-check"', $sanitized );
+	}
+
+	/**
+	 * Tests that ordinary (non-SVG) post-content HTML - the kind most
+	 * flagged elements actually are - passes through unaffected.
+	 */
+	public function test_preserves_ordinary_html_snippet() {
+		$html = '<a href="https://example.com"><strong>Click here</strong></a>';
+
+		$this->assertSame( $html, edac_sanitize_scanned_html( $html ) );
+	}
+
+	/**
+	 * Tests that a plain empty-link snippet (no SVG involved at all) is untouched.
+	 */
+	public function test_preserves_empty_link_snippet() {
+		$html = '<a href="#"><img src="icon.png" alt="Icon"></a>';
+
+		$sanitized = edac_sanitize_scanned_html( $html );
+
+		$this->assertStringContainsString( 'href="#"', $sanitized );
+		$this->assertStringContainsString( 'src="icon.png"', $sanitized );
+	}
+
+	/**
+	 * Tests that non-string input returns an empty string rather than
+	 * throwing or emitting a PHP warning.
+	 *
+	 * @dataProvider non_string_data
+	 *
+	 * @param mixed $value A non-string value.
+	 */
+	public function test_non_string_input_returns_empty_string( $value ) {
+		$this->assertSame( '', edac_sanitize_scanned_html( $value ) );
+	}
+
+	/**
+	 * Data provider of non-string values.
+	 */
+	public function non_string_data() {
+		return [
+			'null'   => [ null ],
+			'array'  => [ [ '<svg onload="alert(1)"></svg>' ] ],
+			'int'    => [ 42 ],
+			'bool'   => [ true ],
+			'object' => [ (object) [ 'markup' => '<svg></svg>' ] ],
+		];
+	}
+
+	/**
+	 * Tests that an empty string input returns an empty string.
+	 */
+	public function test_empty_string_input_returns_empty_string() {
+		$this->assertSame( '', edac_sanitize_scanned_html( '' ) );
+	}
+}

--- a/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
+++ b/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
@@ -29,14 +29,14 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 	 */
 	public function malicious_svg_data() {
 		return [
-			'onload handler'    => [ '<svg onload="alert(document.cookie)"><circle r="5" /></svg>', 'onload' ],
-			'script child'      => [ '<svg><script>alert(1)</script></svg>', '<script' ],
-			'foreignObject'     => [ '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>', 'foreignObject' ],
-			'onclick handler'   => [ '<svg><a onclick="alert(1)"><circle r="5" /></a></svg>', 'onclick' ],
-			'javascript: xlink' => [ '<svg><use xlink:href="javascript:alert(1)" /></svg>', 'javascript:' ],
-			'javascript: href'  => [ '<svg><use href="javascript:alert(1)" /></svg>', 'javascript:' ],
-			'onbegin animate'   => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>', 'onbegin' ],
-			'style expression'  => [ '<svg onmouseover="alert(1)"><rect width="10" height="10" /></svg>', 'onmouseover' ],
+			'onload handler'      => [ '<svg onload="alert(document.cookie)"><circle r="5" /></svg>', 'onload' ],
+			'script child'        => [ '<svg><script>alert(1)</script></svg>', '<script' ],
+			'foreignObject'       => [ '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>', 'foreignObject' ],
+			'onclick handler'     => [ '<svg><a onclick="alert(1)"><circle r="5" /></a></svg>', 'onclick' ],
+			'javascript: xlink'   => [ '<svg><use xlink:href="javascript:alert(1)" /></svg>', 'javascript:' ],
+			'javascript: href'    => [ '<svg><use href="javascript:alert(1)" /></svg>', 'javascript:' ],
+			'onbegin animate'     => [ '<svg><animate onbegin="alert(1)" attributeName="x" /></svg>', 'onbegin' ],
+			'onmouseover handler' => [ '<svg onmouseover="alert(1)"><rect width="10" height="10" /></svg>', 'onmouseover' ],
 		];
 	}
 

--- a/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
+++ b/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
@@ -201,4 +201,57 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 	public function test_empty_string_input_returns_empty_string() {
 		$this->assertSame( '', edac_sanitize_scanned_html( '' ) );
 	}
+
+	/**
+	 * Tests that entity-encoded markup cannot smuggle a live tag past the
+	 * sanitizer. Such a payload is inert text to wp_kses(), so without the
+	 * up-front decode it would survive sanitization and then revive into a
+	 * live tag when the stored value is html_entity_decode()d for display.
+	 *
+	 * @dataProvider entity_smuggled_data
+	 *
+	 * @param string $payload          Entity-encoded malicious markup.
+	 * @param string $must_not_contain Substring that must not survive sanitization.
+	 */
+	public function test_strips_entity_encoded_smuggled_markup( $payload, $must_not_contain ) {
+		$sanitized = edac_sanitize_scanned_html( $payload );
+
+		$this->assertStringNotContainsStringIgnoringCase( $must_not_contain, $sanitized );
+	}
+
+	/**
+	 * Data provider of entity-encoded XSS payloads, including multiply-encoded
+	 * variants that a single decode would not fully collapse.
+	 */
+	public function entity_smuggled_data() {
+		return [
+			'single-encoded onerror' => [ '<svg><title>&lt;img src=x onerror=alert(1)&gt;</title></svg>', 'onerror' ],
+			'single-encoded script'  => [ '<svg><title>&lt;script&gt;alert(1)&lt;/script&gt;</title></svg>', '<script' ],
+			'double-encoded onerror' => [ '<svg><title>&amp;lt;img src=x onerror=alert(1)&amp;gt;</title></svg>', 'onerror' ],
+			'triple-encoded onerror' => [ '<svg><title>&amp;amp;lt;img src=x onerror=alert(1)&amp;amp;gt;</title></svg>', 'onerror' ],
+			'numeric-entity onerror' => [ '<svg><title>&#60;img src=x onerror=alert(1)&#62;</title></svg>', 'onerror' ],
+		];
+	}
+
+	/**
+	 * Tests the full store -> display round trip an attacker would rely on:
+	 * sanitize + esc_attr() at save time (Insert_Rule_Data), then the
+	 * html_entity_decode() every consumer applies before rendering the stored
+	 * object. After the round trip no live event handler or script tag may
+	 * remain, at any encoding depth.
+	 *
+	 * @dataProvider entity_smuggled_data
+	 *
+	 * @param string $payload Entity-encoded malicious markup.
+	 */
+	public function test_smuggled_markup_is_inert_after_store_and_display_decode( $payload ) {
+		// Insert_Rule_Data stores esc_attr( edac_sanitize_scanned_html( $raw ) ).
+		$stored = esc_attr( edac_sanitize_scanned_html( $payload ) );
+
+		// edac_parse_html_for_media() / Frontend_Highlight decode before rendering.
+		$displayed = html_entity_decode( $stored, ENT_QUOTES | ENT_HTML5 );
+
+		$this->assertDoesNotMatchRegularExpression( '/\son\w+\s*=/i', $displayed );
+		$this->assertStringNotContainsStringIgnoringCase( '<script', $displayed );
+	}
 }

--- a/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
+++ b/tests/phpunit/helper-functions/SanitizeScannedHtmlTest.php
@@ -21,7 +21,7 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 	public function test_strips_dangerous_constructs( $svg, $must_not_contain ) {
 		$sanitized = edac_sanitize_scanned_html( $svg );
 
-		$this->assertStringNotContainsString( $must_not_contain, $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( $must_not_contain, $sanitized );
 	}
 
 	/**
@@ -48,10 +48,10 @@ class SanitizeScannedHtmlTest extends WP_UnitTestCase {
 		$svg       = '<svg onload="alert(1)"><script>alert(2)</script><a onclick="alert(3)"><foreignObject><body>hi</body></foreignObject></a></svg>';
 		$sanitized = edac_sanitize_scanned_html( $svg );
 
-		$this->assertStringNotContainsString( 'onload', $sanitized );
-		$this->assertStringNotContainsString( '<script', $sanitized );
-		$this->assertStringNotContainsString( 'onclick', $sanitized );
-		$this->assertStringNotContainsString( 'foreignObject', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( 'onload', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( '<script', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( 'onclick', $sanitized );
+		$this->assertStringNotContainsStringIgnoringCase( 'foreignObject', $sanitized );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Split out of #1832 so the save-time sanitization can be tested independently; that PR now contains only the output-side fix (rendering SVG snippets as data-URI images).
- Adds `edac_sanitize_scanned_html()` and applies it in `Insert_Rule_Data` when persisting an issue's scanned `object` HTML/SVG. The allow-list is `wp_kses_allowed_html( 'post' )` plus a non-scripting SVG vocabulary (shapes, gradients, text, `<title>`/`<desc>`); `<script>`, `<foreignObject>`, `<image>`, SMIL animation, filter primitives, and all `on*` attributes are stripped. `href`/`xlink:href` on `<use>` get core's bad-protocol validation via a scoped `wp_kses_uri_attributes` filter.
- Restores case-sensitive SVG attribute names (`viewBox` etc.) that `wp_kses()` lowercases, so safe SVGs are not visually broken by sanitization.
- Also re-sanitizes the `object` field **after** the `edac_filter_insert_rule_data` filter runs, closing the one write path where a filter callback could persist unsanitized markup.
- Includes review feedback already given on #1832 (docblock corrections, case-insensitive test assertions, data-provider key rename).

## Notes for testing
- New scans store kses-sanitized objects; existing rows are rewritten on the next rescan of each post.
- `wp_kses()` normalizes formatting (attribute whitespace, entities), so stored objects may differ byte-wise from pre-sanitization captures. Known interaction: Pro's global-ignore matching (`edacp_check_global_ignore_on_insert_rule`) compares `object` exactly, so pre-existing global ignores whose snippets kses reformats may stop matching and need a migration or normalized comparison.

## Test plan
- [x] `npm run test:php` — 894 tests, 0 failures (includes new `SanitizeScannedHtmlTest`)
- [x] `./vendor/bin/phpcs` clean on changed files
- [ ] Rescan a post containing an inline SVG issue and confirm the stored object keeps its shape/gradient markup but drops event handlers
- [ ] Confirm Pro global ignores still apply to newly scanned issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for accessibility scan results that include HTML/SVG by sanitizing and safely storing the object content.
  * Blocks dangerous scripts, event handlers, and unsafe URL schemes, while preserving safe SVG/HTML elements and intended references.
  * Restores correct SVG attribute casing to keep rendered output accurate.

* **Tests**
  * Expanded coverage to verify dangerous and entity-encoded “smuggled” payloads are removed and that store-and-display decoding keeps malicious content inert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->