### PR TITLE
Announce accessibility analysis refresh completion

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -204,6 +204,7 @@ class Enqueue_Admin {
 				'wp-i18n',
 				'wp-api-fetch',
 				'wp-components',
+				'wp-a11y',
 			],
 			EDAC_VERSION,
 			false

--- a/src/sidebar/components/SidebarTitleMenu.js
+++ b/src/sidebar/components/SidebarTitleMenu.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useRef, useCallback } from '@wordpress/element';
@@ -34,10 +35,25 @@ const SidebarTitleMenu = ( { postId, refetchData } ) => {
 		document.dispatchEvent( new CustomEvent( 'edac-scan-requested', { detail: { success: true } } ) );
 	};
 
-	const handleRefresh = () => {
-		if ( postId ) {
-			refetchData( postId );
+	const handleRefresh = async () => {
+		if ( ! postId ) {
+			return;
 		}
+
+		let refreshSucceeded = false;
+		try {
+			refreshSucceeded = await refetchData( postId );
+		} catch {
+			// The store normally resolves failures, but keep the user informed if that changes.
+			refreshSucceeded = false;
+		}
+
+		if ( refreshSucceeded ) {
+			speak( __( 'Accessibility analysis refreshed.', 'accessibility-checker' ), 'polite' );
+			return;
+		}
+
+		speak( __( 'Accessibility analysis could not be refreshed.', 'accessibility-checker' ), 'assertive' );
 	};
 
 	const handleClearIssues = async () => {
@@ -113,4 +129,3 @@ const SidebarTitleMenu = ( { postId, refetchData } ) => {
 };
 
 export default SidebarTitleMenu;
-

--- a/src/sidebar/store/accessibility-checker-store.js
+++ b/src/sidebar/store/accessibility-checker-store.js
@@ -210,7 +210,7 @@ const actions = {
 					// If this is the initial load, use regular fetch
 					if ( select.isInitialLoad() ) {
 						await dispatch( actions.fetchData( postId ) );
-						resolve();
+						resolve( ! select.getError() );
 						return;
 					}
 
@@ -218,6 +218,7 @@ const actions = {
 					dispatch( actions.setBackgroundRefresh( true ) );
 					dispatch( actions.setRefreshing( true ) ); // Backwards compatibility
 
+					let refreshSucceeded = false;
 					try {
 						const response = await apiFetch( {
 							path: `/accessibility-checker/v1/sidebar-data/${ postId }`,
@@ -227,6 +228,7 @@ const actions = {
 						if ( response.success ) {
 							// Compare and only update if different
 							dispatch( actions.setDataIfDifferent( response.data ) );
+							refreshSucceeded = true;
 						} else {
 							// Don't show errors during background refresh unless critical
 							// eslint-disable-next-line no-console
@@ -241,7 +243,7 @@ const actions = {
 						dispatch( actions.setRefreshing( false ) );
 					}
 
-					resolve();
+					resolve( refreshSucceeded );
 				}, 200 );
 			} );
 		};

--- a/tests/jest/sidebar/SidebarTitleMenu.test.js
+++ b/tests/jest/sidebar/SidebarTitleMenu.test.js
@@ -1,0 +1,134 @@
+import { act } from 'react';
+import { speak } from '@wordpress/a11y';
+import SidebarTitleMenu from '../../../src/sidebar/components/SidebarTitleMenu';
+import { renderReact } from '../helpers/renderReact';
+
+const mockSetLastFocusedIssue = jest.fn();
+
+jest.mock( '@wordpress/a11y', () => ( {
+	speak: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn(), { virtual: true } );
+
+jest.mock( '@wordpress/components', () => ( {
+	DropdownMenu: ( { label, children } ) => (
+		<div>
+			<button type="button">{ label }</button>
+			{ children( { onClose: jest.fn() } ) }
+		</div>
+	),
+	MenuGroup: ( { children } ) => <div>{ children }</div>,
+	MenuItem: ( { children, onClick } ) => (
+		<button type="button" onClick={ onClick }>{ children }</button>
+	),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn( () => ( {
+		setLastFocusedIssue: mockSetLastFocusedIssue,
+	} ) ),
+} ), { virtual: true } );
+
+jest.mock( '@wordpress/icons', () => ( {
+	moreVertical: null,
+	search: null,
+	update: null,
+	trash: null,
+} ) );
+
+jest.mock( '../../../src/sidebar/store/accessibility-checker-store', () => ( {
+	STORE_NAME: 'accessibility-checker/data',
+} ) );
+
+const getRefreshButton = ( container ) => Array.from( container.querySelectorAll( 'button' ) )
+	.find( ( button ) => button.textContent === 'Refresh' );
+
+describe( 'SidebarTitleMenu', () => {
+	let requestAnimationFrame;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		requestAnimationFrame = window.requestAnimationFrame;
+		window.requestAnimationFrame = jest.fn();
+	} );
+
+	afterEach( () => {
+		window.requestAnimationFrame = requestAnimationFrame;
+	} );
+
+	test( 'announces when a user-triggered refresh succeeds', async () => {
+		const refetchData = jest.fn().mockResolvedValue( true );
+		const { container, unmount } = renderReact(
+			<SidebarTitleMenu postId={ 42 } refetchData={ refetchData } />,
+		);
+
+		await act( async () => {
+			getRefreshButton( container ).click();
+			await Promise.resolve();
+		} );
+
+		expect( refetchData ).toHaveBeenCalledWith( 42 );
+		expect( speak ).toHaveBeenCalledWith(
+			'Accessibility analysis refreshed.',
+			'polite',
+		);
+
+		unmount();
+	} );
+
+	test( 'announces when a user-triggered refresh fails', async () => {
+		const refetchData = jest.fn().mockResolvedValue( false );
+		const { container, unmount } = renderReact(
+			<SidebarTitleMenu postId={ 42 } refetchData={ refetchData } />,
+		);
+
+		await act( async () => {
+			getRefreshButton( container ).click();
+			await Promise.resolve();
+		} );
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Accessibility analysis could not be refreshed.',
+			'assertive',
+		);
+
+		unmount();
+	} );
+
+	test( 'announces failure if the refresh action rejects', async () => {
+		const refetchData = jest.fn().mockRejectedValue( new Error( 'Unexpected error' ) );
+		const { container, unmount } = renderReact(
+			<SidebarTitleMenu postId={ 42 } refetchData={ refetchData } />,
+		);
+
+		await act( async () => {
+			getRefreshButton( container ).click();
+			await Promise.resolve();
+		} );
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Accessibility analysis could not be refreshed.',
+			'assertive',
+		);
+
+		unmount();
+	} );
+
+	test( 'does not refresh or announce without a post ID', async () => {
+		const refetchData = jest.fn();
+		const { container, unmount } = renderReact(
+			<SidebarTitleMenu postId={ null } refetchData={ refetchData } />,
+		);
+
+		await act( async () => {
+			getRefreshButton( container ).click();
+			await Promise.resolve();
+		} );
+
+		expect( refetchData ).not.toHaveBeenCalled();
+		expect( speak ).not.toHaveBeenCalled();
+
+		unmount();
+	} );
+} );

--- a/tests/jest/sidebar/accessibility-checker-store.test.js
+++ b/tests/jest/sidebar/accessibility-checker-store.test.js
@@ -1,0 +1,106 @@
+import apiFetch from '@wordpress/api-fetch';
+import { createReduxStore } from '@wordpress/data';
+import '../../../src/sidebar/store/accessibility-checker-store';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn(), { virtual: true } );
+
+jest.mock( '@wordpress/data', () => ( {
+	createReduxStore: jest.fn( ( name, config ) => ( { name, config } ) ),
+	register: jest.fn(),
+} ), { virtual: true } );
+
+const { actions } = createReduxStore.mock.calls[ 0 ][ 1 ];
+
+const createActionRunner = ( initialLoad = false ) => {
+	const state = {
+		data: null,
+		error: null,
+		initialLoad,
+	};
+
+	const select = {
+		getData: jest.fn( () => state.data ),
+		getError: jest.fn( () => state.error ),
+		isInitialLoad: jest.fn( () => state.initialLoad ),
+	};
+
+	const dispatch = jest.fn( ( action ) => {
+		if ( typeof action === 'function' ) {
+			return action( { dispatch, select } );
+		}
+
+		switch ( action.type ) {
+			case 'SET_DATA':
+				state.data = action.data;
+				break;
+			case 'SET_ERROR':
+				state.error = action.error;
+				break;
+			case 'SET_INITIAL_LOAD':
+				state.initialLoad = action.initialLoad;
+				break;
+			default:
+				break;
+		}
+
+		return action;
+	} );
+
+	return { dispatch, select };
+};
+
+const runRefetch = async ( { initialLoad = false, postId = 42 } = {} ) => {
+	const runner = createActionRunner( initialLoad );
+	const result = actions.refetchData( postId )( runner );
+	jest.advanceTimersByTime( 200 );
+	return result;
+};
+
+describe( 'accessibility checker store refresh results', () => {
+	let consoleWarn;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.clearAllMocks();
+		consoleWarn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		consoleWarn.mockRestore();
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	} );
+
+	test( 'returns true after a successful background refresh', async () => {
+		apiFetch.mockResolvedValue( {
+			success: true,
+			data: { details: {} },
+		} );
+
+		await expect( runRefetch() ).resolves.toBe( true );
+	} );
+
+	test( 'returns false after an unsuccessful background refresh', async () => {
+		apiFetch.mockResolvedValue( {
+			success: false,
+			message: 'Refresh failed',
+		} );
+
+		await expect( runRefetch() ).resolves.toBe( false );
+	} );
+
+	test( 'returns false when a background refresh throws', async () => {
+		apiFetch.mockRejectedValue( new Error( 'Network error' ) );
+
+		await expect( runRefetch() ).resolves.toBe( false );
+	} );
+
+	test( 'returns the initial fetch result when data has not loaded yet', async () => {
+		apiFetch.mockResolvedValue( {
+			success: true,
+			data: { details: {} },
+		} );
+
+		await expect( runRefetch( { initialLoad: true } ) ).resolves.toBe( true );
+	} );
+} );

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -325,7 +325,7 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 	 * Test that the sidebar assets enqueue only in the block editor for scannable post types.
 	 */
 	public function testSidebarScriptEnqueuesInBlockEditorForScannablePost() {
-		global $post, $pagenow;
+		global $post, $pagenow, $wp_scripts;
 		$post    = $this->factory()->post->create_and_get();
 		$pagenow = 'post.php';
 
@@ -335,6 +335,7 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 
 		$this->assertTrue( wp_script_is( 'edac-sidebar', 'enqueued' ) );
 		$this->assertTrue( wp_style_is( 'edac-sidebar', 'enqueued' ) );
+		$this->assertContains( 'wp-a11y', $wp_scripts->registered['edac-sidebar']->deps );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1761

## Summary

- Announce the result of a user-triggered Accessibility Analysis refresh through `wp.a11y.speak`.
- Return the refresh outcome from the sidebar data store so success and failure messages match the request result.
- Load `wp-a11y` with the sidebar bundle and add JavaScript and PHP regression coverage.

## Why

The Refresh action updated the sidebar asynchronously but did not expose a completion status to assistive technologies. Screen reader users therefore had no confirmation that refreshed results were available.

## Testing

- `npm run test:jest -- --runInBand` — 956 tests passed.
- `docker compose exec -T phpunit vendor/bin/phpunit` — 874 tests, 1,867 assertions, 15 skipped.
- `npm run lint:js -- src/sidebar/components/SidebarTitleMenu.js src/sidebar/store/accessibility-checker-store.js tests/jest/sidebar/SidebarTitleMenu.test.js tests/jest/sidebar/accessibility-checker-store.test.js` — passed.
- `docker compose exec -T phpunit vendor/bin/phpcs admin/class-enqueue-admin.php tests/phpunit/Admin/EnqueueAdminTest.php` — passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- Manual verification in Microsoft Edge with NVDA 2026.1.1 — Speech Viewer recorded “Accessibility analysis refreshed.” after activating Refresh.

## Checklist

- [x] PR is linked to the main issue in the repo.
- [x] Tests are added that cover changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Refresh results now provide spoken success or failure announcements.
  * Added support for WordPress accessibility messaging in the editor sidebar.

* **Bug Fixes**
  * Refresh operations now accurately report whether they succeeded, failed, or encountered an error.
  * Refresh is safely skipped when no post is selected.

* **Tests**
  * Added coverage for refresh outcomes and accessibility announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->