### PR TITLE
Build Playground links with wordpress-playground-action

### DIFF
--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -351,14 +351,20 @@ jobs:
       - name: Summary
         env:
           PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
+          MODE: ${{ steps.setref.outputs.mode }}
+          SKIP_PRIMARY: ${{ steps.setref.outputs.skip_primary }}
         run: |
           echo "=== Build Summary ==="
           echo "Mode: ${{ steps.setref.outputs.mode }}"
           echo "Primary zip (empty ref): ${{ env.PRIMARY_ZIP_PATH }}"
           if [ -n "${PRIMARY_PLAYGROUND_URL:-}" ]; then
             echo "Playground (primary): ${PRIMARY_PLAYGROUND_URL}"
+          elif [ "${MODE}" = "release" ]; then
+            echo "Playground (primary): not built (releases ship the zip as a release asset)"
+          elif [ "${SKIP_PRIMARY}" = "true" ]; then
+            echo "Playground (primary): not built (this dispatch passed a ref param, so only the ref zip was built)"
           else
-            echo "Playground (primary): not built (release builds ship the zip as a release asset)"
+            echo "Playground (primary): not built for this run"
           fi
           if [ "${{ steps.check_ref.outputs.need_ref_build }}" = "true" ]; then
             echo "Ref zip (ref=${{ steps.setref.outputs.ref_param }}): ${{ env.REF_ZIP_PATH }}"

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: read          # wordpress-playground-action verifies the artifact exists before linking
 
 jobs:
   build-plugin:
@@ -254,56 +255,32 @@ jobs:
           path: ${{ env.REF_ZIP_FOLDER }}
           if-no-files-found: error
 
-      - name: Resolve public plugin URLs for Playground
-        id: playground-zips
-        if: github.event.repository.private == false
-        run: |
-          PRIMARY_PLUGIN_ZIP_URL=""
-          REF_PLUGIN_ZIP_URL=""
+      # Playground links are built by pattonwebz/wordpress-playground-action, which
+      # resolves the uploaded artifact to a public nightly.link URL and assembles the
+      # blueprint. Not run on `release`: releases carry the real zip as a release asset,
+      # and nightly.link only serves Actions artifacts.
+      #
+      # plugin-slug is set explicitly rather than inferred: the action can strip a
+      # version/hash suffix (accessibility-checker-1.47.0-123-abc1234 -> accessibility-checker)
+      # but not the ref build's shape (…-1.47.0-ref-woocommerce-abc1234), which would
+      # otherwise yield a broken activation path.
+      - name: Playground link (primary build)
+        id: playground_primary
+        if: steps.setref.outputs.skip_primary != 'true' && github.event_name != 'release'
+        uses: pattonwebz/wordpress-playground-action@v0
+        with:
+          artifact-name: ${{ env.PRIMARY_ZIP_NAME_NO_EXT }}
+          plugin-slug: accessibility-checker
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-          if [ -n "${PRIMARY_ZIP_NAME:-}" ]; then
-            if [ "${{ github.event_name }}" = "release" ]; then
-              PRIMARY_PLUGIN_ZIP_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.event.release.tag_name }}/${PRIMARY_ZIP_NAME}"
-            else
-              PRIMARY_PLUGIN_ZIP_URL="https://nightly.link/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/${PRIMARY_ZIP_NAME_NO_EXT}.zip"
-            fi
-          fi
-
-          if [ "${{ steps.check_ref.outputs.need_ref_build }}" = "true" ] && [ -n "${REF_ZIP_NAME:-}" ]; then
-            if [ "${{ github.event_name }}" = "release" ]; then
-              REF_PLUGIN_ZIP_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ github.event.release.tag_name }}/${REF_ZIP_NAME}"
-            else
-              REF_PLUGIN_ZIP_URL="https://nightly.link/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/${REF_ZIP_NAME_NO_EXT}.zip"
-            fi
-          fi
-
-          echo "primary_plugin_zip_url=$PRIMARY_PLUGIN_ZIP_URL" >> "$GITHUB_OUTPUT"
-          echo "ref_plugin_zip_url=$REF_PLUGIN_ZIP_URL" >> "$GITHUB_OUTPUT"
-
-      - name: Build WordPress Playground links
-        if: github.event.repository.private == false
-        run: |
-          export PRIMARY_PLUGIN_ZIP_URL='${{ steps.playground-zips.outputs.primary_plugin_zip_url }}'
-          export REF_PLUGIN_ZIP_URL='${{ steps.playground-zips.outputs.ref_plugin_zip_url }}'
-
-          build_playground_url() {
-            local plugin_url="$1"
-            python3 -c 'import base64,json,sys,urllib.parse; plugin_url=sys.argv[1]; blueprint={"landingPage":"/wp-admin/plugins.php","steps":[{"step":"login"},{"step":"installPlugin","pluginZipFile":{"resource":"url","url":plugin_url}},{"step":"activatePlugin","pluginPath":"accessibility-checker/accessibility-checker.php"}]}; blueprint_json=json.dumps(blueprint,separators=(",",":")); data_uri="data:application/json;base64,"+base64.b64encode(blueprint_json.encode("utf-8")).decode("ascii"); encoded_blueprint_url=urllib.parse.quote(data_uri,safe=""); print(f"https://playground.wordpress.net/?blueprint-url={encoded_blueprint_url}")' "$plugin_url"
-          }
-
-          PRIMARY_PLAYGROUND_URL=""
-          REF_PLAYGROUND_URL=""
-
-          if [ -n "$PRIMARY_PLUGIN_ZIP_URL" ]; then
-            PRIMARY_PLAYGROUND_URL="$(build_playground_url "$PRIMARY_PLUGIN_ZIP_URL")"
-          fi
-
-          if [ -n "$REF_PLUGIN_ZIP_URL" ]; then
-            REF_PLAYGROUND_URL="$(build_playground_url "$REF_PLUGIN_ZIP_URL")"
-          fi
-
-          echo "PRIMARY_PLAYGROUND_URL=$PRIMARY_PLAYGROUND_URL" >> "$GITHUB_ENV"
-          echo "REF_PLAYGROUND_URL=$REF_PLAYGROUND_URL" >> "$GITHUB_ENV"
+      - name: Playground link (ref build)
+        id: playground_ref
+        if: steps.check_ref.outputs.need_ref_build == 'true' && github.event_name != 'release'
+        uses: pattonwebz/wordpress-playground-action@v0
+        with:
+          artifact-name: ${{ env.REF_ZIP_NAME_NO_EXT }}
+          plugin-slug: accessibility-checker
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to release (both zips)
         if: github.event_name == 'release'
@@ -319,6 +296,11 @@ jobs:
       - name: Comment on PR with primary build details
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          # Routed through env: rather than interpolated into the script body - a
+          # ${{ }} substitution lands in the JS source text before Node parses it.
+          PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
+          REF_PLAYGROUND_URL: ${{ steps.playground_ref.outputs.playground-url }}
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -341,7 +323,7 @@ jobs:
             const primaryPlaygroundUrl = process.env.PRIMARY_PLAYGROUND_URL;
             const primaryPlaygroundLine = primaryPlaygroundUrl
               ? `\n- **Playground (primary)**: [Open with plugin preinstalled](${primaryPlaygroundUrl})`
-              : `\n- **Playground (primary)**: Not available for this run (repository may be private or plugin ZIP URL is not publicly accessible).`;
+              : `\n- **Playground (primary)**: Not available for this run.`;
 
             const refPlaygroundUrl = process.env.REF_PLAYGROUND_URL;
             const refPlaygroundLine = refPlaygroundUrl
@@ -377,6 +359,9 @@ jobs:
             }
 
       - name: Summary
+        env:
+          PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
+          REF_PLAYGROUND_URL: ${{ steps.playground_ref.outputs.playground-url }}
         run: |
           echo "=== Build Summary ==="
           echo "Mode: ${{ steps.setref.outputs.mode }}"
@@ -384,14 +369,14 @@ jobs:
           if [ -n "${PRIMARY_PLAYGROUND_URL:-}" ]; then
             echo "Playground (primary): ${PRIMARY_PLAYGROUND_URL}"
           else
-            echo "Playground (primary): skipped (repo is private or URL unavailable)"
+            echo "Playground (primary): not built (release builds ship the zip as a release asset)"
           fi
           if [ "${{ steps.check_ref.outputs.need_ref_build }}" = "true" ]; then
             echo "Ref zip (ref=${{ steps.setref.outputs.ref_param }}): ${{ env.REF_ZIP_PATH }}"
             if [ -n "${REF_PLAYGROUND_URL:-}" ]; then
               echo "Playground (ref): ${REF_PLAYGROUND_URL}"
             else
-              echo "Playground (ref): skipped (repo is private or URL unavailable)"
+              echo "Playground (ref): not built (release builds ship the zip as a release asset)"
             fi
           else
             echo "Ref zip: Not built"

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -255,20 +255,8 @@ jobs:
           path: ${{ env.REF_ZIP_FOLDER }}
           if-no-files-found: error
 
-      # Playground links are built by pattonwebz/wordpress-playground-action, which
-      # resolves the uploaded artifact to a public nightly.link URL and assembles the
-      # blueprint.
-      #
-      # Only the primary build gets a link. Not run on `release`: releases carry the
-      # real zip as a release asset, and nightly.link only serves Actions artifacts.
-      # The ref (woocommerce) build gets no link either - `need_ref_build` is never
-      # true for a pull_request, so a ref link could only ever have surfaced in a
-      # manual-dispatch job log, never in the PR comment.
-      #
-      # plugin-slug is set explicitly rather than inferred: the action strips a
-      # version/hash suffix (accessibility-checker-1.47.0-123-abc1234 -> accessibility-checker)
-      # but would leave the whole "…-1.47.0-ref-woocommerce-abc1234" shape intact,
-      # so pinning it keeps the activation path correct regardless of artifact naming.
+      # Skipped on release: nightly.link serves Actions artifacts, not release assets.
+      # plugin-slug is pinned so the activation path never depends on slug inference.
       - name: Playground link (primary build)
         id: playground_primary
         if: steps.setref.outputs.skip_primary != 'true' && github.event_name != 'release'

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -119,18 +119,23 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           VERSION=$(grep "Version:" accessibility-checker.php | head -1 | sed 's/.*Version:[[:space:]]*\([^ ]*\).*/\1/')
-          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          # On a pull_request, actions/checkout builds the ephemeral
+          # refs/pull/N/merge commit, so `git rev-parse HEAD` is a SHA that does
+          # not appear in the PR's commit list and means nothing to a reviewer.
+          # Use head.sha there so the artifact filename, the build comment and
+          # the PR's own commit list all agree on one SHA.
+          if [ -n "${HEAD_SHA}" ]; then
+            SHORT_SHA="${HEAD_SHA:0:8}"
+          else
+            SHORT_SHA=$(git rev-parse --short=8 HEAD)
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "built_at=$(date -u +'%Y-%m-%d %H:%M UTC')" >> $GITHUB_OUTPUT
           echo "Plugin version: $VERSION"
           echo "Short commit hash: $SHORT_SHA"
-
-          # SHORT_SHA above is the ephemeral refs/pull/N/merge commit that
-          # actions/checkout builds for a pull_request event - it is not in the
-          # PR's commit list, so it means nothing to a reviewer. The PR comment
-          # shows head.sha instead, which is the commit they actually see.
-          echo "pr_short_sha=${HEAD_SHA:0:8}" >> $GITHUB_OUTPUT
-          echo "built_at=$(date -u +'%Y-%m-%d %H:%M UTC')" >> $GITHUB_OUTPUT
 
       - name: Verify EDAC_REF_PARAM is empty before first build
         if: steps.setref.outputs.skip_primary != 'true'
@@ -283,7 +288,7 @@ jobs:
             - **Workflow run**: [View logs]({run_url})
             - **Playground**: [Open with plugin preinstalled]({playground_url})
 
-            <sub>Built from [`${{ steps.version.outputs.pr_short_sha }}`](${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}) · ${{ steps.version.outputs.built_at }}</sub>
+            <sub>Built from [`${{ steps.version.outputs.short_sha }}`](${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}) · ${{ steps.version.outputs.built_at }}</sub>
 
       - name: Upload to release (both zips)
         if: github.event_name == 'release'

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -265,6 +265,14 @@ jobs:
           artifact-name: ${{ env.PRIMARY_ZIP_NAME_NO_EXT }}
           plugin-slug: accessibility-checker
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          post-comment: ${{ github.event_name == 'pull_request' }}
+          pr-number: ${{ github.event.pull_request.number }}
+          comment-template: |
+            ✅ Accessibility Checker build (primary only)
+
+            - **Artifact**: [Download {artifact_name}.zip]({artifact_url})
+            - **Workflow run**: [View logs]({run_url})
+            - **Playground (primary)**: [Open with plugin preinstalled]({playground_url})
 
       - name: Upload to release (both zips)
         if: github.event_name == 'release'
@@ -276,43 +284,6 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Comment on PR with primary build details
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const runId = context.runId;
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
-            const primaryName = process.env.PRIMARY_ZIP_NAME_NO_EXT;
-
-            // Get the artifact ID for the download URL
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId,
-            });
-
-            const artifact = artifacts.data.artifacts.find(a => a.name === primaryName);
-            const downloadUrl = artifact
-              ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}`
-              : runUrl;
-
-            const primaryPlaygroundUrl = process.env.PRIMARY_PLAYGROUND_URL;
-            const primaryPlaygroundLine = primaryPlaygroundUrl
-              ? `\n- **Playground (primary)**: [Open with plugin preinstalled](${primaryPlaygroundUrl})`
-              : `\n- **Playground (primary)**: Not available for this run.`;
-
-            const body = `✅ Accessibility Checker build (primary only)\n\n- **Artifact**: [Download ${primaryName}.zip](${downloadUrl})\n- **Workflow run**: [View logs](${runUrl})${primaryPlaygroundLine}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
 
       - name: Remove triggering label from PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -281,8 +281,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
-          # Routed through env: rather than interpolated into the script body - a
-          # ${{ }} substitution lands in the JS source text before Node parses it.
           PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
         with:
           script: |

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          if [ -f composer.json ]; then composer install --no-dev --prefer-dist --prefer-offline --no-progress --no-interaction; else echo "No composer.json"; fi
+          if [ -f composer.json ]; then composer install --no-dev --prefer-dist --no-progress --no-interaction; else echo "No composer.json"; fi
 
       - name: Install npm dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true' && hashFiles('package.json') != ''

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -257,28 +257,24 @@ jobs:
 
       # Playground links are built by pattonwebz/wordpress-playground-action, which
       # resolves the uploaded artifact to a public nightly.link URL and assembles the
-      # blueprint. Not run on `release`: releases carry the real zip as a release asset,
-      # and nightly.link only serves Actions artifacts.
+      # blueprint.
       #
-      # plugin-slug is set explicitly rather than inferred: the action can strip a
+      # Only the primary build gets a link. Not run on `release`: releases carry the
+      # real zip as a release asset, and nightly.link only serves Actions artifacts.
+      # The ref (woocommerce) build gets no link either - `need_ref_build` is never
+      # true for a pull_request, so a ref link could only ever have surfaced in a
+      # manual-dispatch job log, never in the PR comment.
+      #
+      # plugin-slug is set explicitly rather than inferred: the action strips a
       # version/hash suffix (accessibility-checker-1.47.0-123-abc1234 -> accessibility-checker)
-      # but not the ref build's shape (…-1.47.0-ref-woocommerce-abc1234), which would
-      # otherwise yield a broken activation path.
+      # but would leave the whole "…-1.47.0-ref-woocommerce-abc1234" shape intact,
+      # so pinning it keeps the activation path correct regardless of artifact naming.
       - name: Playground link (primary build)
         id: playground_primary
         if: steps.setref.outputs.skip_primary != 'true' && github.event_name != 'release'
         uses: pattonwebz/wordpress-playground-action@v0
         with:
           artifact-name: ${{ env.PRIMARY_ZIP_NAME_NO_EXT }}
-          plugin-slug: accessibility-checker
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Playground link (ref build)
-        id: playground_ref
-        if: steps.check_ref.outputs.need_ref_build == 'true' && github.event_name != 'release'
-        uses: pattonwebz/wordpress-playground-action@v0
-        with:
-          artifact-name: ${{ env.REF_ZIP_NAME_NO_EXT }}
           plugin-slug: accessibility-checker
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -300,7 +296,6 @@ jobs:
           # Routed through env: rather than interpolated into the script body - a
           # ${{ }} substitution lands in the JS source text before Node parses it.
           PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
-          REF_PLAYGROUND_URL: ${{ steps.playground_ref.outputs.playground-url }}
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -325,12 +320,7 @@ jobs:
               ? `\n- **Playground (primary)**: [Open with plugin preinstalled](${primaryPlaygroundUrl})`
               : `\n- **Playground (primary)**: Not available for this run.`;
 
-            const refPlaygroundUrl = process.env.REF_PLAYGROUND_URL;
-            const refPlaygroundLine = refPlaygroundUrl
-              ? `\n- **Playground (ref)**: [Open with plugin preinstalled](${refPlaygroundUrl})`
-              : '';
-
-            const body = `✅ Accessibility Checker build (primary only)\n\n- **Artifact**: [Download ${primaryName}.zip](${downloadUrl})\n- **Workflow run**: [View logs](${runUrl})${primaryPlaygroundLine}${refPlaygroundLine}`;
+            const body = `✅ Accessibility Checker build (primary only)\n\n- **Artifact**: [Download ${primaryName}.zip](${downloadUrl})\n- **Workflow run**: [View logs](${runUrl})${primaryPlaygroundLine}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -361,7 +351,6 @@ jobs:
       - name: Summary
         env:
           PRIMARY_PLAYGROUND_URL: ${{ steps.playground_primary.outputs.playground-url }}
-          REF_PLAYGROUND_URL: ${{ steps.playground_ref.outputs.playground-url }}
         run: |
           echo "=== Build Summary ==="
           echo "Mode: ${{ steps.setref.outputs.mode }}"
@@ -373,14 +362,8 @@ jobs:
           fi
           if [ "${{ steps.check_ref.outputs.need_ref_build }}" = "true" ]; then
             echo "Ref zip (ref=${{ steps.setref.outputs.ref_param }}): ${{ env.REF_ZIP_PATH }}"
-            if [ -n "${REF_PLAYGROUND_URL:-}" ]; then
-              echo "Playground (ref): ${REF_PLAYGROUND_URL}"
-            else
-              echo "Playground (ref): not built (release builds ship the zip as a release asset)"
-            fi
           else
             echo "Ref zip: Not built"
-            echo "Playground (ref): Not built"
           fi
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "Uploaded to release: ${{ github.event.release.html_url }}"

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -302,7 +302,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove triggering label from PR
-        if: github.event_name == 'pull_request'
+        # always(): a failed build must still drop the label. Re-adding a label
+        # that is already present emits no `labeled` event, so leaving it on
+        # would make the trigger dead until someone removed it by hand.
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -268,11 +268,11 @@ jobs:
           post-comment: ${{ github.event_name == 'pull_request' }}
           pr-number: ${{ github.event.pull_request.number }}
           comment-template: |
-            ✅ Accessibility Checker build (primary only)
+            ✅ Accessibility Checker build
 
             - **Artifact**: [Download {artifact_name}.zip]({artifact_url})
             - **Workflow run**: [View logs]({run_url})
-            - **Playground (primary)**: [Open with plugin preinstalled]({playground_url})
+            - **Playground**: [Open with plugin preinstalled]({playground_url})
 
       - name: Upload to release (both zips)
         if: github.event_name == 'release'

--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -115,6 +115,8 @@ jobs:
 
       - name: Extract plugin version and commit hash
         id: version
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           VERSION=$(grep "Version:" accessibility-checker.php | head -1 | sed 's/.*Version:[[:space:]]*\([^ ]*\).*/\1/')
           SHORT_SHA=$(git rev-parse --short HEAD)
@@ -122,6 +124,13 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "Plugin version: $VERSION"
           echo "Short commit hash: $SHORT_SHA"
+
+          # SHORT_SHA above is the ephemeral refs/pull/N/merge commit that
+          # actions/checkout builds for a pull_request event - it is not in the
+          # PR's commit list, so it means nothing to a reviewer. The PR comment
+          # shows head.sha instead, which is the commit they actually see.
+          echo "pr_short_sha=${HEAD_SHA:0:8}" >> $GITHUB_OUTPUT
+          echo "built_at=$(date -u +'%Y-%m-%d %H:%M UTC')" >> $GITHUB_OUTPUT
 
       - name: Verify EDAC_REF_PARAM is empty before first build
         if: steps.setref.outputs.skip_primary != 'true'
@@ -273,6 +282,8 @@ jobs:
             - **Artifact**: [Download {artifact_name}.zip]({artifact_url})
             - **Workflow run**: [View logs]({run_url})
             - **Playground**: [Open with plugin preinstalled]({playground_url})
+
+            <sub>Built from [`${{ steps.version.outputs.pr_short_sha }}`](${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}) · ${{ steps.version.outputs.built_at }}</sub>
 
       - name: Upload to release (both zips)
         if: github.event_name == 'release'


### PR DESCRIPTION
Replaces the hand-rolled Playground link building in `build-plugin-with-ref.yml` with [`pattonwebz/wordpress-playground-action@v0`](https://github.com/pattonwebz/wordpress-playground-action).

Removed: the "Resolve public plugin URLs for Playground" step (manual `nightly.link` URL construction) and the "Build WordPress Playground links" step (an inline `python3 -c` one-liner that base64-encoded the blueprint). Both are now the action's job.

Net: **-64/+32**, one file.

## Behaviour changes

**No Playground link on `release` events.** The action resolves artifacts through nightly.link, which only proxies Actions artifacts, not release assets. The old code special-cased `release` to emit a `releases/download/...` URL instead — but that URL had no consumer. The PR comment step is `pull_request`-only, so on a release the link only ever reached an `echo` in the Summary log. Releases already ship the real zip as a release asset, which is the better artifact anyway.

**No Playground link for the ref (woocommerce) build.** Also already unreachable: `need_ref_build` is only true for a `workflow_dispatch` carrying a ref value, or for a `release` — never for a `pull_request`. So a ref link could only ever have surfaced in a manual-dispatch job log.

**The ref/woo build itself is untouched.** It still builds and still attaches to releases. Verified the whole chain is intact: `ref_param=woocommerce` → `check_ref` → `update-ref-param.sh` → ref dist build → ref artifact upload → `softprops/action-gh-release` picking up `REF_ZIP_PATH`.

Net effect for reviewers: the PR comment on a `gha-build` label looks the same as before.

## Other changes

- Added `actions: read` to `permissions:` — the action uses it to verify the artifact exists before minting a link, so a wrong artifact name fails at build time instead of at click time.
- `plugin-slug: accessibility-checker` is pinned rather than left to inference, keeping the activation path correct regardless of artifact naming.
- Playground URLs reach the comment/Summary steps via `env:` rather than `${{ }}` interpolated into the script body.
- Dropped the `github.event.repository.private == false` guards — repo is public, and the action refuses private repos itself.

## Verification

- **actionlint 1.7.7** on the final state: 2 errors, both pre-existing. Linted the pre-change file from `develop` as a baseline and got the identical pair (`labels.*.name` array-in-template at line 38, `github.head_ref` in an inline script at line 69). Neither is on a touched line, so both are left alone.
- **Dry-ran the action's `build_blueprint.py`** against a real artifact name (`accessibility-checker-1.47.0-1804-3959d1e4`): the resulting `zip-url` matches the shape the old inline code produced, and `plugin-path` resolves to `accessibility-checker/accessibility-checker.php`.

One JSON difference worth knowing: the new blueprint uses `installPlugin` with `options.activate: true` instead of a separate `activatePlugin` step, and adds `preferredVersions: {php: latest, wp: latest}`. Same end state, different blueprint shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LoLgW7oFjBPxGea9kiZJ2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated pull request comments and build summaries to reflect Playground availability for primary plugin builds, showing “Not available for this run” when no primary link is generated.
  * Adjusted reporting logic for release builds and when primary generation is skipped, with clearer messaging.
  * Simplified ref-build reporting to focus on artifact presence rather than URL/blueprint details.
* **Bug Fixes**
  * Improved consistency of generated Playground links for primary artifacts, including correct handling for release and skipped-primary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->