### PR TITLE
Keep translators comments in the built bundles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,16 @@ module.exports = {
 						reserved: [ '__', '_n', '_x', '_nx' ], // Prevent webpack from using these translation function names and mangling them in the source.
 					},
 					keep_fnames: /(__|_n|_x|_nx)$/,
+					format: {
+						// Keep `translators:` comments in the built bundles. Terser's
+						// default drops every comment except license banners, and
+						// `wp i18n make-pot` scans build/*.bundle.js rather than src/,
+						// so without this a translators comment written in src/ never
+						// reaches the POT and the string stays undocumented.
+						// This only preserves the comment, it does not extract it, so
+						// the existing *.LICENSE.txt output is unaffected.
+						comments: /translators:/i,
+					},
 				},
 			} ),
 			new CssMinimizerPlugin(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,13 +70,7 @@ module.exports = {
 					},
 					keep_fnames: /(__|_n|_x|_nx)$/,
 					format: {
-						// Keep `translators:` comments in the built bundles. Terser's
-						// default drops every comment except license banners, and
-						// `wp i18n make-pot` scans build/*.bundle.js rather than src/,
-						// so without this a translators comment written in src/ never
-						// reaches the POT and the string stays undocumented.
-						// This only preserves the comment, it does not extract it, so
-						// the existing *.LICENSE.txt output is unaffected.
+						// Keep `translators:` comments in the built bundles.
 						comments: /translators:/i,
 					},
 				},


### PR DESCRIPTION
Follow-up to #1846. The first `make-pot` run on `develop` after that merge ([run 30168502285](https://github.com/equalizedigital/accessibility-checker/actions/runs/30168502285)) succeeded in 61s with `pot_changed=false`, but flagged **27 strings with placeholders and no `translators:` comment**.

## The problem this fixes

Every one of those 27 is in `build/*.bundle.js`. **None are in PHP.**

```
12  build/sidebar.bundle.js
 9  build/frontendHighlighterApp.bundle.js
 5  build/issueModal.bundle.js
 1  build/admin.bundle.js
```

Adding the comments to `src/` would have done nothing. Terser's default `format.comments` keeps only license banners, so a `// translators:` comment is stripped before `wp i18n make-pot` — which scans `build/`, not `src/` — ever sees it. You'd write 27 comments, rebuild, and find both the warnings and the POT completely unchanged, which looks like the workflow is broken when it isn't.

## Why only one line, and not the wp-scripts config

Verified with a real webpack run using this repo's exact `terserOptions`:

| config | translators comment | `.LICENSE.txt` emitted |
|---|---|---|
| current | **stripped** | yes |
| **+ `format.comments: /translators:/i`** | **kept** | yes |
| + `extractComments: false` too | kept | **no** |

`@wordpress/scripts` sets `extractComments: false` in its own config, but copying that here would stop the 8 `*.bundle.js.LICENSE.txt` files being emitted, for no benefit. Preserving a comment and extracting one are separate concerns, so this PR adds only the `format.comments` line.

## Confirmed end to end

The non-obvious part is whether `make-pot` can associate a comment with a string in *minified* output, where the whole bundle is a couple of lines. It can — Terser keeps the comment on its own line ahead of the statement:

```
/*! For license information please see b.bundle.js.LICENSE.txt */
(()=>{"use strict";
// translators: 1: current issue number, 2: total issues
sprintf(__("Issue %1$d of %2$d","accessibility-checker"),a,b)})();
```

and `make-pot` produces:

```
#. translators: 1: current issue number, 2: total issues
#: build/b.bundle.js:4
#, js-format
msgid "Issue %1$d of %2$d"
```

The warning disappears for that string. Both the `#.` comment and the `#,` flag are kept by `make-pot.yml`'s diff filter (which ignores only `#:` reference locations), so documenting these strings **will** correctly register as a POT change and raise the update PR — exercising the `create-pull-request` path for the first time.

## Scope

This is the enabling change only; it adds no `translators:` comments. Once merged, the 27 can be added to `src/` and a dispatch of *Generate POT file* will pick them up.

The same gap exists in `accessibility-checker-pro`, `-multisite`, `-audit-history` and `accessibility-new-window-warnings` — all four have `TerserPlugin` with no `format.comments` (export has no `webpack.config.js` at all). Worth applying there too, but only where the POT warnings actually come from bundled JS, which should be checked per repo rather than assumed.

## Testing

- `node --check webpack.config.js` passes.
- Behaviour verified by executing webpack directly with the three config variants above, rather than reasoning from Terser's documented defaults.
- Not yet run through this repo's own build — worth confirming on the first `npm run dist:dotorg` that the bundles still minify as expected and the `.LICENSE.txt` files are still produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LoLgW7oFjBPxGea9kiZJ2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved translator attribution comments in minified production builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->