### PR TITLE
Announce settings save status to screen readers

### DIFF
--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -83,12 +83,7 @@ class Enqueue_Admin {
 			// let extensions supply the correct ID (e.g. a Pro virtual-page ID).
 			$post_id = apply_filters( 'edac_filter_admin_post_id', $post_id );
 
-			$admin_script_dependencies = [ 'jquery' ];
-			if ( 'accessibility_checker_settings' === $page ) {
-				$admin_script_dependencies[] = 'wp-a11y';
-			}
-
-			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', $admin_script_dependencies, EDAC_VERSION, false );
+			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', [ 'jquery', 'wp-a11y' ], EDAC_VERSION, false );
 			wp_set_script_translations( 'edac', 'accessibility-checker', plugin_dir_path( EDAC_PLUGIN_FILE ) . 'languages' );
 			wp_localize_script(
 				'edac',

--- a/admin/class-enqueue-admin.php
+++ b/admin/class-enqueue-admin.php
@@ -83,9 +83,13 @@ class Enqueue_Admin {
 			// let extensions supply the correct ID (e.g. a Pro virtual-page ID).
 			$post_id = apply_filters( 'edac_filter_admin_post_id', $post_id );
 
-			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', [ 'jquery' ], EDAC_VERSION, false );
-			wp_set_script_translations( 'edac', 'accessibility-checker', plugin_dir_path( EDAC_PLUGIN_FILE ) . 'languages' );
+			$admin_script_dependencies = [ 'jquery' ];
+			if ( 'accessibility_checker_settings' === $page ) {
+				$admin_script_dependencies[] = 'wp-a11y';
+			}
 
+			wp_enqueue_script( 'edac', plugin_dir_url( EDAC_PLUGIN_FILE ) . 'build/admin.bundle.js', $admin_script_dependencies, EDAC_VERSION, false );
+			wp_set_script_translations( 'edac', 'accessibility-checker', plugin_dir_path( EDAC_PLUGIN_FILE ) . 'languages' );
 			wp_localize_script(
 				'edac',
 				'edac_script_vars',

--- a/partials/settings-page.php
+++ b/partials/settings-page.php
@@ -110,6 +110,8 @@ if ( 'accessibility-reports' === $edac_settings_tab ) {
 
 	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
+	<?php settings_errors(); ?>
+
 	<?php
 	if ( $edac_settings_tab_items ) {
 		echo '<nav class="nav-tab-wrapper" aria-label="' . esc_attr__( 'Accessibility Checker Settings', 'accessibility-checker' ) . '">';

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -8,6 +8,7 @@ import {
 
 import { initFixesInputStateHandler } from './fixes-page/conditional-disable-settings';
 import { initRequiredSetup } from './fixes-page/conditional-required-settings';
+import { announceSettingsSaveStatus } from './settings/announce-settings-save-status';
 import { inlineSettingsProUpsell } from '../common/settings-pro-callout';
 
 // eslint-disable-next-line camelcase
@@ -17,6 +18,8 @@ const edacScriptVars = edac_script_vars;
 	'use strict';
 
 	jQuery( function() {
+		announceSettingsSaveStatus( window.wp?.a11y );
+
 		if ( document.getElementById( 'edac-fixes-page' ) ) {
 			initFixesInputStateHandler();
 			initRequiredSetup();

--- a/src/admin/settings/announce-settings-save-status.js
+++ b/src/admin/settings/announce-settings-save-status.js
@@ -1,0 +1,33 @@
+/**
+ * Announce the result of saving Accessibility Checker settings.
+ *
+ * @param {Object} a11y          WordPress accessibility utilities.
+ * @param {Window} browserWindow Browser window used to schedule the announcement.
+ */
+export const announceSettingsSaveStatus = ( a11y, browserWindow = window ) => {
+	const notice = document.getElementById( 'setting-error-settings_updated' );
+
+	if ( ! notice || ! a11y || typeof a11y.speak !== 'function' ) {
+		return;
+	}
+
+	const message = notice.textContent.trim();
+	if ( ! message ) {
+		return;
+	}
+
+	const politeness = notice.classList.contains( 'notice-error' ) ? 'assertive' : 'polite';
+	const speakAfterPageLoad = () => {
+		// Give assistive technology time to finish announcing the newly loaded page.
+		browserWindow.setTimeout( () => {
+			a11y.speak( message, politeness );
+		}, 1000 );
+	};
+
+	if ( document.readyState === 'complete' ) {
+		speakAfterPageLoad();
+		return;
+	}
+
+	browserWindow.addEventListener( 'load', speakAfterPageLoad, { once: true } );
+};

--- a/tests/jest/admin/announce-settings-save-status.test.js
+++ b/tests/jest/admin/announce-settings-save-status.test.js
@@ -1,0 +1,94 @@
+import { announceSettingsSaveStatus } from '../../../src/admin/settings/announce-settings-save-status';
+
+describe( 'announceSettingsSaveStatus', () => {
+	let a11y;
+	let readyStateSpy;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		document.body.innerHTML = '';
+		a11y = { speak: jest.fn() };
+		readyStateSpy = jest.spyOn( document, 'readyState', 'get' ).mockReturnValue( 'interactive' );
+	} );
+
+	afterEach( () => {
+		readyStateSpy.mockRestore();
+		jest.useRealTimers();
+	} );
+
+	test( 'announces a successful save politely after the page finishes loading', () => {
+		document.body.innerHTML = `
+			<div id="setting-error-settings_updated" class="notice notice-success settings-error">
+				<p><strong>Settings saved.</strong></p>
+			</div>
+		`;
+
+		announceSettingsSaveStatus( a11y );
+
+		window.dispatchEvent( new Event( 'load' ) );
+		expect( a11y.speak ).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime( 1000 );
+		expect( a11y.speak ).toHaveBeenCalledWith( 'Settings saved.', 'polite' );
+	} );
+
+	test( 'announces a save error assertively', () => {
+		document.body.innerHTML = `
+			<div id="setting-error-settings_updated" class="notice notice-error settings-error">
+				<p><strong>Settings save failed.</strong></p>
+			</div>
+		`;
+
+		announceSettingsSaveStatus( a11y );
+
+		window.dispatchEvent( new Event( 'load' ) );
+		jest.advanceTimersByTime( 1000 );
+		expect( a11y.speak ).toHaveBeenCalledWith( 'Settings save failed.', 'assertive' );
+	} );
+
+	test( 'announces when the page has already finished loading', () => {
+		readyStateSpy.mockReturnValue( 'complete' );
+		document.body.innerHTML = `
+			<div id="setting-error-settings_updated" class="notice notice-success settings-error">
+				<p><strong>Settings saved.</strong></p>
+			</div>
+		`;
+
+		announceSettingsSaveStatus( a11y );
+
+		jest.advanceTimersByTime( 1000 );
+		expect( a11y.speak ).toHaveBeenCalledWith( 'Settings saved.', 'polite' );
+	} );
+
+	test( 'does not announce when the settings notice is missing', () => {
+		announceSettingsSaveStatus( a11y );
+
+		window.dispatchEvent( new Event( 'load' ) );
+		jest.runAllTimers();
+		expect( a11y.speak ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not announce an empty settings notice', () => {
+		document.body.innerHTML = '<div id="setting-error-settings_updated"></div>';
+
+		announceSettingsSaveStatus( a11y );
+
+		window.dispatchEvent( new Event( 'load' ) );
+		jest.runAllTimers();
+		expect( a11y.speak ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not announce when the accessibility utility is unavailable', () => {
+		document.body.innerHTML = `
+			<div id="setting-error-settings_updated">
+				<p><strong>Settings saved.</strong></p>
+			</div>
+		`;
+
+		announceSettingsSaveStatus();
+
+		window.dispatchEvent( new Event( 'load' ) );
+		jest.runAllTimers();
+		expect( a11y.speak ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -73,6 +73,7 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 
 		global $wp_scripts, $wp_styles;
 		unset( $wp_scripts, $wp_styles, $GLOBALS['current_screen'] );
+		unset( $_GET['page'] );
 
 		unset( $this->enqueue_admin );
 	}
@@ -89,11 +90,29 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 
 		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
 		$this->assertFalse( wp_script_is( 'edac-editor-app', 'enqueued' ) );
+		$this->assertNotContains( 'wp-a11y', $wp_scripts->registered['edac']->deps );
 
 		$localized_data = $wp_scripts->get_data( 'edac', 'data' );
 		$this->assertIsString( $localized_data );
 		$this->assertStringContainsString( 'utm_content=__name__', $localized_data );
 		$this->assertStringNotContainsString( 'utm-content=__name__', $localized_data );
+	}
+
+	/**
+	 * Test that the base script loads the accessibility utility on the settings page.
+	 *
+	 * @return void
+	 */
+	public function testEnqueueBaseScriptWithWpA11yOnSettingsPage() {
+
+		global $wp_scripts;
+
+		$_GET['page'] = 'accessibility_checker_settings';
+
+		$this->enqueue_admin::maybe_enqueue_admin_and_editor_app_scripts();
+
+		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
+		$this->assertContains( 'wp-a11y', $wp_scripts->registered['edac']->deps );
 	}
 
 	/**

--- a/tests/phpunit/Admin/EnqueueAdminTest.php
+++ b/tests/phpunit/Admin/EnqueueAdminTest.php
@@ -90,7 +90,7 @@ class EnqueueAdminTest extends WP_UnitTestCase {
 
 		$this->assertTrue( wp_script_is( 'edac', 'enqueued' ) );
 		$this->assertFalse( wp_script_is( 'edac-editor-app', 'enqueued' ) );
-		$this->assertNotContains( 'wp-a11y', $wp_scripts->registered['edac']->deps );
+		$this->assertContains( 'wp-a11y', $wp_scripts->registered['edac']->deps );
 
 		$localized_data = $wp_scripts->get_data( 'edac', 'data' );
 		$this->assertIsString( $localized_data );

--- a/tests/phpunit/partials/SettingsPagePartialTest.php
+++ b/tests/phpunit/partials/SettingsPagePartialTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Accessibility Checker
+ *
+ * @package AccessibilityChecker
+ */
+
+/**
+ * Test the settings page partial.
+ *
+ * @package AccessibilityChecker
+ */
+class SettingsPagePartialTest extends WP_UnitTestCase {
+
+	/**
+	 * Prepare settings errors for each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['wp_settings_errors'] = [];
+		$GLOBALS['title']              = 'Accessibility Checker Settings';
+	}
+
+	/**
+	 * Clean up settings errors after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['wp_settings_errors'], $GLOBALS['title'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the settings page renders the standard saved notice.
+	 */
+	public function testPartialRendersSettingsSavedNotice() {
+		add_settings_error(
+			'general',
+			'settings_updated',
+			'Settings saved.',
+			'success'
+		);
+
+		ob_start();
+		include dirname( __DIR__, 3 ) . '/partials/settings-page.php';
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( "id='setting-error-settings_updated'", $output );
+		$this->assertStringContainsString( 'notice-success', $output );
+		$this->assertStringContainsString( 'Settings saved.', $output );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1757.

- Render WordPress Settings API feedback on the Accessibility Checker settings page.
- Announce the saved result through `wp.a11y.speak`, using polite output for success and assertive output for errors.
- Declare `wp-a11y` as a dependency of the admin bundle.
- Add focused PHPUnit and Jest regression coverage.

## Root cause

The settings form submits through WordPress's Settings API, which stores the standard result notice, but the custom settings page did not call `settings_errors()`. The page therefore refreshed without showing or announcing the save result.

The settings page now renders the standard visible notice immediately after its heading. On DOM ready, the admin bundle detects the notice and schedules the announcement for one second after the page finishes loading. This prevents the polite status from being lost among the screen reader's page-load announcements and does not move keyboard focus.

## Validation

- PHP syntax checks for all changed PHP files
- PHP_CodeSniffer for all changed PHP files
- JavaScript lint for all changed JavaScript files
- Focused Jest: 6 tests passed
- Full Jest: 53 suites and 954 tests passed
- Focused PHPUnit: 27 tests and 56 assertions passed
- Full PHPUnit: 876 tests and 1,872 assertions passed; 15 tests skipped by the existing suite
- `npm run build`
- `git diff --check`
- Automated Edge check: one visible notice, one polite live-region update after load, and no focus movement into the notice or live region
- Manual Edge and NVDA check: one spoken "Settings saved" confirmation after page load

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes