### PR TITLE
Fix Flesch-Kincaid grade 9 threshold

### DIFF
--- a/admin/class-ajax.php
+++ b/admin/class-ajax.php
@@ -674,7 +674,7 @@ class Ajax {
 		$edac_summary           = get_post_meta( $post_id, '_edac_summary', true );
 		$post_grade_readability = ( isset( $edac_summary['readability'] ) ) ? $edac_summary['readability'] : 0;
 		$post_grade             = (int) filter_var( $post_grade_readability, FILTER_SANITIZE_NUMBER_INT );
-		$post_grade_failed      = ( $post_grade < 9 ) ? false : true;
+		$post_grade_failed      = $post_grade > 9;
 
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1072,7 +1072,8 @@ class REST_Api {
 		$edac_summary           = get_post_meta( $post_id, '_edac_summary', true );
 		$post_grade_readability = isset( $edac_summary['readability'] ) ? $edac_summary['readability'] : 0;
 		$post_grade             = (int) filter_var( $post_grade_readability, FILTER_SANITIZE_NUMBER_INT );
-		$post_grade_failed      = $post_grade > 9; // Treat Flesch-Kincaid grade 9+ (above roughly 8th-grade reading level recommended for plain language) as a readability failure.
+		// Treat Flesch-Kincaid grades above 9 (grade 10+) as readability failures.
+		$post_grade_failed = $post_grade > 9;
 
 		$simplified_summary_grade = 0;
 		if ( class_exists( 'DaveChild\TextStatistics\TextStatistics' ) ) {
@@ -1080,7 +1081,7 @@ class REST_Api {
 			$simplified_summary_grade = edac_normalize_fk_grade( $text_statistics->fleschKincaidGradeLevel( $simplified_summary ) );
 		}
 
-		$simplified_summary_grade_failed      = $simplified_summary_grade >= 9;
+		$simplified_summary_grade_failed      = $simplified_summary_grade > 9;
 		$simplified_summary_grade_readability = edac_ordinal( $simplified_summary_grade );
 		$simplified_summary_prompt            = get_option( 'edac_simplified_summary_prompt' );
 

--- a/tests/phpunit/Admin/AjaxReadabilityTest.php
+++ b/tests/phpunit/Admin/AjaxReadabilityTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * AJAX readability behavior tests.
+ *
+ * @package Accessibility_Checker
+ */
+
+use EDAC\Admin\Ajax;
+
+/**
+ * Tests for the AJAX readability response.
+ */
+class AjaxReadabilityTest extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * AJAX handler under test.
+	 *
+	 * @var Ajax
+	 */
+	private $ajax;
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Post ID used for tests.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Create shared fixtures for this test class.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( [ 'role' => 'administrator' ] );
+		self::$post_id  = $factory->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_author'  => self::$admin_id,
+				'post_content' => '<p>Content for AJAX readability tests.</p>',
+			]
+		);
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( self::$admin_id );
+
+		$this->ajax = new Ajax();
+		add_action( 'wp_ajax_edac_readability_ajax', [ $this->ajax, 'readability' ] );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tearDown(): void {
+		remove_action( 'wp_ajax_edac_readability_ajax', [ $this->ajax, 'readability' ] );
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Verify that only reading levels above ninth grade fail.
+	 *
+	 * @dataProvider data_readability_grade_threshold
+	 *
+	 * @param string $readability   Stored readability label.
+	 * @param string $expected_text Expected response text.
+	 * @param string $expected_css  Expected result CSS class.
+	 */
+	public function test_readability_uses_above_ninth_grade_threshold( string $readability, string $expected_text, string $expected_css ) {
+		update_post_meta(
+			self::$post_id,
+			'_edac_summary',
+			[ 'readability' => $readability ]
+		);
+
+		$_POST['nonce']   = wp_create_nonce( 'ajax-nonce' );
+		$_POST['post_id'] = self::$post_id;
+
+		try {
+			$this->_handleAjax( 'edac_readability_ajax' );
+		} catch ( WPAjaxDieContinueException $exception ) {
+			$this->assertNotEmpty( $this->_last_response );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertTrue( $response['success'] );
+
+		$html = json_decode( $response['data'] );
+		$this->assertIsString( $html );
+		$this->assertStringContainsString( $expected_text, $html );
+		$this->assertStringContainsString( $expected_css, $html );
+	}
+
+	/**
+	 * Data provider for the ninth-grade boundary.
+	 *
+	 * @return array<string, array{string, string, string}>
+	 */
+	public static function data_readability_grade_threshold(): array {
+		return [
+			'grade 9 passes' => [
+				'9th Grade',
+				'A simplified summary is not necessary when content reading level is 9th grade or below.',
+				'passed-text-color',
+			],
+			'grade 10 fails' => [
+				'10th Grade',
+				'Your post has a reading level higher than 9th grade.',
+				'failed-text-color',
+			],
+		];
+	}
+}

--- a/tests/phpunit/includes/classes/RestApiSidebarDataTest.php
+++ b/tests/phpunit/includes/classes/RestApiSidebarDataTest.php
@@ -93,6 +93,8 @@ class RestApiSidebarDataTest extends WP_UnitTestCase {
 	 * Clean up after each test.
 	 */
 	protected function tearDown(): void {
+		delete_post_meta( self::$post_id, '_edac_simplified_summary' );
+
 		global $wpdb;
 		$table_name = edac_get_valid_table_name( $wpdb->prefix . 'accessibility_checker' );
 		if ( $table_name ) {

--- a/tests/phpunit/includes/classes/RestApiSidebarDataTest.php
+++ b/tests/phpunit/includes/classes/RestApiSidebarDataTest.php
@@ -150,6 +150,39 @@ class RestApiSidebarDataTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that only simplified summaries above ninth grade fail.
+	 *
+	 * @dataProvider data_readability_grade_threshold
+	 *
+	 * @param int  $word_count     Number of one-syllable words in the test summary.
+	 * @param int  $expected_grade Expected normalized Flesch-Kincaid grade.
+	 * @param bool $expected_failed Whether the summary should fail the threshold.
+	 */
+	public function test_get_readability_data_uses_above_ninth_grade_threshold( int $word_count, int $expected_grade, bool $expected_failed ) {
+		$simplified_summary = str_repeat( 'cat ', $word_count - 1 ) . 'cat.';
+		update_post_meta( self::$post_id, '_edac_simplified_summary', $simplified_summary );
+
+		$api    = new REST_Api();
+		$method = $this->get_private_method( $api, 'get_readability_data' );
+		$data   = $method->invoke( $api, self::$post_id );
+
+		$this->assertSame( $expected_grade, $data['simplified_summary_grade'] );
+		$this->assertSame( $expected_failed, $data['simplified_summary_grade_failed'] );
+	}
+
+	/**
+	 * Data provider for the ninth-grade boundary.
+	 *
+	 * @return array<string, array{int, int, bool}>
+	 */
+	public static function data_readability_grade_threshold(): array {
+		return [
+			'grade 9 passes' => [ 33, 9, false ],
+			'grade 10 fails' => [ 36, 10, true ],
+		];
+	}
+
+	/**
 	 * Ensure get_details_data returns counts and passes rules without rows.
 	 */
 	public function test_get_details_data_counts_and_passed_rules() {


### PR DESCRIPTION
Fixes #1797.

## Summary

- Treat Flesch-Kincaid grade 9 as passing and only grades above 9 as readability failures.
- Align the AJAX post-grade and REST simplified-summary thresholds on `> 9`.
- Correct the misleading threshold comment and add grade 9/10 regression coverage for both paths.

## Root cause

Two readability paths used boundary conditions equivalent to `>= 9`, while the related checks and user-facing copy define a failure as a reading level higher than grade 9. A nearby comment also described the correct `> 9` comparison as "grade 9+."

## Validation

- [x] Focused PHPUnit suite: 11 tests, 46 assertions.
- [x] Full PHPUnit suite: 878 tests, 1,880 assertions, 15 skipped.
- [x] PHPCS on all four changed files.
- [x] PHP lint across 226 files.
- [x] `git diff --check`.

## Checklist

- [x] PR is linked to the main issue in the repo.
- [x] Tests are added that cover changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated readability scoring so grade 9 passes the threshold, while only grades above 9 are marked as failing.
  * Applied the corrected threshold consistently across readability messages, icons, and simplified-summary results.

* **Tests**
  * Added coverage for grade 9 passing and grade 10 failing in readability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->