### PR TITLE
Fix: global dismiss leaks across rules sharing an object (PRO-1264)

### DIFF
--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1230,9 +1230,11 @@ class REST_Api {
 		// If largeBatch is set, verify edit permission for all matching rows,
 		// then perform a single object-based update.
 		if ( $large_batch ) {
-			// Get the 'object' from the issue id.
+			// Get the 'rule' and 'object' from the issue id so the batch is scoped to both.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need fresh data.
-			$object = $wpdb->get_var( $wpdb->prepare( 'SELECT object FROM %i WHERE id = %d', $table_name, $issue_id ) );
+			$representative_row = $wpdb->get_row( $wpdb->prepare( 'SELECT rule, object FROM %i WHERE id = %d', $table_name, $issue_id ), ARRAY_A );
+			$rule               = $representative_row['rule'] ?? '';
+			$object             = $representative_row['object'] ?? '';
 
 			if ( ! $object ) {
 				return new \WP_Error(
@@ -1247,10 +1249,11 @@ class REST_Api {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need current rows for permission validation.
 			$issue_rows = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT id, postid FROM %i WHERE siteid = %d AND object = %s',
+					'SELECT id, postid FROM %i WHERE siteid = %d AND object = %s AND rule = %s',
 					$table_name,
 					$site_id,
-					$object
+					$object,
+					$rule
 				),
 				ARRAY_A
 			);

--- a/includes/classes/class-rest-api.php
+++ b/includes/classes/class-rest-api.php
@@ -1227,8 +1227,8 @@ class REST_Api {
 		$ignre_comment        = $is_ignoring ? $comment : null;
 		$ignre_global         = $is_ignoring ? (int) $ignore_global : 0;
 
-		// If largeBatch is set, verify edit permission for all matching rows,
-		// then perform a single object-based update.
+		// If largeBatch is set, gather every row sharing this issue's rule + object,
+		// verify edit permission for all of them, then update the vetted ids in one query.
 		if ( $large_batch ) {
 			// Get the 'rule' and 'object' from the issue id so the batch is scoped to both.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need fresh data.
@@ -1236,7 +1236,7 @@ class REST_Api {
 			$rule               = $representative_row['rule'] ?? '';
 			$object             = $representative_row['object'] ?? '';
 
-			if ( ! $object ) {
+			if ( ! $representative_row || ! $object ) {
 				return new \WP_Error(
 					'issue_not_found',
 					__( 'Issue not found.', 'accessibility-checker' ),

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -1106,6 +1106,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 			],
 			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
 		);
+		$unrelated_rule_issue_id = $wpdb->insert_id;
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		wp_set_current_user( self::$limited_id );
@@ -1120,6 +1121,16 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 			200,
 			$response->get_status(),
 			'Large batch dismiss should succeed even though an unrelated-rule issue on an unauthorized post shares the object.'
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need fresh data for assertions.
+		$unrelated_ignre = $wpdb->get_var(
+			$wpdb->prepare( 'SELECT ignre FROM %i WHERE id = %d', $table_name, $unrelated_rule_issue_id )
+		);
+		$this->assertSame(
+			'0',
+			$unrelated_ignre,
+			'The unrelated-rule issue on the unauthorized post must stay open -- the batch succeeding must be because it was excluded by the rule filter, not because permissions were skipped.'
 		);
 	}
 

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -692,7 +692,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 		$batch_object = 'batch-all-authorized-test-' . wp_generate_uuid4();
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		// Create multiple issues with the same object (batch).
+		// Create multiple issues sharing the same rule AND object (batch).
 		$issue_ids = [];
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$post_id = ( $i <= 2 ) ? $post_1 : $post_2;
@@ -702,7 +702,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 					'postid'       => $post_id,
 					'siteid'       => $site_id,
 					'type'         => 'error',
-					'rule'         => 'batch-auth-test-' . $i,
+					'rule'         => 'batch-auth-test',
 					'ruletype'     => 'error',
 					'object'       => $batch_object,
 					'recordcheck'  => 1,
@@ -930,13 +930,14 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		// Create first issue on limited_id's post (limited user CAN edit).
+		// Both rows share the same rule AND object so they land in the same batch.
 		$wpdb->insert(
 			$table_name,
 			[
 				'postid'       => $limited_post,
 				'siteid'       => $site_id,
 				'type'         => 'error',
-				'rule'         => 'batch-partial-1',
+				'rule'         => 'batch-partial-test',
 				'ruletype'     => 'error',
 				'object'       => $batch_object,
 				'recordcheck'  => 1,
@@ -955,7 +956,7 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 				'postid'       => $admin_post,
 				'siteid'       => $site_id,
 				'type'         => 'error',
-				'rule'         => 'batch-partial-2',
+				'rule'         => 'batch-partial-test',
 				'ruletype'     => 'error',
 				'object'       => $batch_object,
 				'recordcheck'  => 1,

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -869,19 +869,257 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need fresh data for assertions.
 		$rows = $wpdb->get_results(
-			$wpdb->prepare( 'SELECT id, ignre FROM %i WHERE object = %s ORDER BY id', $table_name, $shared_object ),
+			$wpdb->prepare( 'SELECT id, ignre, ignre_global FROM %i WHERE object = %s ORDER BY id', $table_name, $shared_object ),
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
-		$rows_by_id = array_column( $rows, 'ignre', 'id' );
+		$this->assertCount( 3, $rows, 'All three seeded rows should still exist.' );
 
-		$this->assertSame( '1', $rows_by_id[ $matching_issue_id_1 ], 'The dismissed issue itself should be marked ignored.' );
-		$this->assertSame( '1', $rows_by_id[ $matching_issue_id_2 ], 'The other row sharing rule+object should also be dismissed.' );
+		$ignre_by_id        = array_column( $rows, 'ignre', 'id' );
+		$ignre_global_by_id = array_column( $rows, 'ignre_global', 'id' );
+
+		$this->assertSame( '1', $ignre_by_id[ $matching_issue_id_1 ], 'The dismissed issue itself should be marked ignored.' );
+		$this->assertSame( '1', $ignre_by_id[ $matching_issue_id_2 ], 'The other row sharing rule+object should also be dismissed.' );
+		$this->assertSame( '1', $ignre_global_by_id[ $matching_issue_id_1 ], 'The dismissed issue should be marked as a global ignore.' );
+		$this->assertSame( '1', $ignre_global_by_id[ $matching_issue_id_2 ], 'The other row sharing rule+object should also be marked as a global ignore.' );
 		$this->assertSame(
 			'0',
-			$rows_by_id[ $unrelated_rule_issue_id ],
+			$ignre_by_id[ $unrelated_rule_issue_id ],
 			'A row sharing only the object (different rule) must NOT be dismissed by a global/large-batch action.'
+		);
+	}
+
+	/**
+	 * Test: Large batch reopen (undismiss) only affects rows sharing the same rule, not just the same object.
+	 *
+	 * Mirrors test_large_batch_dismiss_only_affects_matching_rule for the reopen direction:
+	 * a largeBatch action that is NOT a recognized ignore action (e.g. 'reopen') must only
+	 * clear rows matching both rule and object, leaving a row that shares only the object
+	 * (a different rule) still ignored.
+	 *
+	 * @return void
+	 */
+	public function test_large_batch_reopen_only_affects_matching_rule() {
+		global $wpdb;
+
+		$this->assertNotNull( $this->server );
+
+		$post_1 = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Reopen Scoping Post 1',
+				'post_content' => 'Reopen Scoping Content 1',
+			]
+		);
+
+		$post_2 = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Reopen Scoping Post 2',
+				'post_content' => 'Reopen Scoping Content 2',
+			]
+		);
+
+		$post_3 = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Reopen Scoping Post 3',
+				'post_content' => 'Reopen Scoping Content 3',
+			]
+		);
+
+		$table_name    = $wpdb->prefix . 'accessibility_checker';
+		$site_id       = get_current_blog_id();
+		$shared_object = 'reopen-scoping-test-' . wp_generate_uuid4();
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// All three rows start pre-ignored/globally-ignored. Post 1 and Post 2 share rule+object.
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $post_1,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'missing_alt_text',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 1,
+				'ignre_global' => 1,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$matching_issue_id_1 = $wpdb->insert_id;
+
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $post_2,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'missing_alt_text',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 1,
+				'ignre_global' => 1,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$matching_issue_id_2 = $wpdb->insert_id;
+
+		// Post 3 shares the same object but has a DIFFERENT rule — must stay ignored.
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $post_3,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'color_contrast_failure',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 1,
+				'ignre_global' => 1,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$unrelated_rule_issue_id = $wpdb->insert_id;
+
+		// Set limited user (who owns all three posts).
+		wp_set_current_user( self::$limited_id );
+
+		// Reopen globally, starting from one of the matching-rule issues. Any action string
+		// outside the recognized ignore-actions list is treated as "reopen" by dismiss_issue().
+		$request = new \WP_REST_Request( 'POST', '/accessibility-checker/v1/dismiss-issue/' . $matching_issue_id_1 );
+		$request->set_param( 'action', 'undismiss' );
+		$request->set_param( 'largeBatch', true );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Large batch reopen should succeed for the authorized user.' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need fresh data for assertions.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT id, ignre, ignre_global FROM %i WHERE object = %s ORDER BY id', $table_name, $shared_object ),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$this->assertCount( 3, $rows, 'All three seeded rows should still exist.' );
+
+		$ignre_by_id = array_column( $rows, 'ignre', 'id' );
+
+		$this->assertSame( '0', $ignre_by_id[ $matching_issue_id_1 ], 'The reopened issue itself should be marked open.' );
+		$this->assertSame( '0', $ignre_by_id[ $matching_issue_id_2 ], 'The other row sharing rule+object should also be reopened.' );
+		$this->assertSame(
+			'1',
+			$ignre_by_id[ $unrelated_rule_issue_id ],
+			'A row sharing only the object (different rule) must remain ignored after a large-batch reopen.'
+		);
+	}
+
+	/**
+	 * Test: Large batch dismiss succeeds for a user who cannot edit another post that shares
+	 * only the object (different rule), because the rule filter excludes that post's issue
+	 * from the batch entirely.
+	 *
+	 * Before this fix, the batch query matched on object alone, so this same setup would have
+	 * required the limited user to also have edit_post on the admin-owned post and would 403
+	 * without it — even though that post's issue is an unrelated rule violation.
+	 *
+	 * @return void
+	 */
+	public function test_large_batch_dismiss_succeeds_when_unrelated_rule_row_is_on_unauthorized_post() {
+		global $wpdb;
+
+		$this->assertNotNull( $this->server );
+
+		$limited_post = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Scope Narrowing Limited Post',
+				'post_content' => 'Scope Narrowing Limited Content',
+			]
+		);
+
+		$admin_post = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_author'  => self::$admin_id,
+				'post_title'   => 'Scope Narrowing Admin Post',
+				'post_content' => 'Scope Narrowing Admin Content',
+			]
+		);
+
+		$table_name    = $wpdb->prefix . 'accessibility_checker';
+		$site_id       = get_current_blog_id();
+		$shared_object = 'scope-narrowing-test-' . wp_generate_uuid4();
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// Limited user's own issue: the rule being dismissed.
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $limited_post,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'missing_alt_text',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 0,
+				'ignre_global' => 0,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$issue_id = $wpdb->insert_id;
+
+		// Admin-owned post's issue: same object, DIFFERENT rule. Limited user cannot edit this post.
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $admin_post,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'color_contrast_failure',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$admin_id,
+				'ignre'        => 0,
+				'ignre_global' => 0,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		wp_set_current_user( self::$limited_id );
+
+		$request = new \WP_REST_Request( 'POST', '/accessibility-checker/v1/dismiss-issue/' . $issue_id );
+		$request->set_param( 'action', 'dismiss' );
+		$request->set_param( 'largeBatch', true );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			'Large batch dismiss should succeed even though an unrelated-rule issue on an unauthorized post shares the object.'
 		);
 	}
 

--- a/tests/phpunit/includes/classes/RestApiEndpointsTest.php
+++ b/tests/phpunit/includes/classes/RestApiEndpointsTest.php
@@ -749,6 +749,143 @@ class RestApiEndpointsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test: Large batch dismiss only affects rows sharing the same rule, not just the same object.
+	 *
+	 * Regression test for PRO-1264: a global/large-batch dismiss on an issue must only touch
+	 * other rows with the same `rule` AND `object`. Rows that share only the `object` (a
+	 * different rule against the same DOM node) must be left untouched.
+	 *
+	 * @return void
+	 */
+	public function test_large_batch_dismiss_only_affects_matching_rule() {
+		global $wpdb;
+
+		$this->assertNotNull( $this->server );
+
+		$post_1 = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Rule Scoping Post 1',
+				'post_content' => 'Rule Scoping Content 1',
+			]
+		);
+
+		$post_2 = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Rule Scoping Post 2',
+				'post_content' => 'Rule Scoping Content 2',
+			]
+		);
+
+		$post_3 = self::factory()->post->create(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_author'  => self::$limited_id,
+				'post_title'   => 'Rule Scoping Post 3',
+				'post_content' => 'Rule Scoping Content 3',
+			]
+		);
+
+		$table_name    = $wpdb->prefix . 'accessibility_checker';
+		$site_id       = get_current_blog_id();
+		$shared_object = 'rule-scoping-test-' . wp_generate_uuid4();
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// Post 1 and Post 2 share the same rule AND object — these should both be dismissed together.
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $post_1,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'missing_alt_text',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 0,
+				'ignre_global' => 0,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$matching_issue_id_1 = $wpdb->insert_id;
+
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $post_2,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'missing_alt_text',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 0,
+				'ignre_global' => 0,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$matching_issue_id_2 = $wpdb->insert_id;
+
+		// Post 3 shares the same object but has a DIFFERENT rule — must NOT be dismissed.
+		$wpdb->insert(
+			$table_name,
+			[
+				'postid'       => $post_3,
+				'siteid'       => $site_id,
+				'type'         => 'error',
+				'rule'         => 'color_contrast_failure',
+				'ruletype'     => 'error',
+				'object'       => $shared_object,
+				'recordcheck'  => 1,
+				'user'         => self::$limited_id,
+				'ignre'        => 0,
+				'ignre_global' => 0,
+			],
+			[ '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d' ]
+		);
+		$unrelated_rule_issue_id = $wpdb->insert_id;
+
+		// Set limited user (who owns all three posts).
+		wp_set_current_user( self::$limited_id );
+
+		// Dismiss globally, starting from one of the matching-rule issues.
+		$request = new \WP_REST_Request( 'POST', '/accessibility-checker/v1/dismiss-issue/' . $matching_issue_id_1 );
+		$request->set_param( 'action', 'dismiss' );
+		$request->set_param( 'reason', 'Rule scoping test' );
+		$request->set_param( 'largeBatch', true );
+		$request->set_param( 'ignore_global', 1 );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Large batch dismiss should succeed for the authorized user.' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Need fresh data for assertions.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT id, ignre FROM %i WHERE object = %s ORDER BY id', $table_name, $shared_object ),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$rows_by_id = array_column( $rows, 'ignre', 'id' );
+
+		$this->assertSame( '1', $rows_by_id[ $matching_issue_id_1 ], 'The dismissed issue itself should be marked ignored.' );
+		$this->assertSame( '1', $rows_by_id[ $matching_issue_id_2 ], 'The other row sharing rule+object should also be dismissed.' );
+		$this->assertSame(
+			'0',
+			$rows_by_id[ $unrelated_rule_issue_id ],
+			'A row sharing only the object (different rule) must NOT be dismissed by a global/large-batch action.'
+		);
+	}
+
+	/**
 	 * Test: Large batch dismissed by user with partial authorization fails before bulk query.
 	 *
 	 * Verifies that when a user can edit only SOME posts in a large batch,


### PR DESCRIPTION
## Summary
- Fixes PRO-1264: a large-batch/global dismiss on one rule violation was also silently dismissing *unrelated* rule violations that happened to share the same `object`.
- Root cause: `dismiss_issue()`'s largeBatch path in `class-rest-api.php` selected and updated every row matching `siteid` + `object` only. The pro plugin's parallel fix (PR #832 on the paired PRO-1239 branch) scoped its own query by `rule` + `object`, but never touched this one — the actual query that flips `ignre`/`ignre_global` on live rows.
- Fetches the representative issue's `rule` alongside `object` and filters the batch-selection query by both, mirroring the pro plugin's already-correct scoping.

## Test plan
- [x] Added `test_large_batch_dismiss_only_affects_matching_rule` — seeds two posts sharing rule+object and a third sharing only the object; confirms the third is left untouched after a global dismiss. Confirmed failing against the pre-fix query, passing after.
- [x] Updated two pre-existing largeBatch tests (`test_large_batch_dismiss_authorized_on_all`, `test_large_batch_dismiss_authorized_on_some`) whose fixtures used different rules per row within one "batch" — that setup encoded the same assumption behind the bug and needed to share a rule to still be considered one batch under the corrected query.
- [x] Full `RestApiEndpointsTest` suite passes (13/13).
- [x] Full PHPUnit suite passes (875 tests) via `docker compose` + `scripts/setup-phpunit.sh` flow.

Linear: PRO-1264 (related to PRO-1239)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed large-batch issue dismissal and reopening so only issues matching both the selected rule and object are updated.
  * Prevented unrelated issues sharing the same object from being changed accidentally.
  * Improved batch operation handling when unrelated issues involve posts the user cannot edit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->