### PR TITLE
Retain ambiguous anchor text flags even if "Add Label To Links That Open A New Tab/Window" used

### DIFF
--- a/src/pageScanner/checks/has-ambiguous-text.js
+++ b/src/pageScanner/checks/has-ambiguous-text.js
@@ -34,12 +34,6 @@ const checkAmbiguousPhrase = ( text ) => {
 export default {
 	id: 'has_ambiguous_text',
 	evaluate: ( node ) => {
-		if ( node.hasAttribute( 'aria-labelledby' ) ) {
-			const label = node.getAttribute( 'aria-labelledby' );
-			const labelText = document.getElementById( label )?.textContent;
-			return checkAmbiguousPhrase( labelText );
-		}
-
 		if ( node.textContent && node.textContent !== '' ) {
 			return checkAmbiguousPhrase( node.textContent );
 		}

--- a/src/pageScanner/checks/has-ambiguous-text.js
+++ b/src/pageScanner/checks/has-ambiguous-text.js
@@ -34,11 +34,6 @@ const checkAmbiguousPhrase = ( text ) => {
 export default {
 	id: 'has_ambiguous_text',
 	evaluate: ( node ) => {
-		if ( node.hasAttribute( 'aria-label' ) ) {
-			const ariaLabel = node.getAttribute( 'aria-label' );
-			return checkAmbiguousPhrase( ariaLabel );
-		}
-
 		if ( node.hasAttribute( 'aria-labelledby' ) ) {
 			const label = node.getAttribute( 'aria-labelledby' );
 			const labelText = document.getElementById( label )?.textContent;

--- a/tests/jest/rules/linkAmbiguousText.test.js
+++ b/tests/jest/rules/linkAmbiguousText.test.js
@@ -33,16 +33,6 @@ describe( 'Link Ambiguous Text Rule', () => {
 			shouldPass: true,
 		},
 		{
-			name: 'should pass for descriptive aria-label on ambiguous link text',
-			html: '<a href="/team" aria-label="Learn about our team">Read more</a>',
-			shouldPass: true,
-		},
-		{
-			name: 'should pass for descriptive aria-labelledby',
-			html: '<span id="link-label">Visit our accessibility resources</span><a href="/resources" aria-labelledby="link-label">here</a>',
-			shouldPass: true,
-		},
-		{
 			name: 'should pass for an image link with descriptive alt text',
 			html: '<a href="/home"><img src="logo.png" alt="Return to homepage" /></a>',
 			shouldPass: true,
@@ -97,16 +87,6 @@ describe( 'Link Ambiguous Text Rule', () => {
 		{
 			name: 'should fail for "details"',
 			html: '<a href="/item">details</a>',
-			shouldPass: false,
-		},
-		{
-			name: 'should fail for ambiguous aria-label',
-			html: '<a href="/page" aria-label="here">Visit our page</a>',
-			shouldPass: false,
-		},
-		{
-			name: 'should fail for ambiguous aria-labelledby',
-			html: '<span id="lbl">click here</span><a href="/page" aria-labelledby="lbl">Visit page</a>',
 			shouldPass: false,
 		},
 		{


### PR DESCRIPTION
This PR handles the issue around [#1863 Ambiguous Text no longer being flagged despite not being fixed ](https://github.com/equalizedigital/accessibility-checker/issues/1863)

Changes include removal of truthy results for `aria-label` and `aria-labelledby` attribute checks, as well as removal of the Jest checks for those items. This enabled the checking of specifically the anchor link text or image alt text exclusively, for the passing state of Ambiguous text checks.

## Validation

Because we're now expecting to only check in the actual anchor text or image alt text, the tests for `aria-label` and `aria-labelledby` can be considered redundant.

Results from `npm run test:jest`:

Test Suites: 52 passed, 52 total
Tests:       944 passed, 944 total

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ambiguous link-text detection by evaluating visible text and image alternative text.
  * Prevented accessible labels from being incorrectly flagged as ambiguous link text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->