### PR TITLE
Provide feedback to screen reader users when dismissing or undismissing reported issues in old metabox

### DIFF
--- a/admin/class-ignore-ui.php
+++ b/admin/class-ignore-ui.php
@@ -171,7 +171,7 @@ class IgnoreUI {
 			}
 		} elseif ( true === $ignore_permission ) {
 				$html .= '<button class="edac-details-rule-records-record-ignore-submit button button-primary" data-id="' . $issue_id . '" data-action="' . esc_attr( $ignore_action ) . '" data-type="' . esc_attr( $ignore_type ) . '">' . $ignore_icon . ' <span class="edac-details-rule-records-record-ignore-submit-label">' . esc_html( $ignore_submit_label ) . '</span></button>';
-				$html .= '<p class="screen-reader-texts" role="status" aria-live="assertive" id="success-message-' . esc_attr( $issue_id ) . '"></p>';
+				$html .= '<p class="screen-reader-text" role="status" aria-live="assertive" id="success-message-' . esc_attr( $issue_id ) . '"></p>';
 		}
 
 		// No permission message.

--- a/admin/class-ignore-ui.php
+++ b/admin/class-ignore-ui.php
@@ -171,6 +171,7 @@ class IgnoreUI {
 			}
 		} elseif ( true === $ignore_permission ) {
 				$html .= '<button class="edac-details-rule-records-record-ignore-submit button button-primary" data-id="' . $issue_id . '" data-action="' . esc_attr( $ignore_action ) . '" data-type="' . esc_attr( $ignore_type ) . '">' . $ignore_icon . ' <span class="edac-details-rule-records-record-ignore-submit-label">' . esc_html( $ignore_submit_label ) . '</span></button>';
+				$html .= '<p class="screen-reader-texts" role="status" aria-live="assertive" id="success-message-' . esc_attr( $issue_id ) . '"></p>';
 		}
 
 		// No permission message.

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -503,7 +503,7 @@ const edacScriptVars = edac_script_vars;
 					} ).fail( function( data ) {
 						// eslint-disable-next-line no-console
 						console.log( data );
-						document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? __( 'Failed to dismiss issue' ) : __( 'Failed to undismiss issue' );
+						document.querySelector( '#success-message-' + issueId ).textContent = data.restAction === 'dismiss' ? __( 'Failed to dismiss issue' ) : __( 'Failed to undismiss issue' );
 					} );
 				}
 			);

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -9,6 +9,7 @@ import {
 import { initFixesInputStateHandler } from './fixes-page/conditional-disable-settings';
 import { initRequiredSetup } from './fixes-page/conditional-required-settings';
 import { inlineSettingsProUpsell } from '../common/settings-pro-callout';
+import { __ } from '@wordpress/i18n';
 
 // eslint-disable-next-line camelcase
 const edacScriptVars = edac_script_vars;
@@ -367,7 +368,7 @@ const edacScriptVars = edac_script_vars;
 								? '<strong>Date:</strong> ' + data.ignre_date
 								: '';
 
-							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? 'Successfully dismissed issue' : 'Successfully undismissed issue';
+							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? __( 'Successfully dismissed issue', 'accessibility-checker' ) : __( 'Successfully undismissed issue', 'accessibility-checker' );
 							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-submit'
@@ -497,7 +498,7 @@ const edacScriptVars = edac_script_vars;
 						} else {
 							// eslint-disable-next-line no-console
 							console.log( data );
-							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? 'Failed to dismiss issue' : 'Failed to undismiss issue';
+							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? __( 'Failed to dismiss issue' ) : __( 'Failed to undismiss issue' );
 						}
 					} );
 				}

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -367,10 +367,7 @@ const edacScriptVars = edac_script_vars;
 								? '<strong>Date:</strong> ' + data.ignre_date
 								: '';
 
-							jQuery(
-								'#success-message-' +
-								issueId
-							).html( 'Successfully dismissed issue.' );
+							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? 'Successfully dismissed issue' : 'Successfully undismissed issue';
 							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-submit'
@@ -500,10 +497,7 @@ const edacScriptVars = edac_script_vars;
 						} else {
 							// eslint-disable-next-line no-console
 							console.log( data );
-							jQuery(
-								'#success-message-' +
-								issueId
-							).html( 'Failed to dismiss issue.' );
+							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? 'Failed to dismiss issue' : 'Failed to undismiss issue';
 						}
 					} );
 				}

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -503,7 +503,7 @@ const edacScriptVars = edac_script_vars;
 					} ).fail( function( data ) {
 						// eslint-disable-next-line no-console
 						console.log( data );
-						document.querySelector( '#success-message-' + issueId ).textContent = data.restAction === 'dismiss' ? __( 'Failed to dismiss issue' ) : __( 'Failed to undismiss issue' );
+						document.querySelector( '#success-message-' + issueId ).textContent = data.responseJSON.message;
 					} );
 				}
 			);

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -368,6 +368,10 @@ const edacScriptVars = edac_script_vars;
 								: '';
 
 							jQuery(
+								'#success-message-' +
+								issueId
+							).html( 'Successfully dismissed issue.' );
+							jQuery(
 								record +
 									' .edac-details-rule-records-record-ignore-submit'
 							).attr( 'data-action', doneIgnoreAction );
@@ -496,6 +500,10 @@ const edacScriptVars = edac_script_vars;
 						} else {
 							// eslint-disable-next-line no-console
 							console.log( data );
+							jQuery(
+								'#success-message-' +
+								issueId
+							).html( 'Failed to dismiss issue.' );
 						}
 					} );
 				}

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -500,6 +500,10 @@ const edacScriptVars = edac_script_vars;
 							console.log( data );
 							document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? __( 'Failed to dismiss issue' ) : __( 'Failed to undismiss issue' );
 						}
+					} ).fail( function( data ) {
+						// eslint-disable-next-line no-console
+						console.log( data );
+						document.querySelector( '#success-message-' + issueId ).textContent = data.action === 'dismiss' ? __( 'Failed to dismiss issue' ) : __( 'Failed to undismiss issue' );
 					} );
 				}
 			);


### PR DESCRIPTION
This PR handles the issue around [#1770 Success/failure to dismiss issues not being announced](https://github.com/equalizedigital/accessibility-checker/issues/1770)

Changes include adding a new screen-reader only aria-live DOM element with assertive announcing. Each issue in a given report will have its own element that gets updated with a success or fail message, and dismissing/undismissing an issue will only update that associated message element.

As per coderabbit, I have also added in a `.fail()` callback to help harden up AJAX requests.

## Validation
None added, none broken

Results from `npm run test:jest`:
Test Suites: 52 passed, 52 total
Tests:       948 passed, 948 total

## Checklist

- [x] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Accessibility
* Added screen-reader announcements for successful dismiss and reopen actions.

## Bug Fixes
* Improved feedback for dismiss and reopen operations with translated success messages.
* Added clearer, action-specific failure messages and server error notifications when requests cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->