### PR TITLE
Fix: allow anchors with role none, presentation or slider

### DIFF
--- a/includes/classes/Rules/Rule/LinkImproperRule.php
+++ b/includes/classes/Rules/Rule/LinkImproperRule.php
@@ -41,10 +41,12 @@ class LinkImproperRule implements RuleInterface {
 			),
 			'why_it_matters'        => esc_html__( 'Anchor tags (a.k.a. links) are intended for navigation to a new page or a different place on the same page. When they are used to trigger actions (such as expanding accordions or opening modals) without the correct roles or behavior, they confuse users, particularly those using screen readers or keyboards, who expect links to navigate rather than perform actions. They also are likely not to function with the space bar, which is an expectation of a button.', 'accessibility-checker' ),
 			'how_to_fix'            => sprintf(
-			// translators: %1$s is <code>&lt;button&gt;</code>, %2$s is <code>role="button"</code>.
-				esc_html__( 'If the element is used to trigger an action, replace the anchor tag with a %1$s. If you cannot replace it, ensure that %2$s is added to the link, along with JavaScript that adds support for triggering it with the space bar key, and that appropriate ARIA attributes are used for toggle states or other functionality.', 'accessibility-checker' ),
+			// translators: %1$s is <code>&lt;button&gt;</code>, %2$s is <code>role="button"</code>, %3$s is <code>role="none"</code>, %4$s is <code>role="presentation"</code>.
+				esc_html__( 'If the element is used to trigger an action, replace the anchor tag with a %1$s. If you cannot replace it, ensure that %2$s is added to the link, along with JavaScript that adds support for triggering it with the space bar key, and that appropriate ARIA attributes are used for toggle states or other functionality. If the anchor is purely decorative and cannot be focused, %3$s or %4$s marks it as presentational so it is not reported.', 'accessibility-checker' ),
 				'<code>&lt;button&gt;</code>',
-				'<code>role="button"</code>'
+				'<code>role="button"</code>',
+				'<code>role="none"</code>',
+				'<code>role="presentation"</code>'
 			),
 			'references'            => [
 				[

--- a/src/pageScanner/checks/link-has-valid-href-or-role.js
+++ b/src/pageScanner/checks/link-has-valid-href-or-role.js
@@ -16,18 +16,51 @@ export default {
 		const role = node.getAttribute( 'role' ) || '';
 
 		// Parse roles once for efficiency (DRY principle)
-		const roles = role.toLowerCase().split( /\s+/ );
+		const roleTokens = role.toLowerCase().split( /\s+/ );
 
-		// Allow roles of button or tab
-		if ( roles.some( ( r ) => [ 'button', 'tab' ].includes( r ) ) ) {
+		const tabindex = node.getAttribute( 'tabindex' );
+		const parsedTabindex = null === tabindex ? null : Number.parseInt( tabindex, 10 );
+		// A tabindex whose value is not a valid integer is ignored per the HTML spec, so it
+		// confers no focusability at all.
+		const hasValidTabindex = null !== tabindex && ! Number.isNaN( parsedTabindex );
+		const isKeyboardFocusable = hasValidTabindex && parsedTabindex >= 0;
+
+		// Reachable with the Tab key: an href (including href="") or a non-negative tabindex.
+		const isKeyboardOperable = node.hasAttribute( 'href' ) || isKeyboardFocusable;
+
+		// Focusable at all. Unlike the above this includes tabindex="-1", which is focusable
+		// programmatically and by click even though it is outside the tab order.
+		const isFocusable = node.hasAttribute( 'href' ) || hasValidTabindex;
+
+		// Allow roles of button, tab or slider. None of these is exposed as a link, so the
+		// anchor is not being used improperly regardless of how it is focused. Whether a
+		// non-focusable widget role is itself a defect is a separate question from this rule.
+		if ( roleTokens.some( ( r ) => [ 'button', 'tab', 'slider' ].includes( r ) ) ) {
 			return true;
 		}
 
 		// Allow role="menuitem" with aria-expanded (for expandable menu items)
 		// See: https://wordpress.org/support/topic/improper-use-of-link-5/
 		const hasAriaExpanded = node.hasAttribute( 'aria-expanded' );
-		if ( roles.includes( 'menuitem' ) && hasAriaExpanded ) {
+		if ( roleTokens.includes( 'menuitem' ) && hasAriaExpanded ) {
 			return true;
+		}
+
+		// Allow role="none"/"presentation", which removes the element from the accessibility
+		// tree so it is never exposed as a link. Unlike the named-anchor exemption below,
+		// content is permitted here: the role applies regardless of what the anchor wraps.
+		// Per the presentational roles conflict resolution the role is ignored on an element
+		// that is focusable or carries global ARIA states/properties, so neither may apply.
+		if ( ! isFocusable && ( roleTokens.includes( 'none' ) || roleTokens.includes( 'presentation' ) ) ) {
+			// Approximated as any aria-* attribute, which errs toward reporting. aria-hidden is
+			// excluded because it removes the element from the tree outright, making the role moot.
+			const hasGlobalAria = Array.from( node.attributes ).some(
+				( attr ) => attr.name.startsWith( 'aria-' ) && attr.name !== 'aria-hidden'
+			);
+
+			if ( ! hasGlobalAria ) {
+				return true;
+			}
 		}
 
 		// Allow named anchors used as jump targets: no href, has id/name, no visible content,
@@ -40,12 +73,7 @@ export default {
 		const name = node.getAttribute( 'name' ) || '';
 		const hasAnchorTargetName = id.trim() !== '' || name.trim() !== '';
 
-		const tabindex = node.getAttribute( 'tabindex' );
-		const parsedTabindex = null === tabindex ? null : Number.parseInt( tabindex, 10 );
-		const isKeyboardFocusable =
-			null !== tabindex && ( Number.isNaN( parsedTabindex ) || parsedTabindex >= 0 );
-
-		if ( ! node.hasAttribute( 'href' ) && hasAnchorTargetName && ! isKeyboardFocusable && node.children.length === 0 && node.textContent.trim() === '' ) {
+		if ( ! isKeyboardOperable && hasAnchorTargetName && node.children.length === 0 && node.textContent.trim() === '' ) {
 			return true;
 		}
 

--- a/src/pageScanner/rules/link-improper.js
+++ b/src/pageScanner/rules/link-improper.js
@@ -13,7 +13,7 @@ export default {
 	],
 	metadata: {
 		description: 'Links must have a meaningful href or an appropriate role if used as buttons.',
-		help: 'Avoid using <a> tags without href or with href="#" unless role="button" is used.',
+		help: 'Avoid using <a> tags without href or with href="#" unless a widget role such as role="button" is used, or the anchor is non-focusable and marked role="none".',
 		impact: 'serious',
 	},
 	all: [],

--- a/tests/jest/rules/linkImproper.test.js
+++ b/tests/jest/rules/linkImproper.test.js
@@ -202,6 +202,81 @@ describe( 'Link Improper Rule', () => {
 			html: '<a id="meet-the-team" tabindex="-1"></a>',
 			shouldPass: true,
 		},
+
+		// Presentational role cases. See https://github.com/equalizedigital/accessibility-checker/issues/1748
+		{
+			name: 'Passes with role="none" on a non-focusable dropdown wrapper',
+			html: '<a role="none"><span class="nav-drop-title-wrap">eBranch<span class="dropdown-nav-toggle"><span class="kadence-svg-iconset svg-baseline"><svg aria-hidden="true" class="kadence-svg-icon" fill="currentColor" version="1.1" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>Expand</title><path d="M5.293 9.707l6 6c0.391 0.391 1.024 0.391 1.414 0l6-6z"></path> </svg></span></span></span></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes with role="presentation" and no href',
+			html: '<a role="presentation"><span>Menu</span></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes with multiple roles including none and no href',
+			html: '<a role="foo none bar"><span>Menu</span></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Fails with role="none" when focusable via href="#"',
+			html: '<a href="#" role="none">Click</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Fails with role="none" when focusable via tabindex',
+			html: '<a role="none" tabindex="0">Click</a>',
+			shouldPass: false,
+		},
+		{
+			// tabindex="-1" is focusable programmatically and by click, so the presentational
+			// role is ignored per the conflict resolution.
+			name: 'Fails with role="none" and tabindex of -1',
+			html: '<a role="none" tabindex="-1">Click</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Fails with role="none" and a global aria attribute',
+			html: '<a role="none" aria-label="Open menu"><span>Menu</span></a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Passes with role="none" and aria-hidden="true"',
+			html: '<a role="none" aria-hidden="true"><span>Menu</span></a>',
+			shouldPass: true,
+		},
+
+		// Slider role cases. See https://github.com/equalizedigital/accessibility-checker/issues/1748
+		{
+			name: 'Passes with role="slider" on a media player volume control',
+			html: '<a class="mejs-horizontal-volume-slider" href="javascript:void(0);" aria-label="Volume Slider" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" role="slider"><span class="mejs-offscreen">Use Up/Down Arrow keys to increase or decrease volume.</span><div class="mejs-horizontal-volume-total"><div class="mejs-horizontal-volume-current"></div><div class="mejs-horizontal-volume-handle"></div></div></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes with role="slider" and href="#"',
+			html: '<a href="#" role="slider" aria-valuenow="50">Volume</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes with role="slider" and no href',
+			html: '<a role="slider" tabindex="0" aria-valuenow="50">Volume</a>',
+			shouldPass: true,
+		},
+		{
+			// An inactive tab in a roving tabindex tablist is correct markup, so the widget
+			// role exemption must not depend on the anchor being in the tab order.
+			name: 'Passes with role="tab" and tabindex of -1',
+			html: '<a role="tab" tabindex="-1" id="tab-2" aria-controls="panel-2">Tab 2</a>',
+			shouldPass: true,
+		},
+		{
+			// An unparseable tabindex is ignored per the HTML spec, so the anchor is not
+			// focusable and remains a valid jump target.
+			name: 'Passes for a named anchor with an invalid tabindex',
+			html: '<a id="meet-the-team" tabindex=""></a>',
+			shouldPass: true,
+		},
 	] )( '$name', async ( { html, shouldPass, setup } ) => {
 		document.body.innerHTML = html;
 


### PR DESCRIPTION
Fixes #1748.

`link_improper` was flagging two anchors that are not exposed as links:

- `<a role="none">` / `<a role="presentation">` — removed from the accessibility tree entirely.
- `<a role="slider">` — exposed as a slider. Not ideal markup, as the issue notes, but common in older media players and technically correct.

`slider` joins the existing `button` / `tab` allowlist, which stays unconditional: none of those roles is exposed as a link, so the anchor is not being used improperly however it happens to be focused.

The presentational roles get a narrower exemption, following the [presentational roles conflict resolution](https://www.w3.org/TR/wai-aria-1.2/#conflict_resolution_presentation_none). The role is ignored — and the element therefore still exposed as a link — when the anchor is either:

- **Focusable.** Includes `tabindex="-1"`, which is reachable by click and programmatic focus even though it sits outside the tab order. So `<a href="#" role="none">` continues to fail.
- **Carrying a global ARIA state or property.** Approximated as any `aria-*` attribute, which errs toward reporting. `aria-hidden` is excluded, since it removes the element from the tree outright and makes the role moot — matching how `linked-image-alt-present` already handles it.

Also fixes an unrelated false positive found while working in this check: a `tabindex` that is not a valid integer is now ignored per the HTML spec rather than treated as focusable, so an empty named anchor like `<a id="top" tabindex="">` no longer reports.

### Compatibility

Every behavior change here is a relaxation. Nothing that passed on `develop` fails after this change, so it should not surface new issues on existing scans — only remove false positives.

Worth calling out one case I deliberately left alone: `<a role="button">` with no `href` and no `tabindex` still passes, as it does today. Reporting it is defensible, but it is a separate rule change from this issue and would need to account for `tabindex="-1"` being legitimate in composite widgets (an inactive tab in a roving-tabindex tablist, for instance). Happy to open a follow-up issue if that is wanted.

### Testing

15 cases added to `tests/jest/rules/linkImproper.test.js`, including both markup samples from the issue verbatim, the focusability and global-ARIA boundaries in both directions, and a roving-tabindex `role="tab"` case pinning the unconditional allowlist. Full file passes at 47/47; `phpcs` and `wp-scripts lint-js` are clean on the changed files.

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes
