### PR TITLE
Fix: label grouped settings fields with a legend

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -153,13 +153,14 @@ function edac_register_setting() {
 	);
 
 	// Add fields.
+
+	// No label_for: this field is a group of checkboxes labelled by the <legend> in its callback.
 	add_settings_field(
 		'edac_post_types',
 		__( 'Post Types To Be Checked', 'accessibility-checker' ),
 		'edac_post_types_cb',
 		'edac_settings',
-		'edac_general',
-		[ 'label_for' => 'edac_post_types' ]
+		'edac_general'
 	);
 
 	add_settings_field(
@@ -189,13 +190,13 @@ function edac_register_setting() {
 		[ 'label_for' => 'edacp_scan_all_taxonomy_terms' ]
 	);
 
+	// No label_for: this field is a group of checkboxes labelled by the <legend> in its callback.
 	add_settings_field(
 		'edacp_ignore_user_roles',
 		__( 'Dismiss Permissions', 'accessibility-checker' ),
 		'edac_ignore_user_roles_cb',
 		'edac_settings',
-		'edac_permissions',
-		[ 'label_for' => 'edac_ignore_user_roles' ]
+		'edac_permissions'
 	);
 
 	add_settings_field(
@@ -216,22 +217,22 @@ function edac_register_setting() {
 		[ 'label_for' => 'edac_show_metabox_in_block_editor' ]
 	);
 
+	// No label_for: this field is a group of radios labelled by the <legend> in its callback.
 	add_settings_field(
 		'edac_simplified_summary_prompt',
 		__( 'Prompt for Simplified Summary', 'accessibility-checker' ),
 		'edac_simplified_summary_prompt_cb',
 		'edac_settings',
-		'edac_simplified_summary',
-		[ 'label_for' => 'edac_simplified_summary_prompt' ]
+		'edac_simplified_summary'
 	);
 
+	// No label_for: this field is a group of radios labelled by the <legend> in its callback.
 	add_settings_field(
 		'edac_simplified_summary_position',
 		__( 'Simplified Summary Position', 'accessibility-checker' ),
 		'edac_simplified_summary_position_cb',
 		'edac_settings',
-		'edac_simplified_summary',
-		[ 'label_for' => 'edac_simplified_summary_position' ]
+		'edac_simplified_summary'
 	);
 
 	add_settings_field(
@@ -278,13 +279,13 @@ function edac_register_setting() {
 		'edac_footer_accessibility_statement'
 	);
 
+	// No label_for: this field is a group of radios labelled by the <legend> in its callback.
 	add_settings_field(
 		'edac_frontend_highlighter_position',
 		__( 'Frontend Accessibility Checker Position', 'accessibility-checker' ),
 		'edac_frontend_highlighter_position_cb',
 		'edac_settings',
-		'edac_frontend_highlighter',
-		[ 'label_for' => 'edac_frontend_highlighter_position' ]
+		'edac_frontend_highlighter'
 	);
 
 	// Register settings.
@@ -521,8 +522,11 @@ function edac_simplified_summary_position_cb() {
 	$position = get_option( 'edac_simplified_summary_position' );
 	?>
 		<fieldset>
+			<legend class="screen-reader-text">
+				<span><?php esc_html_e( 'Simplified Summary Position', 'accessibility-checker' ); ?></span>
+			</legend>
 			<label>
-				<input type="radio" name="<?php echo 'edac_simplified_summary_position'; ?>" id="<?php echo 'edac_simplified_summary_position'; ?>" value="before" <?php checked( $position, 'before' ); ?>>
+				<input type="radio" name="<?php echo 'edac_simplified_summary_position'; ?>" value="before" <?php checked( $position, 'before' ); ?>>
 				<?php esc_html_e( 'Before the content', 'accessibility-checker' ); ?>
 			</label>
 			<br>
@@ -555,8 +559,11 @@ function edac_frontend_highlighter_position_cb() {
 	$position = get_option( 'edac_frontend_highlighter_position', 'right' );
 	?>
 		<fieldset>
+			<legend class="screen-reader-text">
+				<span><?php esc_html_e( 'Frontend Accessibility Checker Position', 'accessibility-checker' ); ?></span>
+			</legend>
 			<label>
-				<input type="radio" name="edac_frontend_highlighter_position" id="edac_frontend_highlighter_position" value="right" <?php checked( $position, 'right' ); ?>>
+				<input type="radio" name="edac_frontend_highlighter_position" value="right" <?php checked( $position, 'right' ); ?>>
 				<?php esc_html_e( 'Bottom Right Corner (default)', 'accessibility-checker' ); ?>
 			</label>
 			<br>
@@ -604,8 +611,11 @@ function edac_simplified_summary_prompt_cb() {
 	$prompt = get_option( 'edac_simplified_summary_prompt' );
 	?>
 		<fieldset>
+			<legend class="screen-reader-text">
+				<span><?php esc_html_e( 'Prompt for Simplified Summary', 'accessibility-checker' ); ?></span>
+			</legend>
 			<label>
-				<input type="radio" name="<?php echo 'edac_simplified_summary_prompt'; ?>" id="<?php echo 'edac_simplified_summary_prompt'; ?>" value="when required" <?php checked( $prompt, 'when required' ); ?>>
+				<input type="radio" name="<?php echo 'edac_simplified_summary_prompt'; ?>" value="when required" <?php checked( $prompt, 'when required' ); ?>>
 				<?php esc_html_e( 'When Required', 'accessibility-checker' ); ?>
 			</label>
 			<br>
@@ -647,14 +657,15 @@ function edac_post_types_cb() {
 	$all_post_types      = ( is_array( $post_types ) && is_array( $custom_post_types ) ) ? array_merge( $post_types, $custom_post_types ) : [];
 	?>
 		<fieldset>
+			<legend class="screen-reader-text">
+				<span><?php esc_html_e( 'Post Types To Be Checked', 'accessibility-checker' ); ?></span>
+			</legend>
 			<?php
 			if ( $all_post_types ) {
-				$position = 0;
 				foreach ( $all_post_types as $post_type ) {
 					$disabled        = in_array( $post_type, $post_types, true ) ? '' : 'disabled';
 					$post_type_label = edac_get_post_type_label( $post_type );
-					$field_id        = ( 0 === $position ) ? 'edac_post_types' : "edac_post_types_{$post_type}";
-					++$position;
+					$field_id        = "edac_post_types_{$post_type}";
 					?>
 					<label>
 						<input type="checkbox" name="<?php echo 'edac_post_types[]'; ?>" id="<?php echo esc_attr( $field_id ); ?>" value="<?php echo esc_attr( $post_type ); ?>"
@@ -979,10 +990,12 @@ function edac_ignore_user_roles_cb() {
 
 	?>
 	<fieldset <?php echo edac_is_pro() ? '' : 'class="edac-setting--upsell"'; ?>>
+		<legend class="screen-reader-text">
+			<span><?php esc_html_e( 'Dismiss Permissions', 'accessibility-checker' ); ?></span>
+		</legend>
 		<?php if ( $roles ) : ?>
-			<?php $index = 0; ?>
 			<?php foreach ( $roles as $key => $role ) : ?>
-				<?php $field_id = ( 0 === $index ) ? 'edac_ignore_user_roles' : "edac_ignore_user_roles_{$index}"; ?>
+				<?php $field_id = "edac_ignore_user_roles_{$key}"; ?>
 				<label>
 					<input
 						type="checkbox"
@@ -995,7 +1008,6 @@ function edac_ignore_user_roles_cb() {
 					<?php echo esc_html( $role['name'] ); ?>
 				</label>
 				<br>
-				<?php ++$index; ?>
 			<?php endforeach; ?>
 		<?php endif; ?>
 	</fieldset>

--- a/tests/phpunit/includes/OptionsPageGroupLabelsTest.php
+++ b/tests/phpunit/includes/OptionsPageGroupLabelsTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests that grouped settings fields are labelled with a <legend>.
+ *
+ * @package Accessibility_Checker
+ */
+
+/**
+ * Grouped checkbox and radio settings must expose their group label as a
+ * <legend> inside the <fieldset> rather than as a <label> pointing at the first
+ * control in the group.
+ *
+ * @see https://github.com/equalizedigital/accessibility-checker/issues/1753
+ */
+class OptionsPageGroupLabelsTest extends WP_UnitTestCase {
+
+	/**
+	 * The settings fields registered before this test class ran.
+	 *
+	 * @var array|null
+	 */
+	private $original_settings_fields;
+
+	/**
+	 * Reset the registered settings fields before each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_settings_fields;
+		$this->original_settings_fields = $wp_settings_fields;
+		$wp_settings_fields             = []; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- resetting a WP registry between tests.
+
+		edac_register_setting();
+	}
+
+	/**
+	 * Restore the settings fields registry so later test classes still see the
+	 * fields registered during bootstrap. WP_UnitTestCase does not back this up.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		global $wp_settings_fields;
+		$wp_settings_fields = $this->original_settings_fields; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring the registry saved in set_up().
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Every grouped field, as [ section, field ].
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function grouped_field_provider(): array {
+		return [
+			'post types'                  => [ 'edac_general', 'edac_post_types' ],
+			'dismiss permissions'         => [ 'edac_permissions', 'edacp_ignore_user_roles' ],
+			'simplified summary prompt'   => [ 'edac_simplified_summary', 'edac_simplified_summary_prompt' ],
+			'simplified summary position' => [ 'edac_simplified_summary', 'edac_simplified_summary_position' ],
+			'highlighter position'        => [ 'edac_frontend_highlighter', 'edac_frontend_highlighter_position' ],
+		];
+	}
+
+	/**
+	 * Every grouped field's render callback, as [ callback, group label ].
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function grouped_field_callback_provider(): array {
+		return [
+			'post types'                  => [ 'edac_post_types_cb', 'Post Types To Be Checked' ],
+			'dismiss permissions'         => [ 'edac_ignore_user_roles_cb', 'Dismiss Permissions' ],
+			'simplified summary prompt'   => [ 'edac_simplified_summary_prompt_cb', 'Prompt for Simplified Summary' ],
+			'simplified summary position' => [ 'edac_simplified_summary_position_cb', 'Simplified Summary Position' ],
+			'highlighter position'        => [ 'edac_frontend_highlighter_position_cb', 'Frontend Accessibility Checker Position' ],
+		];
+	}
+
+	/**
+	 * A grouped field must not use label_for, which would tie the group label to
+	 * the first control in the group only.
+	 *
+	 * @dataProvider grouped_field_provider
+	 *
+	 * @param string $section Section the field is registered in.
+	 * @param string $field   Field id.
+	 *
+	 * @return void
+	 */
+	public function test_grouped_field_has_no_label_for( string $section, string $field ) {
+		global $wp_settings_fields;
+
+		$this->assertArrayHasKey( $field, $wp_settings_fields['edac_settings'][ $section ] );
+		$this->assertArrayNotHasKey( 'label_for', $wp_settings_fields['edac_settings'][ $section ][ $field ]['args'] );
+	}
+
+	/**
+	 * A grouped field is wrapped in a fieldset whose first child is a legend
+	 * carrying the group label.
+	 *
+	 * @dataProvider grouped_field_callback_provider
+	 *
+	 * @param string $callback Render callback for the field.
+	 * @param string $label    Expected group label.
+	 *
+	 * @return void
+	 */
+	public function test_grouped_field_fieldset_is_labelled_by_a_legend( string $callback, string $label ) {
+		ob_start();
+		$callback();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'#<fieldset[^>]*>\s*<legend[^>]*>\s*<span>' . preg_quote( $label, '#' ) . '</span>#',
+			$output,
+			"The {$label} fieldset should open with a legend naming the group."
+		);
+	}
+
+	/**
+	 * Controls within a group must not share an id. Each control carries its own
+	 * wrapping <label>, so a duplicate id would tie two controls to one label and
+	 * leave the markup invalid.
+	 *
+	 * @dataProvider grouped_field_callback_provider
+	 *
+	 * @param string $callback Render callback for the field.
+	 * @param string $label    Expected group label.
+	 *
+	 * @return void
+	 */
+	public function test_grouped_field_control_ids_are_unique( string $callback, string $label ) {
+		ob_start();
+		$callback();
+		$output = ob_get_clean();
+
+		preg_match_all( '#<input[^>]*\sid="([^"]+)"#', $output, $matches );
+		$ids = $matches[1];
+
+		$this->assertCount(
+			count( array_unique( $ids ) ),
+			$ids,
+			"Controls in the {$label} group should not share an id. Rendered ids: " . implode( ', ', $ids )
+		);
+	}
+
+	/**
+	 * Every grouped field's render callback, as [ callback, control name ].
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function grouped_field_name_provider(): array {
+		return [
+			'post types'                  => [ 'edac_post_types_cb', 'edac_post_types[]' ],
+			'dismiss permissions'         => [ 'edac_ignore_user_roles_cb', 'edacp_ignore_user_roles[]' ],
+			'simplified summary prompt'   => [ 'edac_simplified_summary_prompt_cb', 'edac_simplified_summary_prompt' ],
+			'simplified summary position' => [ 'edac_simplified_summary_position_cb', 'edac_simplified_summary_position' ],
+			'highlighter position'        => [ 'edac_frontend_highlighter_position_cb', 'edac_frontend_highlighter_position' ],
+		];
+	}
+
+	/**
+	 * The radio groups carry no id, so the admin JS addresses them by name
+	 * instead: src/admin/index.js reads and watches
+	 * input[type=radio][name=edac_simplified_summary_position] to toggle the
+	 * manual-insertion code block. Renaming a control would break that wiring
+	 * silently, so pin the name every control in each group renders with.
+	 *
+	 * @dataProvider grouped_field_name_provider
+	 *
+	 * @param string $callback Render callback for the field.
+	 * @param string $name     Name attribute every control in the group shares.
+	 *
+	 * @return void
+	 */
+	public function test_grouped_field_controls_are_addressable_by_name( string $callback, string $name ) {
+		ob_start();
+		$callback();
+		$output = ob_get_clean();
+
+		preg_match_all( '#<input[^>]*\sname="([^"]+)"#', $output, $matches );
+
+		$this->assertNotEmpty(
+			$matches[1],
+			"The {$callback} group should render at least one control."
+		);
+		$this->assertSame(
+			[ $name ],
+			array_values( array_unique( $matches[1] ) ),
+			"Every control in the {$callback} group should be addressable as name=\"{$name}\"."
+		);
+	}
+}


### PR DESCRIPTION
Grouped checkbox and radio fields on the settings page passed `label_for` to
`add_settings_field`. WordPress renders that as a `<label>` bound to the *first*
control in the group, so the `<fieldset>` had no accessible name and the
group/options relationship was never exposed programmatically. Fails WCAG 1.3.1
Info and Relationships (Level A).

Fixes #1753

## Scope note

#1753 reports one group ("Post Types To Be Checked"). This fixes that group and
four others on the same page with the identical defect: Dismiss Permissions,
Prompt for Simplified Summary, Simplified Summary Position, and Frontend
Accessibility Checker Position. Same root cause and success criterion, so fixing
one and leaving four seemed worse than widening.

## What changed

- Drop `label_for` from the five grouped fields; titles now render as plain
  `<th>` text.
- Add a `screen-reader-text` `<legend>` to each `<fieldset>`, matching WP core.
  No visual change.
- Remove the ids those `label_for` args targeted, plus the dead first-item id
  special-cases they required. Ids are now keyed on post type / role slug rather
  than loop position.

The Settings API has no first-class way to name a group of controls — `label_for`
only ever targets a single input. Upstream:
https://core.trac.wordpress.org/ticket/39441

The other seven fieldsets in `options-page.php` each wrap a single control and
correctly keep `label_for`. Fieldsets elsewhere already have legends.

The radio groups now carry no id. Nothing consumed those ids —
`src/admin/index.js` selects by `name`. Two tests pin that down: group ids stay
unique, and every control keeps rendering the `name` it's addressed by.

## Testing

New `OptionsPageGroupLabelsTest`: 20 tests / 30 assertions. Full suite green
(897 tests, 1913 assertions, 15 pre-existing skips), `phpcs` clean.

Manually verified in `wp-env`: all five legends present and visually hidden, no
`<th>` still a label, zero duplicate ids page-wide, no layout shift.

## Not covered

- **Not verified with a real screen reader** — markup matches the core pattern,
  but announcement wasn't confirmed by hand.
- The name assertion pins the PHP side only; changing the selector in
  `index.js` would still break the toggle silently.

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen-reader labeling for grouped checkbox and radio settings.
  * Added properly labelled fieldsets and legends to make grouped controls easier to understand and navigate.
* **Bug Fixes**
  * Ensured control IDs are unique and consistently associated with their corresponding post types and roles.
  * Removed redundant identifiers from select radio options.
* **Tests**
  * Added coverage for grouped settings markup, accessibility labels, control IDs, and input names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->