### PR TITLE
chore(security): bump squizlabs/php_codesniffer to 3.13.6 (CVE-2026-67434)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3001,16 +3001,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -3076,7 +3076,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/polyfill-php73",


### PR DESCRIPTION
## Summary
CI's security check started failing on every PR: `squizlabs/php_codesniffer` 3.13.5 has a newly published CVE ([GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq), published 2026-08-06) - a command injection vulnerability in the Gitblame/Hgblame/Svnblame report generators via crafted filenames. Fixed upstream in 3.13.6.

This is a transitive dev-only dependency (pulled in by `automattic/vipwpcs`'s `^3.13.5` constraint, itself satisfied by 3.13.6), never shipped to end users. Least-invasive fix: `composer update squizlabs/php_codesniffer` alone - touches only `composer.lock`, no other packages moved.

## Test plan
- [x] `symfony security:check` now reports zero known vulnerabilities (was 1 before)
- [x] `composer check-cs` still runs cleanly against this codebase (patch release, no behavior change relevant here)

Standalone fix, isolated from other in-flight work, so it can merge and be backmerged into open branches independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)