### PR TITLE
Add RTL support

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,11 @@
 {
 	"extends": "@wordpress/stylelint-config/scss-stylistic",
+	"plugins": [
+		"stylelint-scss",
+		"stylelint-use-logical"
+	],
 	"rules": {
+		"csstools/use-logical": "always",
 		"selector-class-pattern": null,
 		"selector-id-pattern": null,
 		"scss/load-no-partial-leading-underscore": null

--- a/admin/AdminPage/FixesSettingType/Text.php
+++ b/admin/AdminPage/FixesSettingType/Text.php
@@ -28,7 +28,7 @@ trait Text {
 		?>
 		<label
 			for="<?php echo esc_attr( $args['name'] ); ?>"
-			style="display: block; margin-bottom: 6px;"
+			style="display: block; margin-block-end: 6px;"
 			<?php echo ( $upsell ) ? 'class="edac-fix--disabled edac-fix--upsell"' : ''; ?>
 		>
 			<?php if ( isset( $args['location'] ) && $upsell ) : ?>

--- a/admin/class-ignore-ui.php
+++ b/admin/class-ignore-ui.php
@@ -167,7 +167,7 @@ class IgnoreUI {
 		// Submit button or manage link.
 		if ( $ignore_global && function_exists( 'edac_is_pro' ) && edac_is_pro() ) {
 			if ( true === $ignore_permission ) {
-				$html .= '<a href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_ignored&tab=global' ) ) . '" target="_blank" rel="noreferrer noopener" class="edac-details-rule-records-record-ignore-global button button-primary">' . esc_html__( 'Manage Globally Dismissed', 'accessibility-checker' ) . '<span style="margin-left: 0.5rem"><span aria-hidden="true"> ↗</span><span class="screen-reader-text">' . esc_html__( ', opens a new window', 'accessibility-checker' ) . '</span></span></a>';
+				$html .= '<a href="' . esc_url( admin_url( 'admin.php?page=accessibility_checker_ignored&tab=global' ) ) . '" target="_blank" rel="noreferrer noopener" class="edac-details-rule-records-record-ignore-global button button-primary">' . esc_html__( 'Manage Globally Dismissed', 'accessibility-checker' ) . '<span style="margin-inline-start: 0.5rem"><span aria-hidden="true"> ↗</span><span class="screen-reader-text">' . esc_html__( ', opens a new window', 'accessibility-checker' ) . '</span></span></a>';
 			}
 		} elseif ( true === $ignore_permission ) {
 				$html .= '<button class="edac-details-rule-records-record-ignore-submit button button-primary" data-id="' . $issue_id . '" data-action="' . esc_attr( $ignore_action ) . '" data-type="' . esc_attr( $ignore_type ) . '">' . $ignore_icon . ' <span class="edac-details-rule-records-record-ignore-submit-label">' . esc_html( $ignore_submit_label ) . '</span></button>';

--- a/admin/class-welcome-page.php
+++ b/admin/class-welcome-page.php
@@ -63,13 +63,13 @@ class Welcome_Page {
 			<?php if ( defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID ) : ?>
 				<section>
 					<div class="edac-cols edac-cols-header">
-						<div class="edac-cols-left">
+						<div class="edac-cols-start">
 							<h2>
 								<?php esc_html_e( 'Most Recent Test Summary', 'accessibility-checker' ); ?>
 							</h2>
 						</div>
 
-						<p class="edac-cols-right">
+						<p class="edac-cols-end">
 							<?php if ( current_user_can( 'publish_posts' ) ) : ?>
 								<button class="button" id="edac_clear_cached_stats">
 									<?php esc_html_e( 'Update Counts', 'accessibility-checker' ); ?>
@@ -317,11 +317,11 @@ class Welcome_Page {
 
 				<section>
 					<div class="edac-cols edac-cols-header">
-						<h2 class="edac-cols-left">
+						<h2 class="edac-cols-start">
 							<?php esc_html_e( 'Site-Wide Accessibility Reports', 'accessibility-checker' ); ?>
 						</h2>
 
-						<p class="edac-cols-right">
+						<p class="edac-cols-end">
 							<button id="dismiss_welcome_cta" class="button">
 								<?php esc_html_e( 'Hide banner', 'accessibility-checker' ); ?>
 							</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessibility-checker",
-  "version": "1.45.0",
+  "version": "1.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "accessibility-checker",
-      "version": "1.45.0",
+      "version": "1.47.0",
       "hasInstallScript": true,
       "license": "GPL-2.0+",
       "devDependencies": {
@@ -38,6 +38,8 @@
         "patch-package": "^8.0.0",
         "sass": "^1.81.0",
         "sass-loader": "^16.0.3",
+        "stylelint": "^16.26.1",
+        "stylelint-use-logical": "^2.1.3",
         "tabbable": "^6.1.2",
         "unique-selector": "^0.5.0",
         "webpack": "^5.96.1",
@@ -213,7 +215,6 @@
       "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -2109,16 +2110,16 @@
       "dev": true
     },
     "node_modules/@cacheable/memory": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
-      "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.3.3",
-        "@keyv/bigmap": "^1.3.0",
-        "hookified": "^1.14.0",
-        "keyv": "^5.5.5"
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
@@ -2144,20 +2145,19 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
-      "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hashery": "^1.3.0",
-        "keyv": "^5.5.5"
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/utils/node_modules/keyv": {
@@ -2258,30 +2258,12 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
       }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
-      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0"
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -2299,7 +2281,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2625,7 +2606,6 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3809,7 +3789,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3833,7 +3812,6 @@
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3847,7 +3825,6 @@
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -4330,7 +4307,6 @@
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -4358,7 +4334,6 @@
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -4387,7 +4362,6 @@
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5091,9 +5065,9 @@
       }
     },
     "node_modules/@stylistic/stylelint-plugin/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5263,7 +5237,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5530,7 +5503,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
       "integrity": "sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5714,7 +5686,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5788,7 +5759,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5876,25 +5846,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/source-list-map": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
-      "integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/@types/tapable": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
-      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
@@ -5911,63 +5867,6 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
-    },
-    "node_modules/@types/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-Hm/T0kV3ywpJyMGNbsItdivRhYNCQQf1IIsYsXnoVPES4t+FMLyDe0/K+Ea7ahWtMtSNb22ZdY7MIyoD9rqARg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@types/uglify-js/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@types/webpack": {
-      "version": "4.41.38",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
-      "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tapable": "^1",
-        "@types/uglify-js": "*",
-        "@types/webpack-sources": "*",
-        "anymatch": "^3.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@types/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/source-list-map": "*",
-        "source-map": "^0.7.3"
-      }
-    },
-    "node_modules/@types/webpack/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -6077,7 +5976,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
       "integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.13.1",
         "@typescript-eslint/types": "6.13.1",
@@ -6962,7 +6860,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7004,7 +6901,6 @@
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7125,13 +7021,13 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.47.0.tgz",
-      "integrity": "sha512-SPmYu3Ihqfaqve4xEKf8+SAhae9UuYLncFovXHHEHeNrKwldYyNy3fm+3Aifd/RK5r7Vc7nr0zONYkuhWkDlNw==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.52.0.tgz",
+      "integrity": "sha512-94oHBKPty4pp6L5510LWDwJwNqFhikxLfwN6VUcDOQzj3itkc0MQ4ZQhmsfBy3Y6IRxSGx+p2bjSQvA4D+M96A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.47.0"
+        "@wordpress/hooks": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7139,13 +7035,13 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.47.0.tgz",
-      "integrity": "sha512-HD9pdNpS8dJnA70ZSBjx6FBbC4dChNaWWE+OxlvhgKisgETSIZaxvvc+W23WPIfC1WsKfD4amKtfLHXo+38TrQ==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.52.0.tgz",
+      "integrity": "sha512-LUY9nI9h6blk4xBuG83KgyfTnx7PMs/g6ZVzY/SOaCcOc2P3zOfzacADq/vxQydbZpcwtLM6juzgnNta6AX95w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.47.0"
+        "@wordpress/deprecated": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7216,9 +7112,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.47.0.tgz",
-      "integrity": "sha512-3D3dlMxpfc3rTrxASc5osqIR3gp+WgQSn8aqN+1zP8VctM0hm7HdzIix0LwPbyw64DfLiG/jnlRBrtHF6S9UQw==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.52.0.tgz",
+      "integrity": "sha512-sW8X839Xu8aiJlCGF48MM3iYrcXspuiY0By8iTpXKpnUdd2u0SL9HRR0ALSAsOf2ujOeWm/x58ODMSchovRWGw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7295,9 +7191,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
-      "integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.52.0.tgz",
+      "integrity": "sha512-EbV/nJTerhqwNW3DLvvGutJfNyXcmBHXuWyJpv1NypzT80k21jPGP79HBE5Z0A2oAI2kIBp6Klaa4O8uEjq/sw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7317,16 +7213,15 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.20.0.tgz",
-      "integrity": "sha512-CRwh4/kRtetolDHL8qXUuvV4XV4lSbvqQ7TiqBK3t6OTtj+exQME9Jb/vQACaQFKJBGCHTHoEtwMfJ5tfrkggg==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.25.0.tgz",
+      "integrity": "sha512-UcyUT8CJgEkhjzEGTVV6kw0Qi4OraF0I9J9FBLmTda/1Wi1o6rLAXZBm2aJrP740ezFxPneHH92aQF4Z5xZqcQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.47.0",
+        "@wordpress/hooks": "^4.52.0",
         "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
         "tannin": "^1.2.0"
       },
       "bin": {
@@ -7356,9 +7251,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.47.0.tgz",
-      "integrity": "sha512-NskF7HZlGvK8e5GlU8U340g9LGe/rcH3+4UxDAj9oECVL09B1s1IQaHWNUs65lq+ACNca6p7eOOfcBQ7PNhqXA==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.52.0.tgz",
+      "integrity": "sha512-LMIBLLTZ+vvq0DlYebL4d9XaCu16PNnhPGSn8QqsMPmBzwBYOjO0/btMLpYbs9rRc8k1QKBDWvw8eddvRVsYxA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7404,17 +7299,25 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.47.0.tgz",
-      "integrity": "sha512-hAN65nUfVyhbq9EfIG7ue4FtZ7PoWCSmN7BnWdPAP6GLe9/RdfPuHtc91Of7xBULdMeXLeH04KsfwuE99tjo+w==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.52.0.tgz",
+      "integrity": "sha512-KRvwViTTdxUDgikYaCm+qnXSH2UlFuCDjAIvtjjcen8oRviSkeMv6bPn1T2vqFRKcVgt88xTtKlvI8l5U99o2Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.20.0"
+        "@wordpress/i18n": "^6.25.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
@@ -7486,7 +7389,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7528,7 +7430,6 @@
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7564,9 +7465,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.47.0.tgz",
-      "integrity": "sha512-KWvo9JmFkNrv16DJEiqna97Oe7HLlVZaaB3t05QH8uJYG1YiH58Ld15B2V7nZWxZZ+HBm6CLrPUuGnt1+Ohtiw==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.52.0.tgz",
+      "integrity": "sha512-aYnVXxV5j4D73tRld2n1D3G6cKLfSwKWcTnktJ7XlmiswW7xlaAqvn4FyBjwmIe20pZw0A7xLH5xCuQcqOM7nw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7578,9 +7479,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.47.0.tgz",
-      "integrity": "sha512-DfwLsmencI2LUZhY6u1aZCwZYO1ILuyJf7Cn15G/gVbPlA7pBJp9YVFk+3FR5U35I0e0infNMDDn8u5632urmQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.52.0.tgz",
+      "integrity": "sha512-gFcmBXSti73Y4uEx++5qUNDaH/o0/2ijrHEJkY5e/df4RtmxVSQOIVxftRiI4m9thCWfJMoehMMreJxhwx6Qtg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7651,7 +7552,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7751,7 +7651,6 @@
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8116,6 +8015,33 @@
         "prettier": ">=3"
       }
     },
+    "node_modules/@wordpress/scripts/node_modules/@wordpress/theme": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.5.0.tgz",
+      "integrity": "sha512-6V14snLXUqVs3fBPmGJhWkgtWcrwEe7vUS04nTl7hyI5uyL+N7LXRldWTjnzwaQL0ywBIx4u13gJU/GZqOc8dQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.38.0",
+        "@wordpress/private-apis": "^1.38.0",
+        "colorjs.io": "^0.6.0",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "stylelint": "^16.8.2"
+      },
+      "peerDependenciesMeta": {
+        "stylelint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/warning": {
       "version": "3.38.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.38.0.tgz",
@@ -8143,7 +8069,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8554,15 +8479,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@wordpress/style-runtime": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
+      "integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.30.0.tgz",
-      "integrity": "sha512-35s8w52ZxTVkvllBSCMbV2cFLQjHd+8FzROUIBW0OaUlZum3bQXnz2I3Q71e6fG2/jXvXVrHRh45P2oIhWnKPQ==",
+      "version": "23.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.42.0.tgz",
+      "integrity": "sha512-k9lNU4sK3fdipdhHI2d/Rzd/NnfznPmOZ60ok8O8QhfCMZw2Jd1M8ckYqaIrHTKU62ZrcsugdfJlHodsdrxEzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stylistic/stylelint-plugin": "^3.0.1",
-        "@wordpress/theme": "^0.5.0",
+        "@wordpress/theme": "^0.17.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-recommended-scss": "^14.1.0"
       },
@@ -8576,14 +8512,17 @@
       }
     },
     "node_modules/@wordpress/theme": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.5.0.tgz",
-      "integrity": "sha512-6V14snLXUqVs3fBPmGJhWkgtWcrwEe7vUS04nTl7hyI5uyL+N7LXRldWTjnzwaQL0ywBIx4u13gJU/GZqOc8dQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.17.0.tgz",
+      "integrity": "sha512-BU+PLBLxMBM4WJYrd1QEwy+IA64vUP+8IEEB9lLx2NfB+3/45vvuvXx9o3qPKRDHvtMtEaRArld4Kn05UIW9IA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.38.0",
-        "@wordpress/private-apis": "^1.38.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/style-runtime": "^0.5.0",
         "colorjs.io": "^0.6.0",
         "memize": "^2.1.0"
       },
@@ -8592,24 +8531,105 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
+        "esbuild": "^0.27.2",
+        "postcss": "^8.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2"
+        "stylelint": "^16.8.2",
+        "vite": "^7.3.2"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
         "stylelint": {
+          "optional": true
+        },
+        "vite": {
           "optional": true
         }
       }
     },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.47.0.tgz",
-      "integrity": "sha512-tmAIGJ28X0+/yt9KHacPwJTXX/qjmLgZgrkF86b/qXC5uz5OuvjrtcUwG3YcH/DoQjDRwe8eOkJ/6Ql3LwqrhA==",
+    "node_modules/@wordpress/theme/node_modules/@wordpress/compose": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.5.0.tgz",
+      "integrity": "sha512-giYS22Tbhtr3Lj4lK6lxzGqV6EkM2QeVBiP7+c9r2F9rnQN3F6A8cN4gQM5sVGdgIOlps9tw+dsn9OHzIFVwIg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.47.0"
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/priority-queue": "^3.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/undo-manager": "^1.52.0",
+        "change-case": "^4.1.2",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/theme/node_modules/@wordpress/element": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.4.0.tgz",
+      "integrity": "sha512-/LzW+0MpSmKfYiESoXUQtjBPqOPyvqUm17GigQR5c0Z8Wj2NiklP72x4XaF02uSkau1ru1Z9lP8NWEGjwBwLsA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/theme/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.52.0.tgz",
+      "integrity": "sha512-6hI0WWDOtLLVEkWqQokCoQRz5Pba9UNtgt5MV4hHGe5x0mzsowj+GWHedppf8UCVZ2ex3cde7fThaRKMCackrQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8669,7 +8689,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8768,7 +8787,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9397,7 +9415,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9947,7 +9964,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10047,17 +10063,17 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
-      "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memory": "^2.0.7",
-        "@cacheable/utils": "^2.3.3",
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
         "hookified": "^1.15.0",
-        "keyv": "^5.5.5",
-        "qified": "^0.6.0"
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
@@ -10889,7 +10905,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -11124,13 +11139,13 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12 || >=16"
+        "node": ">=12"
       }
     },
     "node_modules/css-loader": {
@@ -11241,7 +11256,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -12380,8 +12394,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
       "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -12683,6 +12696,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -12977,7 +12991,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -14333,9 +14346,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -15147,13 +15160,13 @@
       }
     },
     "node_modules/hashery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
-      "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.14.0"
+        "hookified": "^1.15.0"
       },
       "engines": {
         "node": ">=20"
@@ -15221,9 +15234,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
-      "integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "dev": true,
       "license": "MIT"
     },
@@ -16561,7 +16574,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -17254,7 +17266,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -17676,8 +17687,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
       "version": "8.19.0",
@@ -18910,7 +18920,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -19303,7 +19312,6 @@
       "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
@@ -20318,6 +20326,7 @@
       "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.0"
       },
@@ -20337,6 +20346,7 @@
       "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -20355,6 +20365,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -20405,7 +20416,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -21124,7 +21134,6 @@
       "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
       "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21421,17 +21430,24 @@
       ]
     },
     "node_modules/qified": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
-      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.14.0"
+        "hookified": "^2.1.1"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -21540,7 +21556,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21599,7 +21614,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -21620,7 +21634,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21855,8 +21868,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -23593,7 +23605,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -23713,23 +23724,23 @@
       }
     },
     "node_modules/stylelint-scss/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/stylelint-scss/node_modules/css-tree/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -23744,16 +23755,16 @@
       }
     },
     "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.26.0.tgz",
-      "integrity": "sha512-ZqI0qjKWHMPcGUfLmlr80NPNVHIOjPMHtIOe1qXYFGS0YBZ1YKAzo9yk8W+gGrLCN0Xdv/RKxqdIsqPakEfmow==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.31.0.tgz",
+      "integrity": "sha512-+q2nMMt5Rd+PFSC6Nypqn0nU/po6kUPNIHEKYo3xxdl7ASK+Uam3zHOkSBVyw+Wjvb+dkWXfNJqIM0RWJio/MQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23762,6 +23773,44 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/stylelint-use-logical": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.3.tgz",
+      "integrity": "sha512-haPkgxKre+eSqr4IZJnHwNT/9/wICykeFZIaz7rZbe4SohTHkw7vBahMOrZJZpdny/EBVHAcPH2IBeoiUcZWWw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": ">= 11 < 18"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
@@ -23826,9 +23875,9 @@
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23853,38 +23902,38 @@
       }
     },
     "node_modules/stylelint/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
-      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.20"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.20",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
-      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^2.3.2",
-        "flatted": "^3.3.3",
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
         "hookified": "^1.15.0"
       }
     },
@@ -23937,10 +23986,20 @@
       }
     },
     "node_modules/stylelint/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -23960,9 +24019,9 @@
       }
     },
     "node_modules/stylelint/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -23980,12 +24039,11 @@
       }
     },
     "node_modules/stylelint/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -24340,7 +24398,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -24561,7 +24618,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24850,7 +24906,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -25088,7 +25143,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -25430,7 +25484,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -25557,7 +25610,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -25635,7 +25687,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -25689,7 +25740,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -25749,7 +25799,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -25863,7 +25912,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "patch-package": "^8.0.0",
     "sass": "^1.81.0",
     "sass-loader": "^16.0.3",
+    "stylelint": "^16.26.1",
+    "stylelint-use-logical": "^2.1.3",
     "tabbable": "^6.1.2",
     "unique-selector": "^0.5.0",
     "webpack": "^5.96.1",

--- a/partials/welcome-page.php
+++ b/partials/welcome-page.php
@@ -16,9 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="wrap edac-welcome-container">
 
 	<div class="edac-cols">
-	<div class="edac-cols-left edac-welcome">
+	<div class="edac-cols-start edac-welcome">
 		<div class="edac-welcome-header">
-			<div class="edac-welcome-header-left">
+			<div class="edac-welcome-header-start">
 				<h1 class="edac-welcome-title">
 					<?php
 					if ( defined( 'EDACP_VERSION' ) && EDAC_KEY_VALID === true ) {
@@ -39,7 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</h1>
 			</div>
 
-		<div class="edac-welcome-header-right">
+		<div class="edac-welcome-header-end">
 				<a href="<?php edac_link_wrapper( 'https://equalizedigital.com/?utm_source=accessibility-checker&utm_medium=software', 'welcome-page', 'logo-link' ); ?>" target="_blank">
 					<img src="<?php echo esc_url( plugin_dir_url( __DIR__ ) ); ?>assets/images/accessibility-checker-logo-transparent-bg.svg" alt="<?php esc_attr_e( 'Link to Equalize Digital Website', 'accessibility-checker' ); ?>">
 				</a>
@@ -190,10 +190,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php
 	if ( ! defined( 'EDACP_VERSION' ) || ! EDAC_KEY_VALID ) {
-		echo '<div class="edac-cols-right edac-welcome-aside">
+		echo '<div class="edac-cols-end edac-welcome-aside">
 			<div class="edac-has-cta">';
 	} else {
-		echo '<div class="edac-cols-right edac-welcome-aside">
+		echo '<div class="edac-cols-end edac-welcome-aside">
 			<div>';
 	}
 

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -707,12 +707,12 @@ window.addEventListener( 'load', function() {
 
 	// On our welcome page the notices break layout, so we move them to a new container in
 	// the grid we have in the header.
-	const notices = document.querySelectorAll( '.edac-welcome-header-left .notice' );
+	const notices = document.querySelectorAll( '.edac-welcome-header-start .notice' );
 	if ( notices.length ) {
-		// Create a new div after .edac-welcome-header-right element
+		// Create a new div after .edac-welcome-header-end element
 		const noticesContainer = document.createElement( 'div' );
 		noticesContainer.classList.add( 'edac-welcome-header-notices' );
-		document.querySelector( '.edac-welcome-header-right' ).insertAdjacentElement( 'afterend', noticesContainer );
+		document.querySelector( '.edac-welcome-header-end' ).insertAdjacentElement( 'afterend', noticesContainer );
 		// If the new container was created then put the notices into it.
 		if ( document.querySelector( '.edac-welcome-header-notices' ) ) {
 			notices.forEach( function( notice ) {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1123,7 +1123,7 @@
 
 	&-list {
 		display: inline-block;
-		margin-left: 35px;
+		margin-inline-start: 35px;
 		margin-bottom: 25px;
 		text-align: start;
 

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -163,7 +163,7 @@
 				background-color: variables.$color-gray-lightest;
 				box-shadow: inset 0 0 0 1px variables.$color-gray-light;
 				padding: 15px;
-				text-align: left;
+				text-align: start;
 				margin-bottom: 20px;
 				border-left: solid 5px variables.$color-red;
 			}
@@ -389,7 +389,7 @@
 						margin-bottom: 0;
 
 						@include helpers.breakpoint(xs) {
-							text-align: right;
+							text-align: end;
 						}
 					}
 
@@ -399,7 +399,7 @@
 						margin-bottom: 0;
 
 						@include helpers.breakpoint(xs) {
-							text-align: left;
+							text-align: start;
 						}
 
 						br {
@@ -416,7 +416,7 @@
 					font-size: 16px;
 					align-items: center;
 					padding-left: 0;
-					text-align: left;
+					text-align: start;
 
 					&-icon {
 						width: 33px;
@@ -439,7 +439,7 @@
 
 			&-disclaimer {
 				margin-top: 20px;
-				text-align: left;
+				text-align: start;
 			}
 		}
 
@@ -455,7 +455,7 @@
 					gap: 10px;
 					padding: 10px;
 					background-color: variables.$color-white;
-					text-align: left;
+					text-align: start;
 					font-size: 16px;
 					border-bottom: solid 1px variables.$color-gray-light;
 
@@ -555,7 +555,7 @@
 						}
 
 						&-object {
-							text-align: left;
+							text-align: start;
 							word-break: break-word;
 						}
 
@@ -620,7 +620,7 @@
 						&-ignore {
 							grid-column: 1 / 4;
 							border-bottom: solid 1px variables.$color-gray-light;
-							text-align: left;
+							text-align: start;
 							padding: 10px;
 							display: none;
 
@@ -661,7 +661,7 @@
 		}
 
 		.edac-readability {
-			text-align: left;
+			text-align: start;
 
 			&-list {
 				margin-top: 0;
@@ -1125,7 +1125,7 @@
 		display: inline-block;
 		margin-left: 35px;
 		margin-bottom: 25px;
-		text-align: left;
+		text-align: start;
 
 		li {
 			list-style-type: none !important;
@@ -1273,7 +1273,7 @@
 }
 
 .edac-right-text {
-	text-align: right;
+	text-align: end;
 }
 
 .edac-center-text {
@@ -1303,7 +1303,7 @@
 		flex-direction: row !important;
 
 		.edac-cols-right {
-			text-align: right;
+			text-align: end;
 		}
 
 		@media screen and (max-width: variables.$small-screen-width ) {
@@ -1430,7 +1430,7 @@
 
 	h3 {
 		font-weight: 700;
-		text-align: left;
+		text-align: start;
 	}
 
 	.edac-summary {
@@ -1442,7 +1442,7 @@
 		&-header {
 			display: flex;
 			width: 100%;
-			text-align: left;
+			text-align: start;
 
 			&-label {
 				flex: 1;
@@ -1747,14 +1747,14 @@
 		justify-items: stretch;
 
 		.edac-welcome-header-right {
-			text-align: right;
+			text-align: end;
 
 			img {
 				width: 200px;
 			}
 
 			[dir="rtl"] & {
-				text-align: left;
+				text-align: start;
 			}
 		}
 

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1752,10 +1752,6 @@
 			img {
 				width: 200px;
 			}
-
-			[dir="rtl"] & {
-				text-align: start;
-			}
 		}
 
 		@media screen and (max-width: variables.$small-screen-width ) {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -46,7 +46,7 @@
 
 			#edac-clear-issues-button {
 				margin-inline-start: auto;
-				//margin-bottom: 1em;
+				//margin-block-end: 1em;
 			}
 		}
 
@@ -1019,7 +1019,7 @@
 			margin-block-start: 6px;
 		}
 
-		&-left {
+		&-start {
 			grid-row: 1;
 			grid-column: 1 / 2;
 		}
@@ -1028,7 +1028,7 @@
 			grid-column: 1 / -1;
 		}
 
-		&-right {
+		&-end {
 			grid-column: 2 / 3;
 			grid-row: 1;
 
@@ -1269,7 +1269,7 @@
 	font-size: variables.$font-size-small;
 }
 
-.edac-right-text {
+.edac-end-text {
 	text-align: end;
 }
 
@@ -1299,7 +1299,7 @@
 		gap: 1rem;
 		flex-direction: row !important;
 
-		.edac-cols-right {
+		.edac-cols-end {
 			text-align: end;
 		}
 
@@ -1307,7 +1307,7 @@
 			flex-direction: column !important;
 			text-align: center;
 
-			.edac-cols-right {
+			.edac-cols-end {
 				text-align: center;
 			}
 		}
@@ -1721,7 +1721,7 @@
 		>.edac-cols {
 			flex-direction: column !important;
 
-			.edac-cols-right {
+			.edac-cols-end {
 
 				.edac-panel {
 					padding: 0 1rem;
@@ -1743,7 +1743,7 @@
 		display: grid;
 		justify-items: stretch;
 
-		.edac-welcome-header-right {
+		.edac-welcome-header-end {
 			text-align: end;
 
 			img {
@@ -1756,11 +1756,11 @@
 			flex-direction: column-reverse;
 			text-align: center;
 
-			.edac-welcome-header-left {
+			.edac-welcome-header-start {
 				order: 2;
 			}
 
-			.edac-welcome-header-right {
+			.edac-welcome-header-end {
 				text-align: center;
 				order: 3;
 			}

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -10,7 +10,7 @@
 
 	p {
 		font-size: 14px;
-		margin-top: 0;
+		margin-block-start: 0;
 	}
 
 	* {
@@ -19,13 +19,13 @@
 
 	label {
 		font-weight: 700;
-		margin-bottom: 5px;
+		margin-block-end: 5px;
 		display: inline-block;
 		font-size: 14px;
 	}
 
 	textarea {
-		margin-bottom: 1em;
+		margin-block-end: 1em;
 		border: solid 1px #ddd;
 	}
 
@@ -45,36 +45,35 @@
 			gap: 10px;
 
 			#edac-clear-issues-button {
-				margin-left: auto;
+				margin-inline-start: auto;
 				//margin-bottom: 1em;
 			}
 		}
 
 		.edac-tabs {
-			margin-bottom: 0;
-			margin-top: 0;
+			margin-block: 0;
 			position: relative;
 			z-index: 2;
 		}
 
 		.edac-tab {
 			display: inline;
-			margin-bottom: 0;
+			margin-block-end: 0;
 			vertical-align: bottom;
 
 			> button {
-				width: 100%;
+				inline-size: 100%;
 				padding: 16px 18px;
 				display: inline-block;
 				background-color: variables.$color-gray-lightest;
 				border: solid 1px variables.$color-gray-light;
-				border-bottom: none;
+				border-block-end: none;
 				text-decoration: none;
 				font-size: 14px;
 				color: variables.$color-blue;
 
 				@include helpers.breakpoint(xs) {
-					width: auto;
+					inline-size: auto;
 				}
 
 				&:hover,
@@ -118,16 +117,16 @@
 		.edac-summary {
 
 			.edac-icon {
-				width: 37px;
-				height: 37px;
+				inline-size: 37px;
+				block-size: 37px;
 				position: absolute;
-				top: 12px;
-				left: 12px;
+				inset-block-start: 12px;
+				inset-inline-start: 12px;
 				display: block;
 
 				svg {
-					width: 37px;
-					height: 37px;
+					inline-size: 37px;
+					block-size: 37px;
 				}
 			}
 
@@ -164,8 +163,8 @@
 				box-shadow: inset 0 0 0 1px variables.$color-gray-light;
 				padding: 15px;
 				text-align: start;
-				margin-bottom: 20px;
-				border-left: solid 5px variables.$color-red;
+				margin-block-end: 20px;
+				border-inline-start: solid 5px variables.$color-red;
 			}
 
 			&-total {
@@ -182,7 +181,7 @@
 				}
 
 				&-mobile {
-					width: 100%;
+					inline-size: 100%;
 					color: variables.$color-dark-gray;
 
 					@include helpers.breakpoint(xs) {
@@ -190,16 +189,16 @@
 					}
 
 					&-bar {
-						width: 100%;
-						height: $progress-bar-width * 2;
+						inline-size: 100%;
+						block-size: $progress-bar-width * 2;
 						background-color: variables.$color-gray-light;
 						border-radius: 5px;
 						overflow: hidden;
-						margin-top: 20px;
+						margin-block-start: 20px;
 
 						span {
 							display: block;
-							height: $progress-bar-width * 2;
+							block-size: $progress-bar-width * 2;
 							background-color: variables.$color-blue;
 						}
 					}
@@ -210,8 +209,8 @@
 					font-size: 20px;
 					position: relative;
 					padding: 0;
-					width: $progress-circle-size;
-					height: $progress-circle-size;
+					inline-size: $progress-circle-size;
+					block-size: $progress-circle-size;
 					background-color: variables.$color-gray-light;
 					border-radius: 50%;
 					line-height: $progress-circle-size;
@@ -230,13 +229,13 @@
 					&:after {
 						border: none;
 						position: absolute;
-						top: $progress-bar-width;
-						left: $progress-bar-width;
+						inset-block-start: $progress-bar-width;
+						inset-inline-start: $progress-bar-width;
 						text-align: center;
 						display: block;
 						border-radius: 50%;
-						width: $progress-circle-size - ($progress-bar-width * 2);
-						height: $progress-circle-size - ($progress-bar-width * 2);
+						inline-size: $progress-circle-size - ($progress-bar-width * 2);
+						block-size: $progress-circle-size - ($progress-bar-width * 2);
 						background-color: variables.$color-white;
 						content: " ";
 					}
@@ -244,14 +243,14 @@
 					&-label {
 						position: absolute;
 						line-height: 20px;
-						width: $progress-circle-size;
+						inline-size: $progress-circle-size;
 						text-align: center;
 						display: block;
 						color: sidebar-variables.$info-grey;
 						z-index: 2;
 
 						div:first-child {
-							margin-top: 95px;
+							margin-block-start: 95px;
 						}
 					}
 				}
@@ -260,8 +259,8 @@
 
 					/* a round circle */
 					border-radius: 50%;
-					width: $progress-circle-size;
-					height: $progress-circle-size;
+					inline-size: $progress-circle-size;
+					block-size: $progress-circle-size;
 					position: absolute;
 
 					/* needed for clipping */
@@ -284,8 +283,8 @@
 
 					/*needed for clipping*/
 					clip: rect(0, calc($progress-circle-size / 2), $progress-circle-size, 0);
-					width: $progress-circle-size;
-					height: $progress-circle-size;
+					inline-size: $progress-circle-size;
+					block-size: $progress-circle-size;
 					border-radius: 50%;
 					border: $progress-bar-width solid variables.$color-blue;
 
@@ -308,8 +307,8 @@
 					clip: rect(0, $progress-circle-size, $progress-circle-size, calc($progress-circle-size / 2));
 					background-color: variables.$color-blue;
 					border-radius: 50%;
-					width: $progress-circle-size;
-					height: $progress-circle-size;
+					inline-size: $progress-circle-size;
+					block-size: $progress-circle-size;
 				}
 
 				.edac-summary-total-progress-circle:not(.over50) .first50-bar {
@@ -318,21 +317,21 @@
 			}
 
 			&-stats {
-				width: 100%;
+				inline-size: 100%;
 
 				@include helpers.breakpoint(lg) {
-					width: calc(50% - 12px);
+					inline-size: calc(50% - 12px);
 					float: inline-end;
 				}
 
 				@include helpers.breakpoint(xl) {
-					width: calc(60% - 12px);
+					inline-size: calc(60% - 12px);
 				}
 			}
 
 			&-stat {
-				height: 125px;
-				padding-top: 25px;
+				block-size: 125px;
+				padding-block-start: 25px;
 				background-position: 10px 10px;
 				background-repeat: no-repeat;
 				background-size: 30px auto;
@@ -341,18 +340,18 @@
 				position: relative;
 
 				@include helpers.breakpoint(xs) {
-					padding-top: 50px;
-					height: 175px;
+					padding-block-start: 50px;
+					block-size: 175px;
 				}
 
 				&:nth-child(2),
 				&:nth-child(4) {
-					margin-right: 0;
+					margin-inline-end: 0;
 				}
 			}
 
 			&-readability {
-				width: 100%;
+				inline-size: 100%;
 				box-shadow: inset 0 0 0 1px variables.$color-gray-light;
 				clear: both;
 				padding: 14px;
@@ -369,24 +368,24 @@
 					display: flex;
 					align-items: center;
 					gap: 14px;
-					margin-bottom: 15px;
-					padding-right: 14px;
+					margin-block-end: 15px;
+					padding-inline-end: 14px;
 
 					.edac-icon {
 						position: relative;
-						top: auto;
-						left: auto;
+						inset-block-start: auto;
+						inset-inline-start: auto;
 					}
 
 					@include helpers.breakpoint(lg) {
-						border-right: solid 3px variables.$color-gray-light;
-						margin-bottom: 0;
+						border-inline-end: solid 3px variables.$color-gray-light;
+						margin-block-end: 0;
 					}
 
 					.edac-panel-number {
 						color: sidebar-variables.$info-grey;
 						text-align: center;
-						margin-bottom: 0;
+						margin-block-end: 0;
 
 						@include helpers.breakpoint(xs) {
 							text-align: end;
@@ -396,7 +395,7 @@
 					.edac-panel-number-label {
 						color: sidebar-variables.$info-grey;
 						text-align: center;
-						margin-bottom: 0;
+						margin-block-end: 0;
 
 						@include helpers.breakpoint(xs) {
 							text-align: start;
@@ -415,12 +414,12 @@
 				&-summary {
 					font-size: 16px;
 					align-items: center;
-					padding-left: 0;
+					padding-inline-start: 0;
 					text-align: start;
 
 					&-icon {
-						width: 33px;
-						height: 33px;
+						inline-size: 33px;
+						block-size: 33px;
 						display: block;
 						background: url(../images/error-icon-red.png) no-repeat center center;
 						background-size: contain;
@@ -438,7 +437,7 @@
 			}
 
 			&-disclaimer {
-				margin-top: 20px;
+				margin-block-start: 20px;
 				text-align: start;
 			}
 		}
@@ -457,7 +456,7 @@
 					background-color: variables.$color-white;
 					text-align: start;
 					font-size: 16px;
-					border-bottom: solid 1px variables.$color-gray-light;
+					border-block-end: solid 1px variables.$color-gray-light;
 
 					h3 {
 						display: flex;
@@ -468,7 +467,7 @@
 					}
 
 					.edac-badge {
-						margin-left: 0;
+						margin-inline-start: 0;
 					}
 
 					&:hover {
@@ -479,7 +478,7 @@
 						background: none;
 						border: none;
 						border-radius: 0;
-						margin-left: auto;
+						margin-inline-start: auto;
 
 						&:hover,
 						&:focus {
@@ -505,7 +504,7 @@
 				}
 
 				&-count {
-					margin-left: -5px;
+					margin-inline-start: -5px;
 				}
 
 				&-count-ignore {
@@ -529,7 +528,7 @@
 				}
 
 				&-records {
-					width: 100%;
+					inline-size: 100%;
 					display: none;
 
 					&-labels {
@@ -540,7 +539,7 @@
 
 						&-label {
 							padding: 3px;
-							border-right: solid 1px variables.$color-gray-light;
+							border-inline-end: solid 1px variables.$color-gray-light;
 						}
 					}
 
@@ -550,8 +549,8 @@
 
 						&-cell {
 							padding: 10px;
-							border-bottom: solid 1px variables.$color-gray-light;
-							border-right: solid 1px variables.$color-gray-light;
+							border-block-end: solid 1px variables.$color-gray-light;
+							border-inline-end: solid 1px variables.$color-gray-light;
 						}
 
 						&-object {
@@ -563,13 +562,13 @@
 
 							img,
 							svg {
-								max-width: 100%;
-								height: auto;
+								max-inline-size: 100%;
+								block-size: auto;
 							}
 						}
 
 						&-actions {
-							border-right: none;
+							border-inline-end: none;
 
 							&-ignore,
 							&-fix,
@@ -583,8 +582,8 @@
 								padding: 4px 0;
 
 								svg {
-									width: 18px;
-									height: auto;
+									inline-size: 18px;
+									block-size: auto;
 									display: inline-block;
 									margin: 0 5px 0 0;
 
@@ -612,25 +611,25 @@
 								}
 
 								.dashicons {
-									margin-right: 3px;
+									margin-inline-end: 3px;
 								}
 							}
 						}
 
 						&-ignore {
 							grid-column: 1 / 4;
-							border-bottom: solid 1px variables.$color-gray-light;
+							border-block-end: solid 1px variables.$color-gray-light;
 							text-align: start;
 							padding: 10px;
 							display: none;
 
 							&-info {
-								margin-bottom: 10px;
+								margin-block-end: 10px;
 							}
 
 							&-comment {
-								width: 100%;
-								margin-bottom: 10px;
+								inline-size: 100%;
+								margin-block-end: 10px;
 								font-size: 12px;
 							}
 
@@ -644,10 +643,10 @@
 								}
 
 								svg {
-									width: 18px;
-									height: auto;
+									inline-size: 18px;
+									block-size: auto;
 									display: inline-block;
-									margin-right: 2px;
+									margin-inline-end: 2px;
 
 									path {
 										fill: variables.$color-white;
@@ -664,12 +663,11 @@
 			text-align: start;
 
 			&-list {
-				margin-top: 0;
+				margin-block: 0 1em;
 				position: relative;
-				margin-bottom: 1em;
 
 				&-item {
-					padding-left: 30px;
+					padding-inline-start: 30px;
 
 					&-title {
 						font-size: 16px;
@@ -678,7 +676,7 @@
 
 					&-icon {
 						position: absolute;
-						left: 0;
+						inset-inline-start: 0;
 
 						&.edac-icon--success {
 							color: sidebar-variables.$check-green;
@@ -700,10 +698,10 @@
 			}
 
 			&-simplified-summary {
-				width: 100%;
+				inline-size: 100%;
 
 				textarea {
-					width: 100%;
+					inline-size: 100%;
 					display: block;
 				}
 			}
@@ -720,7 +718,7 @@
 	}
 
 	.edac-settings-tab__badge {
-		margin-left: 8px;
+		margin-inline-start: 8px;
 		padding: 2px 12px;
 		border-radius: 999px;
 		background: #ffcc17;
@@ -732,7 +730,7 @@
 }
 
 .edac-reports-page {
-	margin-top: 24px;
+	margin-block-start: 24px;
 	display: grid;
 	gap: 16px;
 
@@ -749,7 +747,7 @@
 		display: grid;
 		gap: 24px;
 
-		min-width: 0;
+		min-inline-size: 0;
 	}
 
 	&__panel {
@@ -760,16 +758,16 @@
 	}
 
 	&__intro {
-		max-width: 980px;
+		max-inline-size: 980px;
 		margin: 0 0 32px;
 	}
 
 	&__single-action {
-		margin-top: 24px;
+		margin-block-start: 24px;
 	}
 
 	&__button {
-		min-height: 52px;
+		min-block-size: 52px;
 		padding: 0 20px;
 		border-radius: 8px;
 	}
@@ -783,8 +781,8 @@
 	&__license-input,
 	&__license-mask {
 		display: block;
-		width: 100%;
-		max-width: none;
+		inline-size: 100%;
+		max-inline-size: none;
 		margin: 0 0 20px;
 		padding: 18px 20px;
 		border: 1px solid #b5bcc4;
@@ -845,14 +843,14 @@
 
 	&__status-icon {
 		display: inline-flex;
-		width: 27px;
-		height: 27px;
+		inline-size: 27px;
+		block-size: 27px;
 	}
 
 	&__status-icon svg {
 		display: inline-flex;
-		width: 27px;
-		height: 27px;
+		inline-size: 27px;
+		block-size: 27px;
 	}
 
 	&__status--warning {
@@ -869,10 +867,10 @@
 
 .edac-reports-stat {
 	text-align: center;
-	padding-top: 28px;
+	padding-block-start: 28px;
 
 	&__label {
-		margin-bottom: 10px;
+		margin-block-end: 10px;
 		color: #1d2327;
 		font-size: 15px;
 		font-weight: 600;
@@ -887,7 +885,7 @@
 	}
 
 	&__caption {
-		margin-top: 12px;
+		margin-block-start: 12px;
 		color: #1d2327;
 		font-size: 20px;
 		font-weight: 400;
@@ -897,18 +895,18 @@
 
 .edac-reports-preview {
 	display: none;
-	min-width: 0;
+	min-inline-size: 0;
 
 	@include helpers.breakpoint(lg) {
 		display: block;
-		width: 320px;
+		inline-size: 320px;
 	}
 
 	&__image {
 		display: block;
-		width: 100%;
-		height: auto;
-		margin-bottom: -15px;
+		inline-size: 100%;
+		block-size: auto;
+		margin-block-end: -15px;
 		box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.06);
 		clip-path: inset(-10px -10px 0 -10px);
 		border-radius: 5px 5px 0 0;
@@ -916,9 +914,8 @@
 }
 
 .ac-simplified-summary {
-	max-width: 800px;
-	margin-left: auto;
-	margin-right: auto;
+	max-inline-size: 800px;
+	margin-inline: auto;
 }
 
 #ac-simplified-summary-option-code {
@@ -926,10 +923,10 @@
 }
 
 .edac-settings {
-	max-width: 800px;
+	max-inline-size: 800px;
 
 	&--reports {
-		max-width: 1390px;
+		max-inline-size: 1390px;
 
 		.edac-reports-page__legal {
 
@@ -940,7 +937,7 @@
 	}
 
 	&.pro-callout-wrapper {
-		max-width: fit-content;
+		max-inline-size: fit-content;
 	}
 
 	.edac-description {
@@ -951,7 +948,7 @@
 		background-color: variables.$color-white;
 		padding: 15px;
 		border: solid 1px variables.$color-gray-light;
-		margin-top: 20px;
+		margin-block-start: 20px;
 		border-radius: 10px;
 	}
 
@@ -972,7 +969,7 @@
 
 		.form-table {
 			display: block;
-			margin-bottom: 50px;
+			margin-block-end: 50px;
 
 			tbody {
 				display: block;
@@ -980,7 +977,7 @@
 
 			tr {
 				border: solid 1px variables.$color-gray-light;
-				margin-bottom: 10px;
+				margin-block-end: 10px;
 				display: block;
 			}
 
@@ -998,8 +995,8 @@
 	.edac-pro-callout {
 		background-color: #fff;
 		border: 1px solid variables.$color-gray-light;
-		margin-top: 30px;
-		max-width: 500px;
+		margin-block-start: 30px;
+		max-inline-size: 500px;
 	}
 }
 
@@ -1009,7 +1006,7 @@
 
 	&-header {
 		padding: 1rem 2rem;
-		border-bottom: 1px solid variables.$color-gray-light;
+		border-block-end: 1px solid variables.$color-gray-light;
 
 		@include helpers.breakpoint(sm) {
 			display: grid;
@@ -1019,7 +1016,7 @@
 		&-version {
 			display: block;
 			font-size: 12px;
-			margin-top: 6px;
+			margin-block-start: 6px;
 		}
 
 		&-left {
@@ -1053,7 +1050,7 @@
 
 	&-section {
 		padding: 2rem;
-		border-bottom: 1px solid variables.$color-gray-light;
+		border-block-end: 1px solid variables.$color-gray-light;
 
 		@include helpers.breakpoint(md) {
 			display: grid;
@@ -1065,13 +1062,13 @@
 			font-size: 21px;
 
 			&:first-child {
-				margin-top: 0;
+				margin-block-start: 0;
 			}
 		}
 
 		&-divider {
-			border-bottom: 1px solid variables.$color-gray-light;
-			margin-top: 30px;
+			border-block-end: 1px solid variables.$color-gray-light;
+			margin-block-start: 30px;
 		}
 
 		&-documentation-support {
@@ -1087,7 +1084,7 @@
 	}
 
 	.edac-welcome-pro-callout {
-		margin-bottom: 30px;
+		margin-block-end: 30px;
 
 		@include helpers.breakpoint(md) {
 			grid-column: 2 / 3;
@@ -1112,7 +1109,7 @@
 	font-family: "Open Sans", sans-serif;
 
 	&-icon {
-		width: 200px;
+		inline-size: 200px;
 	}
 
 	&-title {
@@ -1124,20 +1121,20 @@
 	&-list {
 		display: inline-block;
 		margin-inline-start: 35px;
-		margin-bottom: 25px;
+		margin-block-end: 25px;
 		text-align: start;
 
 		li {
 			list-style-type: none !important;
 			position: relative;
-			margin-bottom: 16px;
+			margin-block-end: 16px;
 			font-size: 16px;
 
 			// stylelint-disable-next-line selector-pseudo-element-colon-notation
 			&:before {
 				content: url(../images/list-check.png);
-				height: 21px;
-				width: 21px;
+				block-size: 21px;
+				inline-size: 21px;
 				margin-inline-end: 18px;
 				display: inline-block;
 				vertical-align: middle;
@@ -1183,11 +1180,11 @@
 		&:after {
 			content: "";
 			position: absolute;
-			height: calc(100% + 3px);
-			width: calc(100% + 3px);
+			block-size: calc(100% + 3px);
+			inline-size: calc(100% + 3px);
 			z-index: -1;
-			bottom: -8px;
-			right: -8px;
+			inset-block-end: -8px;
+			inset-inline-end: -8px;
 			background: #f3cd1e;
 		}
 
@@ -1199,7 +1196,7 @@
 	}
 
 	&-activate {
-		margin-top: 10px;
+		margin-block-start: 10px;
 		display: block;
 	}
 }
@@ -1230,7 +1227,7 @@
 			// stylelint-disable-next-line font-family-no-missing-generic-family-keyword
 			font-family: dashicons;
 			position: relative;
-			bottom: -1px;
+			inset-block-end: -1px;
 			color: variables.$color-yellow;
 			font-size: 10px;
 		}
@@ -1241,7 +1238,7 @@
 .edac_black_friday_notice {
 
 	.button {
-		margin-top: 5px;
+		margin-block-start: 5px;
 	}
 }
 
@@ -1318,35 +1315,35 @@
 }
 
 .edac-mt-1 {
-	margin-top: 0.5rem !important;
+	margin-block-start: 0.5rem !important;
 }
 
 .edac-mt-3 {
-	margin-top: 1.5rem !important;
+	margin-block-start: 1.5rem !important;
 }
 
 .edac-mb-1 {
-	margin-bottom: 0.5rem !important;
+	margin-block-end: 0.5rem !important;
 }
 
 .edac-mb-3 {
-	margin-bottom: 1.5rem !important;
+	margin-block-end: 1.5rem !important;
 }
 
 .edac-ml-1 {
-	margin-left: 0.5rem !important;
+	margin-inline-start: 0.5rem !important;
 }
 
 .edac-ml-3 {
-	margin-left: 1.5rem !important;
+	margin-inline-start: 1.5rem !important;
 }
 
 .edac-mr-1 {
-	margin-right: 0.5rem !important;
+	margin-inline-end: 0.5rem !important;
 }
 
 .edac-mr-3 {
-	margin-right: 1.5rem !important;
+	margin-inline-end: 1.5rem !important;
 }
 
 
@@ -1366,10 +1363,10 @@
 	.edac-modal {
 
 		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
+		inset-block-start: 0;
+		inset-inline-start: 0;
+		inline-size: 100%;
+		block-size: 100%;
 		background-color: rgba(0, 0, 0, 0.5);
 		z-index: 1000;
 
@@ -1386,8 +1383,8 @@
 			align-items: center;
 
 			background-color: #fff;
-			width: 80%;
-			max-width: 500px;
+			inline-size: 80%;
+			max-inline-size: 500px;
 
 			//  margin: 40px auto 40px;
 			padding: 1.5rem;
@@ -1395,8 +1392,8 @@
 
 			&-close {
 				position: absolute;
-				top: 0;
-				right: 0.5rem;
+				inset-block-start: 0;
+				inset-inline-end: 0.5rem;
 				font-size: variables.$font-size-x-large;
 				cursor: pointer;
 				padding: 0;
@@ -1418,8 +1415,8 @@
 		&::before {
 			content: "";
 			display: inline-block;
-			width: 24px;
-			height: 24px;
+			inline-size: 24px;
+			block-size: 24px;
 			flex-shrink: 0;
 			/* stylelint-disable-next-line function-url-quotes */
 			background-image: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(%23clip0_0_1)"><path d="M11.6841 23.0679C17.9712 23.0679 23.0679 17.9712 23.0679 11.6841C23.0679 5.39699 17.9712 0.300293 11.6841 0.300293C5.39698 0.300293 0.300285 5.39699 0.300285 11.6841C0.300285 17.9712 5.39698 23.0679 11.6841 23.0679Z" fill="white"/><path d="M11.6808 0.689766C17.8291 0.689871 22.8136 5.67427 22.8136 11.8226C22.8135 17.9708 17.829 22.9553 11.6808 22.9554C5.53246 22.9554 0.548063 17.9709 0.547958 11.8226C0.547958 5.6742 5.5324 0.689766 11.6808 0.689766Z" fill="%23FACB00" stroke="%23002449"/><path d="M18.0318 8.24537C18.0318 7.92632 17.7899 7.66565 17.4917 7.66565H15.7067L15.3 8.39551H17.3499V14.9851H5.73673V8.39551H11.8655L12.27 7.66565H5.59492C5.29672 7.66565 5.05482 7.92423 5.05482 8.24537V15.7192H18.0318V8.24537Z" fill="%23002449"/><path d="M11.1878 13.5254L7.7866 10.4537H9.11286L10.9563 12.0845L14.2448 6.28725H15.3L11.1878 13.5254Z" fill="%23002449"/><path d="M12.952 16.4887L12.8018 16.7806H10.2848L10.1347 16.4887H3.6952C3.6952 16.9453 4.04136 17.3144 4.46677 17.3144H18.622C19.0474 17.3144 19.3935 16.9453 19.3935 16.4887H12.954H12.952Z" fill="%23002449"/></g><defs><clipPath id="clip0_0_1"><rect width="23.4411" height="24" fill="white"/></clipPath></defs></svg>');
@@ -1441,7 +1438,7 @@
 
 		&-header {
 			display: flex;
-			width: 100%;
+			inline-size: 100%;
 			text-align: start;
 
 			&-label {
@@ -1463,8 +1460,8 @@
 				flex-direction: column;
 				justify-content: center;
 				align-items: center;
-				width: 150px;
-				height: 150px;
+				inline-size: 150px;
+				block-size: 150px;
 				border-radius: 50%;
 				margin: auto;
 
@@ -1482,7 +1479,7 @@
 		}
 
 		&-metadata {
-			width: 100%;
+			inline-size: 100%;
 			padding: 0.5rem 0 1rem;
 			font-size: variables.$font-size-small;
 
@@ -1632,7 +1629,7 @@
 					}
 
 					&-number {
-						margin-left: auto;
+						margin-inline-start: auto;
 						font-size: variables.$font-size-small;
 						font-weight: 600;
 					}
@@ -1662,7 +1659,7 @@
 			text-align: center;
 
 			a {
-				width: 100%;
+				inline-size: 100%;
 			}
 		}
 	}
@@ -1680,7 +1677,7 @@
 	}
 
 	.edac-widget-footer-link-list-spacer {
-		border-left: 2px solid #ccc;
+		border-inline-start: 2px solid #ccc;
 		padding: 0;
 		margin: 0;
 	}
@@ -1701,11 +1698,11 @@
 	}
 
 	.edac-welcome-aside > div {
-		width: 200px;
+		inline-size: 200px;
 	}
 
 	.edac-welcome-aside > div.edac-has-cta {
-		width: 320px;
+		inline-size: 320px;
 	}
 
 	.edac-upcoming-meetup {
@@ -1732,13 +1729,13 @@
 			}
 
 			.edac-welcome-aside > div {
-				width: unset;
+				inline-size: unset;
 			}
 		}
 	}
 
 	section {
-		border-bottom: 1px solid #e2e4e7;
+		border-block-end: 1px solid #e2e4e7;
 		padding: 2rem;
 	}
 
@@ -1750,7 +1747,7 @@
 			text-align: end;
 
 			img {
-				width: 200px;
+				inline-size: 200px;
 			}
 		}
 
@@ -1781,7 +1778,7 @@
 			background-repeat: no-repeat;
 			background-size: cover;
 			background-position: top left;
-			min-height: 300px;
+			min-block-size: 300px;
 
 			@media screen and (max-width: calc(variables.$medium-screen-width - 1px)) {
 				background-image: url(../images/welcome-screenshot-medium.png);
@@ -1815,13 +1812,13 @@
 
 			.edac-inner-row:nth-child(1) {
 				align-items: flex-end;
-				height: 50%;
+				block-size: 50%;
 			}
 
 			.edac-inner-row:nth-child(2) {
-				margin-top: 0.5rem;
+				margin-block-start: 0.5rem;
 				align-items: flex-start;
-				height: 50%;
+				block-size: 50%;
 			}
 
 			background-color: variables.$color-gray-lightest;
@@ -1842,13 +1839,13 @@
 
 			.edac-inner-row:nth-child(2) {
 				align-items: flex-end;
-				height: 50%;
+				block-size: 50%;
 			}
 
 			.edac-inner-row:nth-child(3) {
-				margin-top: 0.5rem;
+				margin-block-start: 0.5rem;
 				align-items: flex-start;
-				height: 50%;
+				block-size: 50%;
 			}
 		}
 
@@ -1857,8 +1854,8 @@
 			flex-direction: column;
 			justify-content: center;
 			align-items: center;
-			width: 250px;
-			height: 250px;
+			inline-size: 250px;
+			block-size: 250px;
 			border-radius: 50%;
 			margin: auto;
 
@@ -1884,19 +1881,19 @@
 
 		.edac-welcome-grid-item .edac-icon {
 			position: absolute;
-			top: 10px;
-			left: 10px;
+			inset-block-start: 10px;
+			inset-inline-start: 10px;
 			display: inline-flex;
 			align-items: center;
 			justify-content: center;
 
 			svg {
-				width: 27px;
-				height: 27px;
+				inline-size: 27px;
+				block-size: 27px;
 
 				@include helpers.breakpoint(xl) {
-					width: 37px;
-					height: 37px;
+					inline-size: 37px;
+					block-size: 37px;
 				}
 			}
 		}
@@ -2064,7 +2061,7 @@
 		}
 
 		.edac-modal-content {
-			min-height: 200px;
+			min-block-size: 200px;
 			border: solid 1px variables.$color-gray-light;
 			padding: 0 1rem;
 		}
@@ -2077,10 +2074,10 @@
 
 	.edac-pro-callout-icon {
 		position: absolute;
-		top: -25px;
-		left: 50%;
+		inset-block-start: -25px;
+		inset-inline-start: 50%;
 		transform: translateX(-50%);
-		max-width: 50px;
+		max-inline-size: 50px;
 	}
 
 	.edac-support-section {
@@ -2100,11 +2097,11 @@
 				padding: 1rem;
 
 				h3 {
-					margin-top: 0;
+					margin-block-start: 0;
 				}
 
 				p:last-child {
-					margin-bottom: 0;
+					margin-block-end: 0;
 				}
 			}
 		}
@@ -2116,12 +2113,9 @@
 
 	.edac-panel-loading::before {
 		background-color: hsla(0, 0%, 100%, 0.5);
-		bottom: 0;
 		content: "";
-		left: 0;
 		position: absolute;
-		right: 0;
-		top: 0;
+		inset: 0;
 		z-index: 9;
 	}
 }

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -1138,13 +1138,13 @@
 				content: url(../images/list-check.png);
 				height: 21px;
 				width: 21px;
-				margin-right: 18px;
+				margin-inline-end: 18px;
 				display: inline-block;
 				vertical-align: middle;
 				line-height: normal;
 				position: absolute;
-				left: -35px;
-				top: -1px;
+				inset-inline-start: -35px;
+				inset-block-start: -1px;
 			}
 		}
 	}

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -2078,6 +2078,10 @@
 		inset-inline-start: 50%;
 		transform: translateX(-50%);
 		max-inline-size: 50px;
+
+		[dir="rtl"] & {
+			transform: translateX(50%);
+		}
 	}
 
 	.edac-support-section {

--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -322,7 +322,7 @@
 
 				@include helpers.breakpoint(lg) {
 					width: calc(50% - 12px);
-					float: right;
+					float: inline-end;
 				}
 
 				@include helpers.breakpoint(xl) {
@@ -432,7 +432,7 @@
 
 					img {
 						display: block;
-						float: right;
+						float: inline-end;
 					}
 				}
 			}

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -144,6 +144,10 @@
 	border-radius: 5px;
 	box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 
+	[dir="rtl"] & {
+		transform: translate(50%, -50%);
+	}
+
 	// stylelint-disable selector-pseudo-element-colon-notation
 	.dashicons,
 	.dashicons-before:before {

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -1,9 +1,9 @@
 @use "variables";
 
 .edac-fix-modal-present #TB_ajaxContent {
-	width: auto !important;
-	height: auto !important;
-	max-height: 70vh !important;
+	inline-size: auto !important;
+	block-size: auto !important;
+	max-block-size: 70vh !important;
 	overflow-y: auto;
 }
 
@@ -18,13 +18,13 @@
 
 		label {
 			display: block;
-			margin-bottom: 1rem;
+			margin-block-end: 1rem;
 		}
 
 		input,
 		select,
 		textarea {
-			width: 100%;
+			inline-size: 100%;
 			padding: 0.5rem;
 			margin: 0.25rem 0;
 			border: 1px solid #ccc;
@@ -36,7 +36,7 @@
 			border-radius: 5px;
 			margin: 0 0.5rem 0 0;
 			padding: 0 !important;
-			width: auto;
+			inline-size: auto;
 
 			// stylelint-disable-next-line selector-pseudo-element-colon-notation
 			&:before {
@@ -47,8 +47,8 @@
 			&:checked:before {
 				content: url(data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%233582c4%27%2F%3E%3C%2Fsvg%3E);
 				margin: -0.1875rem -0.25rem 0 -0.25rem;
-				height: 1.3125rem;
-				width: 1.3125rem;
+				block-size: 1.3125rem;
+				inline-size: 1.3125rem;
 			}
 		}
 
@@ -83,7 +83,7 @@
 
 		.modal-opening-message {
 			padding: 0;
-			margin-bottom: 0;
+			margin-block-end: 0;
 		}
 
 	}
@@ -93,7 +93,7 @@
 		display: flex;
 		gap: 0.5rem;
 		align-items: center;
-		margin-top: 1rem;
+		margin-block-start: 1rem;
 	}
 
 	&--button {
@@ -132,11 +132,11 @@
 
 	display: none;
 	position: fixed;
-	top: 50%;
-	left: 50%;
+	inset-block-start: 50%;
+	inset-inline-start: 50%;
 	transform: translate(-50%, -50%);
 	z-index: 10000000001;
-	max-height: 90vh;
+	max-block-size: 90vh;
 	overflow: auto;
 
 	background: #fff;
@@ -160,8 +160,8 @@
 		text-rendering: auto;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
-		width: 20px;
-		height: 20px;
+		inline-size: 20px;
+		block-size: 20px;
 		font-size: 20px;
 		vertical-align: top;
 		text-align: center;
@@ -170,12 +170,12 @@
 
 	&__overlay {
 		display: none;
-		height: 100vh;
-		width: 100%;
+		block-size: 100vh;
+		inline-size: 100%;
 		background-color: #000000b0;
 		position: fixed;
-		top: 0;
-		left: 0;
+		inset-block-start: 0;
+		inset-inline-start: 0;
 		z-index: 10000000000;
 	}
 
@@ -187,12 +187,12 @@
 	//}
 
 	&__header {
-		margin-bottom: 0.5rem;
+		margin-block-end: 0.5rem;
 
 		h2 {
 			font-size: 1.25rem;
 			font-weight: 600;
-			margin-bottom: 0;
+			margin-block-end: 0;
 			align-self: center;
 			display: block;
 		}
@@ -201,18 +201,18 @@
 	h3 {
 		font-size: 1.1rem;
 		font-weight: 600;
-		margin-bottom: 0.5rem;
+		margin-block-end: 0.5rem;
 		display: block;
 	}
 
 	&__close {
 		border: none;
 		cursor: pointer;
-		height: 35px;
-		width: 35px;
+		block-size: 35px;
+		inline-size: 35px;
 		position: absolute;
-		top: 8px;
-		right: 8px;
+		inset-block-start: 8px;
+		inset-inline-end: 8px;
 		color: variables.$color-blue-dark;
 		background: transparent;
 		border-radius: 2px;

--- a/src/emailOptIn/sass/email-opt-in.scss
+++ b/src/emailOptIn/sass/email-opt-in.scss
@@ -3,7 +3,7 @@
 	margin: 0;
 
 	input {
-		width: 100%;
+		inline-size: 100%;
 	}
 
 	._button-wrapper {
@@ -12,13 +12,13 @@
 		justify-content: flex-start;
 		gap: 1rem;
 		align-items: center;
-		margin-top: 0;
+		margin-block-start: 0;
 
 		.edac-welcome-aside & {
 			flex-direction: column;
 
 			button {
-				width: 100%;
+				inline-size: 100%;
 			}
 		}
 	}

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -10,8 +10,8 @@
 // Uses !important so the styles survive the panel's `* { all: unset }` reset.
 .edac-sr-only {
 	position: absolute !important;
-	width: 1px !important;
-	height: 1px !important;
+	inline-size: 1px !important;
+	block-size: 1px !important;
 	padding: 0 !important;
 	margin: -1px !important;
 	overflow: hidden !important;
@@ -54,19 +54,19 @@ body {
 		box-shadow: 0 0 0 8px variables.$color-white !important;
 
 		&-min-width {
-			min-width: 25px !important;
+			min-inline-size: 25px !important;
 			display: inline-block !important;
 		}
 
 		&-min-height {
-			min-height: 16px !important;
+			min-block-size: 16px !important;
 		}
 	}
 
 	&-btn {
 		all: unset;
-		width: 40px !important;
-		height: 40px !important;
+		inline-size: 40px !important;
+		block-size: 40px !important;
 		display: block !important;
 		font-size: 0 !important;
 		border-radius: 50% !important;
@@ -96,16 +96,16 @@ body {
 
 	&-panel {
 
-		width: auto;
-		max-width: 400px !important;
+		inline-size: auto;
+		max-inline-size: 400px !important;
 		position: fixed !important;
 		z-index: 2147483647 !important;
-		bottom: 15px !important;
+		inset-block-end: 15px !important;
 		font-weight: 400 !important;
 
 		@media screen and (max-width: variables.$small-screen-width) {
-			width: 100%;
-			max-width: calc(100% - 30px) !important;
+			inline-size: 100%;
+			max-inline-size: calc(100% - 30px) !important;
 		}
 
 		@media screen and (max-width: variables.$extra-small-screen-width) {
@@ -116,7 +116,7 @@ body {
 
 				button {
 					padding: 4px 7px !important;
-					margin-right: 0 !important;
+					margin-inline-end: 0 !important;
 				}
 			}
 
@@ -130,7 +130,7 @@ body {
 
 				button {
 					padding: 4px 7px !important;
-					margin-right: 0 !important;
+					margin-inline-end: 0 !important;
 				}
 			}
 
@@ -147,47 +147,43 @@ body {
 		}
 
 		&--right {
-			right: 15px !important;
+			inset-inline-end: 15px !important;
 		}
 
 		&--left {
-			left: 15px !important;
+			inset-inline-start: 15px !important;
 		}
 
 		&--docked {
-			bottom: 0 !important;
-			right: 0 !important;
-			left: 0 !important;
-			max-width: none !important;
-			width: auto !important;
+			inset-block-end: 0 !important;
+			inset-inline: 0 !important;
+			max-inline-size: none !important;
+			inline-size: auto !important;
 
 			&.edac-highlight-panel--right {
-				right: 0 !important;
-				left: auto !important;
+				inset-inline: auto 0 !important;
 			}
 
 			&.edac-highlight-panel--left {
-				left: 0 !important;
-				right: auto !important;
+				inset-inline: 0 auto !important;
 			}
 
 			.edac-highlight-panel-controls {
 				position: fixed !important;
-				top: var(--edac-adminbar-height, 0) !important;
-				bottom: 0 !important;
-				height: calc(100vh - var(--edac-adminbar-height, 0px)) !important;
-				max-height: calc(100vh - var(--edac-adminbar-height, 0px)) !important;
-				width: min(400px, 100vw) !important;
-				min-width: 0 !important;
-				max-width: 100vw !important;
+				inset-block: var(--edac-adminbar-height, 0) 0 !important;
+				block-size: calc(100vh - var(--edac-adminbar-height, 0px)) !important;
+				max-block-size: calc(100vh - var(--edac-adminbar-height, 0px)) !important;
+				inline-size: min(400px, 100vw) !important;
+				min-inline-size: 0 !important;
+				max-inline-size: 100vw !important;
 				border-radius: 0 !important;
 				box-shadow: none !important;
-				border-left: 1px solid variables.$color-gray-light !important;
+				border-inline-start: 1px solid variables.$color-gray-light !important;
 			}
 
 			&.edac-highlight-panel--left .edac-highlight-panel-controls {
-				border-left: none !important;
-				border-right: 1px solid variables.$color-gray-light !important;
+				border-inline-start: none !important;
+				border-inline-end: 1px solid variables.$color-gray-light !important;
 			}
 
 			// Hide the header grab cursor in docked mode.
@@ -197,12 +193,12 @@ body {
 		}
 
 		&-visible {
-			width: 400px !important;
+			inline-size: 400px !important;
 		}
 
 		&-toggle {
-			width: 50px !important;
-			height: 50px !important;
+			inline-size: 50px !important;
+			block-size: 50px !important;
 			display: block;
 			background: transparent url(../images/edac-emblem.png) center center no-repeat !important;
 			background-size: contain !important;
@@ -219,7 +215,7 @@ body {
 			@media screen and (max-width: variables.$small-screen-width) {
 
 				.edac-highlight-panel--right & {
-					float: right !important;
+					float: inline-end !important;
 				}
 			}
 		}
@@ -304,8 +300,8 @@ body {
 
 				svg {
 					display: block !important;
-					width: 16px !important;
-					height: 16px !important;
+					inline-size: 16px !important;
+					block-size: 16px !important;
 					overflow: visible !important;
 					stroke: currentcolor !important;
 					fill: none !important;
@@ -322,7 +318,7 @@ body {
 				flex-wrap: wrap !important;
 				gap: 8px !important;
 				font-weight: 700 !important;
-				margin-bottom: 5px !important;
+				margin-block-end: 5px !important;
 
 				&-text {
 					font-weight: 700 !important;
@@ -334,7 +330,7 @@ body {
 				align-items: center !important;
 				flex-wrap: wrap !important;
 				gap: 8px !important;
-				margin-bottom: 10px !important;
+				margin-block-end: 10px !important;
 				font-size: 12px !important;
 
 				&-label {
@@ -347,7 +343,7 @@ body {
 				display: flex !important;
 				flex-direction: column !important;
 				gap: 8px !important;
-				margin-bottom: 12px !important;
+				margin-block-end: 12px !important;
 			}
 
 			&-meta-row {
@@ -359,7 +355,7 @@ body {
 
 			&-meta-label {
 				font-weight: 700 !important;
-				min-width: 70px !important;
+				min-inline-size: 70px !important;
 				flex-shrink: 0 !important;
 				font-size: 13px !important;
 			}
@@ -369,11 +365,11 @@ body {
 				padding: 5px 7px !important;
 				border-radius: 4px !important;
 				line-height: 12px !important;
-				margin-left: 10px !important;
+				margin-inline-start: 10px !important;
 				display: inline-block !important;
 				text-transform: capitalize !important;
 				position: relative !important;
-				top: -2px !important;
+				inset-block-start: -2px !important;
 
 				&-error {
 					color: variables.$color-white !important;
@@ -395,14 +391,14 @@ body {
 				font-size: 16px !important;
 				display: block !important;
 				font-weight: 700 !important;
-				margin-bottom: 5px !important;
+				margin-block-end: 5px !important;
 			}
 
 			&-notice {
 				display: block !important;
-				margin-bottom: 10px !important;
+				margin-block-end: 10px !important;
 				padding: 8px 12px !important;
-				border-left: 4px solid variables.$color-yellow !important;
+				border-inline-start: 4px solid variables.$color-yellow !important;
 				background-color: rgba(variables.$color-yellow, 0.15) !important;
 				color: #1e1e1e !important;
 				font-size: 13px !important;
@@ -415,7 +411,7 @@ body {
 				display: flex !important;
 				align-items: center !important;
 				gap: 2px !important;
-				margin-top: 8px !important;
+				margin-block-start: 8px !important;
 				font-size: 13px !important;
 				color: variables.$color-blue !important;
 				cursor: pointer !important;
@@ -447,8 +443,8 @@ body {
 				background-color: variables.$color-blue !important;
 				padding: 8px 13px !important;
 				display: inline-block !important;
-				margin-top: 10px !important;
-				margin-right: 10px !important;
+				margin-block-start: 10px !important;
+				margin-inline-end: 10px !important;
 				border-radius: 2px !important;
 
 				&:hover {
@@ -494,19 +490,19 @@ body {
 				border-radius: 3px !important;
 				padding: 10px 15px !important;
 				display: none;
-				margin-top: 10px !important;
+				margin-block-start: 10px !important;
 			}
 
 			&-close {
-				width: 25px !important;
-				height: 25px !important;
+				inline-size: 25px !important;
+				block-size: 25px !important;
 				color: variables.$color-blue-dark !important;
 				background-color: variables.$color-yellow !important;
 				font-size: 18px !important;
 				line-height: 25px !important;
 				position: absolute !important;
-				top: 1px !important;
-				right: 1px !important;
+				inset-block-start: 1px !important;
+				inset-inline-end: 1px !important;
 				text-align: center !important;
 
 				&:hover,
@@ -527,7 +523,7 @@ body {
 				display: flex !important;
 				align-items: center !important;
 				gap: 2px !important;
-				margin-top: 8px !important;
+				margin-block-start: 8px !important;
 				font-size: 13px !important;
 				color: variables.$color-blue !important;
 				cursor: pointer !important;
@@ -575,14 +571,13 @@ body {
 
 			&-how-to-fix {
 				display: block !important;
-				margin-bottom: 0 !important;
-				margin-top: 12px !important;
+				margin-block: 12px 0 !important;
 
 				&-title {
 					display: block !important;
 					font-size: 15px !important;
 					font-weight: 700 !important;
-					margin-bottom: 5px !important;
+					margin-block-end: 5px !important;
 				}
 			}
 		}
@@ -592,7 +587,7 @@ body {
 			background-color: variables.$color-white !important;
 			display: none;
 			flex-direction: column !important;
-			max-height: calc(100vh - 80px) !important;
+			max-block-size: calc(100vh - 80px) !important;
 			box-shadow: 0 4px 20px rgba(variables.$color-black, 0.35) !important;
 			border-radius: 10px !important;
 			overflow: hidden !important;
@@ -640,8 +635,8 @@ body {
 				&-icon {
 					display: inline-block !important;
 					flex-shrink: 0 !important;
-					width: 24px !important;
-					height: 24px !important;
+					inline-size: 24px !important;
+					block-size: 24px !important;
 					background-image: url("data:image/svg+xml;utf8,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><g clip-path='url(%23clip0_0_1)'><path d='M11.6841 23.0679C17.9712 23.0679 23.0679 17.9712 23.0679 11.6841C23.0679 5.39699 17.9712 0.300293 11.6841 0.300293C5.39698 0.300293 0.300285 5.39699 0.300285 11.6841C0.300285 17.9712 5.39698 23.0679 11.6841 23.0679Z' fill='white'/><path d='M11.6808 0.689766C17.8291 0.689871 22.8136 5.67427 22.8136 11.8226C22.8135 17.9708 17.829 22.9553 11.6808 22.9554C5.53246 22.9554 0.548063 17.9709 0.547958 11.8226C0.547958 5.6742 5.5324 0.689766 11.6808 0.689766Z' fill='%23FACB00' stroke='%23002449'/><path d='M18.0318 8.24537C18.0318 7.92632 17.7899 7.66565 17.4917 7.66565H15.7067L15.3 8.39551H17.3499V14.9851H5.73673V8.39551H11.8655L12.27 7.66565H5.59492C5.29672 7.66565 5.05482 7.92423 5.05482 8.24537V15.7192H18.0318V8.24537Z' fill='%23002449'/><path d='M11.1878 13.5254L7.7866 10.4537H9.11286L10.9563 12.0845L14.2448 6.28725H15.3L11.1878 13.5254Z' fill='%23002449'/><path d='M12.952 16.4887L12.8018 16.7806H10.2848L10.1347 16.4887H3.6952C3.6952 16.9453 4.04136 17.3144 4.46677 17.3144H18.622C19.0474 17.3144 19.3935 16.9453 19.3935 16.4887H12.954H12.952Z' fill='%23002449'/></g><defs><clipPath id='clip0_0_1'><rect width='23.4411' height='24' fill='white'/></clipPath></defs></svg>") !important;
 					background-repeat: no-repeat !important;
 					background-size: contain !important;
@@ -653,8 +648,8 @@ body {
 				display: flex !important;
 				align-items: center !important;
 				justify-content: center !important;
-				width: 28px !important;
-				height: 28px !important;
+				inline-size: 28px !important;
+				block-size: 28px !important;
 				color: variables.$color-white !important;
 				font-size: 18px !important;
 				cursor: pointer !important;
@@ -671,12 +666,12 @@ body {
 				flex: 1 !important;
 				overflow-y: auto !important;
 				padding: 15px !important;
-				border-bottom: solid 1px variables.$color-gray-light !important;
+				border-block-end: solid 1px variables.$color-gray-light !important;
 
 				&-empty {
 					margin: 15px !important;
 					padding: 8px 12px !important;
-					border-left: 4px solid variables.$color-yellow !important;
+					border-inline-start: 4px solid variables.$color-yellow !important;
 					background-color: rgba(variables.$color-yellow, 0.15) !important;
 					color: #1e1e1e !important;
 					font-size: 13px !important;
@@ -691,7 +686,7 @@ body {
 
 			&-footer {
 				flex-shrink: 0 !important;
-				border-top: solid 1px variables.$color-gray-light !important;
+				border-block-start: solid 1px variables.$color-gray-light !important;
 			}
 
 			&-summary {
@@ -708,7 +703,7 @@ body {
 					display: block !important;
 					font-size: 12px !important;
 					opacity: 0.85 !important;
-					margin-top: 2px !important;
+					margin-block-start: 2px !important;
 				}
 			}
 
@@ -727,7 +722,7 @@ body {
 					padding: 8px 13px !important;
 					display: inline-block !important;
 					flex-shrink: 0 !important;
-					width: 80px !important;
+					inline-size: 80px !important;
 					text-align: center !important;
 					border-radius: 2px !important;
 
@@ -767,8 +762,8 @@ body {
 				display: flex !important;
 				align-items: center !important;
 				justify-content: center !important;
-				width: 28px !important;
-				height: 28px !important;
+				inline-size: 28px !important;
+				block-size: 28px !important;
 				color: variables.$color-white !important;
 				font-size: 18px !important;
 				cursor: pointer !important;
@@ -786,13 +781,13 @@ body {
 				all: unset !important;
 				display: block !important;
 				position: absolute !important;
-				top: calc(100% + 6px) !important;
-				right: 0 !important;
+				inset-block-start: calc(100% + 6px) !important;
+				inset-inline-end: 0 !important;
 				background-color: variables.$color-white !important;
 				list-style: none !important;
 				margin: 0 !important;
 				padding: 6px !important;
-				min-width: 200px !important;
+				min-inline-size: 200px !important;
 				z-index: 10 !important;
 				box-shadow: 0 4px 16px rgba(variables.$color-black, 0.15) !important;
 				border-radius: 8px !important;
@@ -813,7 +808,7 @@ body {
 					display: flex !important;
 					align-items: center !important;
 					justify-content: space-between !important;
-					width: 100% !important;
+					inline-size: 100% !important;
 					box-sizing: border-box !important;
 					color: #1e1e1e !important;
 					padding: 8px 10px !important;
@@ -846,7 +841,7 @@ body {
 }
 
 .notyf__toast {
-	max-width: 100% !important;
+	max-inline-size: 100% !important;
 }
 
 .notyf__message {
@@ -862,7 +857,7 @@ body {
 
 .edac-accessibility-statement {
 	text-align: center;
-	max-width: 800px;
+	max-inline-size: 800px;
 	margin: auto;
 	padding: 15px;
 }
@@ -887,7 +882,7 @@ body {
 // stylelint-disable-next-line no-duplicate-selectors
 .edac-fixes-modal {
 	display: none;
-	width: 650px;
+	inline-size: 650px;
 	-webkit-font-smoothing: antialiased !important;
 	-moz-osx-font-smoothing: grayscale !important;
 	background-color: #fff !important;
@@ -897,16 +892,16 @@ body {
 	font-family: sans-serif !important;
 	font-size: 14px !important;
 	line-height: 22px !important;
-	margin-bottom: 15px !important;
-	max-height: calc(100vh - 230px) !important;
+	margin-block-end: 15px !important;
+	max-block-size: calc(100vh - 230px) !important;
 	overflow-y: auto !important;
 	padding: 40px !important;
-	text-align: left !important;
+	text-align: start !important;
 	letter-spacing: initial !important;
 
 	@media screen and (max-width: variables.$medium-screen-width) {
-		width: 100% !important;
-		max-width: calc(100% - 30px) !important;
+		inline-size: 100% !important;
+		max-inline-size: calc(100% - 30px) !important;
 		padding: 20px !important;
 	}
 
@@ -917,15 +912,15 @@ body {
 
 	h3 {
 		font-size: 1.1em;
-		margin-bottom: 0.5em;
+		margin-block-end: 0.5em;
 	}
 
 	label {
-		margin-bottom: 0.75em;
+		margin-block-end: 0.75em;
 	}
 
 	&__header {
-		margin-bottom: 0.25em;
+		margin-block-end: 0.25em;
 	}
 
 	&__close,
@@ -952,7 +947,7 @@ body {
 
 			&--action-row {
 				gap: 0.5em;
-				margin-top: 0.75em;
+				margin-block-start: 0.75em;
 			}
 
 			&--button--save {
@@ -980,7 +975,7 @@ body {
 
 	.modal-opening-message {
 		display: inline-block;
-		margin-bottom: 0.5em !important;
+		margin-block-end: 0.5em !important;
 	}
 
 	*:focus {
@@ -1014,7 +1009,7 @@ body {
 
 	&--action-open {
 		display: inline-block;
-		width: 100%;
+		inline-size: 100%;
 	}
 
 	&--notice-slot a {
@@ -1034,8 +1029,8 @@ body {
 .edac-menu-icon {
 	display: inline-block !important;
 	flex-shrink: 0 !important;
-	width: 16px !important;
-	height: 16px !important;
+	inline-size: 16px !important;
+	block-size: 16px !important;
 	background-color: currentcolor !important;
 	mask-repeat: no-repeat !important;
 	mask-size: contain !important;

--- a/src/issueModal/sass/_dismiss-panel.scss
+++ b/src/issueModal/sass/_dismiss-panel.scss
@@ -13,11 +13,11 @@
 
 // Radio reason picker inside the dismiss panel.
 .edac-analysis__dismiss-panel {
-	margin-top: 16px;
+	margin-block-start: 16px;
 
 	.components-base-control__label {
 		font-size: $modal-font-size-small;
-		margin-bottom: 0.75em;
+		margin-block-end: 0.75em;
 		text-transform: none;
 	}
 
@@ -28,13 +28,13 @@
 	}
 
 	.components-radio-control__group-wrapper {
-		margin-bottom: 24px;
+		margin-block-end: 24px;
 	}
 }
 
 // Already-dismissed state: shows who dismissed, when, and why.
 .edac-analysis__dismissed-comment {
-	margin-top: 16px;
+	margin-block-start: 16px;
 
 	&-label {
 		font-weight: 600;
@@ -71,22 +71,22 @@
 
 // Action buttons shown in the already-dismissed state.
 .edac-analysis__dismissed-actions {
-	margin-top: 20px;
-	padding-top: 16px;
-	border-top: 1px solid $outline-grey;
+	margin-block-start: 20px;
+	padding-block-start: 16px;
+	border-block-start: 1px solid $outline-grey;
 
 	.edac-analysis__dismiss-button {
-		margin-top: 0;
+		margin-block-start: 0;
 	}
 }
 
 // Primary dismiss/restore button.
 // stylelint-disable-next-line no-descending-specificity
 .edac-analysis__dismiss-button {
-	margin-top: 12px;
+	margin-block-start: 12px;
 
 	.components-spinner {
-		margin-right: 8px;
+		margin-inline-end: 8px;
 	}
 }
 
@@ -101,6 +101,6 @@
 
 	.edac-analysis__dismiss-dropdown-toggle {
 		border-radius: 0 2px 2px 0;
-		margin-left: 2px;
+		margin-inline-start: 2px;
 	}
 }

--- a/src/issueModal/sass/issue-modal.scss
+++ b/src/issueModal/sass/issue-modal.scss
@@ -29,7 +29,7 @@
 		}
 
 		.components-modal__header {
-			height: 60px;
+			block-size: 60px;
 			padding: 0 24px 0;
 
 			&-heading {
@@ -39,23 +39,23 @@
 
 		.components-modal__content {
 			padding: 16px 24px 24px;
-			margin-top: 60px;
+			margin-block-start: 60px;
 		}
 
 		.edac-analysis__modal-content {
-			margin-bottom: 16px;
+			margin-block-end: 16px;
 		}
 
 		// The className prop on Modal is applied to .components-modal__frame
 		// so we use &.components-modal__frame to match:
 		// .edac-analysis__issue-modal.components-modal__frame
 		&.components-modal__frame {
-			width: 890px;
-			max-width: 80%;
+			inline-size: 890px;
+			max-inline-size: 80%;
 
 			.components-modal__content {
 				padding: 0;
-				border-top: $outline-grey 1px solid;
+				border-block-start: $outline-grey 1px solid;
 			}
 		}
 
@@ -69,7 +69,7 @@
 				line-height: 1.5;
 
 				&:last-child {
-					margin-bottom: 0;
+					margin-block-end: 0;
 				}
 			}
 
@@ -80,20 +80,20 @@
 
 		.edac-analysis__issue-modal-left {
 			flex: 1;
-			min-width: 0;
+			min-inline-size: 0;
 			padding: 24px;
 		}
 
 		.edac-analysis__issue-modal-right {
-			width: 200px;
+			inline-size: 200px;
 			flex-shrink: 0;
 		}
 
 		.edac-analysis__issue-sidebar {
 			padding: 24px;
-			border-left: 1px solid $outline-grey;
+			border-inline-start: 1px solid $outline-grey;
 			background: #fafafa;
-			height: 100%;
+			block-size: 100%;
 		}
 
 		.edac-analysis__issue-sidebar-list {
@@ -123,12 +123,12 @@
 		}
 
 		.edac-analysis__issue-sidebar-button {
-			width: 100%;
+			inline-size: 100%;
 			justify-content: center;
 		}
 
 		.edac-analysis__issue-title {
-			margin-top: 0 !important;
+			margin-block-start: 0 !important;
 		}
 
 		.edac-analysis__issue-wcag {
@@ -172,7 +172,7 @@
 
 		.edac-analysis__issue-help-accordion {
 
-			margin-bottom: 21px;
+			margin-block-end: 21px;
 
 			.components-panel__body {
 				border: none;
@@ -197,7 +197,7 @@
 
 				button {
 					padding: 0;
-					width: auto;
+					inline-size: auto;
 					flex-direction: row-reverse;
 					text-decoration: underline;
 					color: $info-blue;
@@ -232,10 +232,10 @@
 			// Sections inside the accordion
 			.edac-analysis__issue-why-it-matters,
 			.edac-analysis__issue-how-to-fix {
-				margin-bottom: 16px;
+				margin-block-end: 16px;
 
 				&:last-child {
-					margin-bottom: 0;
+					margin-block-end: 0;
 				}
 
 				h4 {
@@ -291,7 +291,7 @@
 			}
 
 			.components-panel__body-title {
-				margin-bottom: 0;
+				margin-block-end: 0;
 
 				button {
 					padding: 12px 24px;
@@ -303,7 +303,7 @@
 			.components-panel__body.is-opened {
 
 				.components-panel__body-title button {
-					border-bottom: 1px solid $outline-grey;
+					border-block-end: 1px solid $outline-grey;
 				}
 			}
 		}
@@ -322,18 +322,18 @@
 			}
 
 			> :first-child {
-				margin-top: 16px;
+				margin-block-start: 16px;
 
 				.components-panel__body {
-					border-top: 1px solid $outline-grey;
-					border-bottom: 1px solid $outline-grey;
+					border-block-start: 1px solid $outline-grey;
+					border-block-end: 1px solid $outline-grey;
 				}
 			}
 
 			> :not(:first-child) {
 
 				.components-panel__body {
-					border-bottom: 1px solid $outline-grey;
+					border-block-end: 1px solid $outline-grey;
 				}
 			}
 
@@ -368,7 +368,7 @@
 		}
 
 		.edac-analysis__code-wrapper {
-			margin-top: 16px;
+			margin-block-start: 16px;
 
 			&::after {
 				content: "";
@@ -392,7 +392,7 @@
 		.edac-fix-card {
 
 			&:not(:last-child) {
-				margin-bottom: 24px;
+				margin-block-end: 24px;
 			}
 		}
 	}
@@ -417,9 +417,9 @@
 		// overflow: hidden is required for CSS resize to work (visible blocks
 		// the resize handle). CodeMirror's own .CodeMirror-scroll handles
 		// internal scrolling.
-		height: 160px;
-		min-height: 100px;
-		max-height: 600px;
+		block-size: 160px;
+		min-block-size: 100px;
+		max-block-size: 600px;
 		resize: vertical;
 		overflow: hidden;
 		border: 1px solid #ddd;
@@ -433,24 +433,24 @@
 	}
 
 	.edac-analysis__issue-image {
-		margin-top: 16px;
+		margin-block-start: 16px;
 
 		&-item {
-			max-width: 100%;
-			height: auto;
+			max-inline-size: 100%;
+			block-size: auto;
 			border: 1px solid #ddd;
 			border-radius: 4px;
-			margin-bottom: 8px;
+			margin-block-end: 8px;
 
 			&:last-child {
-				margin-bottom: 0;
+				margin-block-end: 0;
 			}
 		}
 
 		img {
-			max-width: 100%;
-			max-height: 300px;
-			height: auto;
+			max-inline-size: 100%;
+			max-block-size: 300px;
+			block-size: auto;
 			border: 1px solid #ddd;
 			border-radius: 4px;
 		}

--- a/src/issueModal/sass/rich-textarea.scss
+++ b/src/issueModal/sass/rich-textarea.scss
@@ -2,24 +2,24 @@
 
 .edac-rich-textarea-label {
 	display: block;
-	margin-bottom: 0.75em;
+	margin-block-end: 0.75em;
 	font-weight: 500;
 	font-size: $modal-font-size-small;
 	color: #1e1e1e;
 }
 
 .edac-rich-textarea {
-	width: 100%;
+	inline-size: 100%;
 	box-sizing: border-box;
 	padding: 12px;
-	margin-bottom: 0.75em;
+	margin-block-end: 0.75em;
 	border: 1px solid #e0e0e0;
 	border-radius: 4px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 	font-size: 14px;
 	line-height: 1.6;
-	min-height: 100px;
-	max-height: 300px;
+	min-block-size: 100px;
+	max-block-size: 300px;
 	overflow-y: auto;
 	resize: vertical;
 

--- a/src/sidebar/components/Panels/ReadabilityAnalysis.js
+++ b/src/sidebar/components/Panels/ReadabilityAnalysis.js
@@ -236,7 +236,7 @@ const ReadabilityAnalysis = () => {
 			onToggle={ handlePanelToggle }
 		>
 			{ notice && (
-				<div style={ { marginTop: '16px' } }>
+				<div style={ { marginBlockStart: '16px' } }>
 					<Notice
 						status={ notice.type }
 						isDismissible={ true }

--- a/src/sidebar/sass/components/accessibility-analysis-tabs.scss
+++ b/src/sidebar/sass/components/accessibility-analysis-tabs.scss
@@ -9,10 +9,9 @@
 		// TabPanel's tab list wrapper
 		.components-tab-panel__tabs {
 			display: flex;
-			margin-bottom: 0;
-			border-bottom: 1px solid #ddd;
-			margin-left: -16px;
-			margin-right: -16px;
+			margin-block-end: 0;
+			border-block-end: 1px solid #ddd;
+			margin-inline: -16px;
 		}
 
 		// Individual tab buttons
@@ -25,7 +24,7 @@
 			padding: 24px 8px;
 			border: none;
 			border-radius: 0;
-			border-left: 1px solid $outline-grey;
+			border-inline-start: 1px solid $outline-grey;
 			background: transparent;
 			color: $subtext-gray;
 			font-size: $sidebar-font-size-large;
@@ -36,7 +35,7 @@
 
 			// First tab has no left border
 			&:first-child {
-				border-left: none;
+				border-inline-start: none;
 			}
 
 			&:hover {

--- a/src/sidebar/sass/components/accessibility-analysis.scss
+++ b/src/sidebar/sass/components/accessibility-analysis.scss
@@ -9,7 +9,7 @@
 	&-panel {
 
 		.components-panel__body.is-opened {
-			padding-bottom: 0;
+			padding-block-end: 0;
 		}
 	}
 
@@ -24,8 +24,7 @@
 	&__panel {
 		display: flex;
 		flex-direction: column;
-		margin-left: -16px;
-		margin-right: -16px;
+		margin-inline: -16px;
 	}
 
 	&__message {
@@ -60,7 +59,7 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 8px;
-		width: 100%;
+		inline-size: 100%;
 		padding: 12px;
 		border: none;
 		background: transparent;
@@ -77,8 +76,8 @@
 
 	&__group-icon {
 		flex-shrink: 0;
-		width: 20px;
-		height: 20px;
+		inline-size: 20px;
+		block-size: 20px;
 		color: #666;
 		order: 10; // Move chevron to the right
 	}
@@ -104,7 +103,7 @@
 		list-style: none;
 		margin: 0;
 		padding: 0;
-		border-top: 1px solid #ddd;
+		border-block-start: 1px solid #ddd;
 		background: #fafafa;
 	}
 
@@ -123,12 +122,12 @@
 		justify-content: space-between;
 		padding: 0 8px;
 		font-size: $sidebar-font-size-medium;
-		border-bottom: 1px solid #ddd;
-		margin-bottom: 0;
+		border-block-end: 1px solid #ddd;
+		margin-block-end: 0;
 
 		&:last-child {
-			border-bottom: none;
-			margin-bottom: 0;
+			border-block-end: none;
+			margin-block-end: 0;
 		}
 	}
 
@@ -158,17 +157,17 @@
 	}
 
 	&__rule {
-		border-bottom: 1px solid $outline-grey;
+		border-block-end: 1px solid $outline-grey;
 
 		&:last-child {
-			border-bottom: none;
+			border-block-end: none;
 		}
 	}
 
 	&__rule-toggle {
 		display: flex;
 		align-items: center;
-		width: 100%;
+		inline-size: 100%;
 		background: none;
 		border: none;
 		cursor: pointer;
@@ -176,8 +175,8 @@
 		font-size: $sidebar-font-size-large;
 		font-weight: 500;
 		color: $info-grey;
-		min-height: auto;
-		height: auto;
+		min-block-size: auto;
+		block-size: auto;
 		box-shadow: none !important;
 
 		&:hover {
@@ -199,12 +198,12 @@
 			padding: 16px;
 
 			svg {
-				max-width: 24px;
+				max-inline-size: 24px;
 			}
 		}
 
 		.components-button__icon {
-			margin-left: auto;
+			margin-inline-start: auto;
 		}
 	}
 
@@ -212,14 +211,14 @@
 		flex: 1;
 		font-weight: 500;
 		color: $info-grey;
-		margin-right: 8px;
+		margin-inline-end: 8px;
 	}
 
 	&__rule-content {
 		padding: 8px 8px 9px 8px;
 		overflow: hidden;
 		background: #f9f9f9;
-		border-top: 1px solid $outline-grey;
+		border-block-start: 1px solid $outline-grey;
 
 		&[aria-hidden="true"] {
 			display: none;
@@ -232,7 +231,7 @@
 
 	&__show-ignored {
 		display: block;
-		margin-top: 12px;
+		margin-block-start: 12px;
 		padding: 0 12px;
 		background: none;
 		border: none;
@@ -247,8 +246,8 @@
 	}
 
 	&__ignored-issues {
-		margin-top: 8px;
-		padding-top: 8px;
-		border-top: 1px dashed #ddd;
+		margin-block-start: 8px;
+		padding-block-start: 8px;
+		border-block-start: 1px dashed #ddd;
 	}
 }

--- a/src/sidebar/sass/components/accessibility-analysis.scss
+++ b/src/sidebar/sass/components/accessibility-analysis.scss
@@ -68,7 +68,7 @@
 		font-size: $sidebar-font-size-large;
 		font-weight: 600;
 		color: $info-grey;
-		text-align: left;
+		text-align: start;
 
 		&:hover {
 			background-color: #f9f9f9;
@@ -172,7 +172,7 @@
 		background: none;
 		border: none;
 		cursor: pointer;
-		text-align: left;
+		text-align: start;
 		font-size: $sidebar-font-size-large;
 		font-weight: 500;
 		color: $info-grey;
@@ -239,7 +239,7 @@
 		color: $info-blue;
 		font-size: $sidebar-font-size-large;
 		cursor: pointer;
-		text-align: left;
+		text-align: start;
 
 		&:hover {
 			text-decoration: underline;

--- a/src/sidebar/sass/components/accessibility-status.scss
+++ b/src/sidebar/sass/components/accessibility-status.scss
@@ -10,7 +10,7 @@
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		gap: 8px;
-		width: calc(100% + 16px);
+		inline-size: calc(100% + 16px);
 		align-items: stretch;
 		margin: -8px -8px -7px -8px;
 	}
@@ -19,7 +19,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0;
-		height: 100%;
+		block-size: 100%;
 		border: solid 1px $outline-grey;
 		border-radius: 5px;
 		padding: 8px;
@@ -64,8 +64,8 @@
 			margin: -2.5px -2.5px 0 0;
 
 			.edac-icon {
-				width: 16px;
-				height: 16px;
+				inline-size: 16px;
+				block-size: 16px;
 			}
 		}
 
@@ -77,8 +77,8 @@
 		}
 
 		&__progress {
-			width: 100%;
-			height: 6px;
+			inline-size: 100%;
+			block-size: 6px;
 			border: none;
 			border-radius: 3px;
 			overflow: hidden;
@@ -109,14 +109,14 @@
 		&__meta {
 			font-size: 10px;
 			color: $info-blue;
-			margin-top: 2px;
+			margin-block-start: 2px;
 		}
 	}
 
 	.edac-status-footer {
-		margin-top: 16px;
-		padding-top: 12px;
-		border-top: 1px solid $outline-grey;
+		margin-block-start: 16px;
+		padding-block-start: 12px;
+		border-block-start: 1px solid $outline-grey;
 
 		&__note {
 			margin: 0 0 8px 0;

--- a/src/sidebar/sass/components/badge.scss
+++ b/src/sidebar/sass/components/badge.scss
@@ -16,7 +16,7 @@
 	font-size: $sidebar-font-size-small;
 	font-weight: 400;
 	white-space: nowrap;
-	margin-left: auto;
+	margin-inline-start: auto;
 
 	&__label {
 		line-height: 1;
@@ -33,8 +33,8 @@
 		font-size: $sidebar-font-size-medium;
 
 		.edac-icon {
-			width: 20px;
-			height: 20px;
+			inline-size: 20px;
+			block-size: 20px;
 			font-size: 20px;
 		}
 	}

--- a/src/sidebar/sass/components/icon.scss
+++ b/src/sidebar/sass/components/icon.scss
@@ -10,8 +10,8 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 24px;
-	height: 24px;
+	inline-size: 24px;
+	block-size: 24px;
 
 	&--success {
 		color: $check-green;
@@ -35,6 +35,6 @@
 	}
 
 	.components-panel__body-title & {
-		margin-right: 4px;
+		margin-inline-end: 4px;
 	}
 }

--- a/src/sidebar/sass/components/quick-access-panel.scss
+++ b/src/sidebar/sass/components/quick-access-panel.scss
@@ -5,11 +5,11 @@
 	}
 
 	&__description {
-		margin-bottom: 1rem;
+		margin-block-end: 1rem;
 	}
 
 	&__button {
-		width: 100%;
+		inline-size: 100%;
 		justify-content: center;
 	}
 }

--- a/src/sidebar/sass/components/screen-reader-text-format.scss
+++ b/src/sidebar/sass/components/screen-reader-text-format.scss
@@ -1,10 +1,10 @@
 .edac-screen-reader-text-format {
 
 	.components-base-control {
-		width: 100%;
+		inline-size: 100%;
 	}
 
 	.components-base-control__help {
-		margin-bottom: 0;
+		margin-block-end: 0;
 	}
 }

--- a/src/sidebar/sass/components/sidebar-content.scss
+++ b/src/sidebar/sass/components/sidebar-content.scss
@@ -14,31 +14,31 @@
 .edac-panel-body {
 
 	.edac-refreshing-message {
-		margin-bottom: 12px;
+		margin-block-end: 12px;
 	}
 }
 
 .edac-data-row {
-	width: 100%;
+	inline-size: 100%;
 }
 
 .edac-data-section {
-	margin-bottom: 12px;
+	margin-block-end: 12px;
 
 	&:last-child {
-		margin-bottom: 0;
+		margin-block-end: 0;
 	}
 
 	&__label {
 		display: block;
-		margin-bottom: 4px;
+		margin-block-end: 4px;
 		font-weight: 600;
 	}
 
 	&__count {
 		font-size: 24px;
 		font-weight: 700;
-		margin-right: 8px;
+		margin-inline-end: 8px;
 
 		&--errors {
 			color: $error-red;
@@ -75,7 +75,7 @@
 		display: flex;
 		align-items: flex-start;
 		gap: 12px;
-		margin-bottom: 4px;
+		margin-block-end: 4px;
 	}
 
 	&__title {
@@ -91,7 +91,7 @@
 		line-height: 1.5;
 
 		&:last-child {
-			margin-bottom: 0;
+			margin-block-end: 0;
 		}
 	}
 
@@ -100,14 +100,14 @@
 	}
 
 	&__subsection {
-		margin-top: 16px;
-		padding-top: 12px;
-		border-top: 1px solid $outline-grey;
+		margin-block-start: 16px;
+		padding-block-start: 12px;
+		border-block-start: 1px solid $outline-grey;
 
 		&:first-child {
-			margin-top: 0;
-			padding-top: 0;
-			border-top: none;
+			margin-block-start: 0;
+			padding-block-start: 0;
+			border-block-start: none;
 		}
 	}
 
@@ -124,7 +124,6 @@
  * with icons. The is-compact class is added in 6.9 (and hopefully later).
  */
 .edac-sidebar-menu-group.components-menu-group button:not(.is-compact) > svg {
-	max-width: 24px;
-	margin-left: -24px !important;
-	margin-right: 16px !important;
+	max-inline-size: 24px;
+	margin-inline: -24px 16px !important;
 }

--- a/src/sidebar/sass/sidebar.scss
+++ b/src/sidebar/sass/sidebar.scss
@@ -30,41 +30,41 @@
 	&__body {
 
 		&-title {
-			margin-bottom: 0 !important;
+			margin-block-end: 0 !important;
 		}
 
 		&-title:has([aria-expanded="true"]) {
-			border-bottom: 1px solid $outline-grey !important;
+			border-block-end: 1px solid $outline-grey !important;
 		}
 	}
 
 	&__row {
-		padding-top: 16px;
+		padding-block-start: 16px;
 	}
 }
 
 .components-panel__header-title:has(.edac-sidebar__title) {
 	display: flex;
-	width: 100%;
+	inline-size: 100%;
 }
 
 .interface-complementary-area-header__title:has(.edac-sidebar__title) {
-	width: 100%;
+	inline-size: 100%;
 }
 
 .edac-sidebar__title {
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	width: 100%;
+	inline-size: 100%;
 	flex: 1 1 auto;
-	min-width: 0;
+	min-inline-size: 0;
 }
 
 .edac-sidebar__title-spinner {
-	margin-left: 8px;
+	margin-inline-start: 8px;
 }
 
 .edac-sidebar__title-menu {
-	margin-left: auto;
+	margin-inline-start: auto;
 }

--- a/src/srOnlyFormat/sass/sr-only-format.scss
+++ b/src/srOnlyFormat/sass/sr-only-format.scss
@@ -22,7 +22,8 @@
 		white-space: nowrap;
 
 		position: absolute;
-		inset: logical 100% -2px auto auto;
+		inset-block: 100% auto;
+		inset-inline: -2px auto;
 		z-index: 1;
 	}
 }

--- a/src/srOnlyFormat/sass/sr-only-format.scss
+++ b/src/srOnlyFormat/sass/sr-only-format.scss
@@ -15,24 +15,20 @@
 		font-family: Verdana, sans-serif;
 		font-size: 11px;
 		line-height: 1.2;
-		padding-left: 3px;
-		padding-right: 3px;
+		padding-inline: 3px;
 		pointer-events: none;
 		text-decoration: none;
 		text-indent: 0;
 		white-space: nowrap;
 
 		position: absolute;
-		bottom: auto;
-		left: -2px;
-		right: auto;
-		top: 100%;
+		inset: logical 100% -2px auto auto;
 		z-index: 1;
 	}
 }
 
 .sr-only-show-always .text-format-sr-only {
-	border-bottom: 2px solid #f0f;
+	border-block-end: 2px solid #f0f;
 	border-radius: 0;
 }
 
@@ -55,14 +51,14 @@ body:not(.sr-only-show-always) .text-format-sr-only:not(.is-selected .text-forma
 		white-space: nowrap;
 
 		position: absolute;
-		top: 0;
-		left: 0;
+		inset-block-start: 0;
+		inset-inline-start: 0;
 
 		clip-path: inset(50%);
 		clip: rect($size, $size, $size, $size);
-		margin-top: $size-negative;
-		margin-left: $size-negative;
-		width: $size;
-		height: $size;
+		margin-block-start: $size-negative;
+		margin-inline-start: $size-negative;
+		inline-size: $size;
+		block-size: $size;
 	}
 }

--- a/tests/jest/rules/underlinedText.test.js
+++ b/tests/jest/rules/underlinedText.test.js
@@ -80,7 +80,7 @@ describe( 'Underlined Text Validation', () => {
 		},
 		{
 			name: 'should pass for text with bottom border (not text-decoration)',
-			html: '<span style="border-bottom: 1px solid black;">Text with border</span>',
+			html: '<span style="border-block-end: 1px solid black;">Text with border</span>',
 			shouldPass: true,
 		},
 


### PR DESCRIPTION
Implement CSS Logical Properties to add bi-directional support (LTR & RTL).

Currently, the layout looks good for **Left-To-Right** (LTR) languages as all the styles use **CSS Physical Properties** (left/right).

To support **Right-To-Left** (RTL) languages, we should migrate to **CSS Logical Properties** (start/end).

This way the browser engine flips all the elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved support for right-to-left and alternative writing-direction layouts across accessibility administration screens, sidebars, panels, modals, and forms.
  * Updated sizing, alignment, spacing, borders, positioning, and floating behavior to adapt correctly to text direction while preserving the existing visual design.
  * Improved directional alignment for accessibility analysis controls and welcome-page sections.
  * Standardized directional styling terminology from left/right to start/end for more consistent layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->