### PR TITLE
Enforce stylelint `selector-pseudo-element-colon-notation`

### DIFF
--- a/src/admin/sass/accessibility-checker-admin.scss
+++ b/src/admin/sass/accessibility-checker-admin.scss
@@ -226,8 +226,7 @@
 						display: inline-block;
 					}
 
-					// stylelint-disable-next-line selector-pseudo-element-colon-notation
-					&:after {
+					&::after {
 						border: none;
 						position: absolute;
 						top: $progress-bar-width;
@@ -1133,8 +1132,7 @@
 			margin-bottom: 16px;
 			font-size: 16px;
 
-			// stylelint-disable-next-line selector-pseudo-element-colon-notation
-			&:before {
+			&::before {
 				content: url(../images/list-check.png);
 				height: 21px;
 				width: 21px;
@@ -1179,8 +1177,7 @@
 			display: inline;
 		}
 
-		// stylelint-disable-next-line selector-pseudo-element-colon-notation
-		&:after {
+		&::after {
 			content: "";
 			position: absolute;
 			height: calc(100% + 3px);
@@ -1224,8 +1221,7 @@
 	&-review {
 		font-weight: 600;
 
-		// stylelint-disable-next-line selector-pseudo-element-colon-notation
-		&:after {
+		&::after {
 			content: " \f155\f155\f155\f155\f155";
 			// stylelint-disable-next-line font-family-no-missing-generic-family-keyword
 			font-family: dashicons;

--- a/src/common/sass/_fix-settings.scss
+++ b/src/common/sass/_fix-settings.scss
@@ -38,13 +38,11 @@
 			padding: 0 !important;
 			width: auto;
 
-			// stylelint-disable-next-line selector-pseudo-element-colon-notation
-			&:before {
+			&::before {
 				content: none;
 			}
 
-			// stylelint-disable-next-line selector-pseudo-element-colon-notation
-			&:checked:before {
+			&:checked::before {
 				content: url(data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%233582c4%27%2F%3E%3C%2Fsvg%3E);
 				margin: -0.1875rem -0.25rem 0 -0.25rem;
 				height: 1.3125rem;
@@ -144,10 +142,8 @@
 	border-radius: 5px;
 	box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 
-	// stylelint-disable selector-pseudo-element-colon-notation
 	.dashicons,
-	.dashicons-before:before {
-		// stylelint-enable selector-pseudo-element-colon-notation
+	.dashicons-before::before {
 		// stylelint-disable-next-line font-family-no-missing-generic-family-keyword
 		font-family: dashicons;
 		display: inline-block;

--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -853,10 +853,8 @@ body {
 	color: #000;
 }
 
-// stylelint-disable selector-pseudo-element-colon-notation
-.notyf__dismiss-btn:before,
-.notyf__dismiss-btn:after {
-	// stylelint-enable selector-pseudo-element-colon-notation
+.notyf__dismiss-btn::before,
+.notyf__dismiss-btn::after {
 	background: #000 !important;
 }
 
@@ -966,13 +964,11 @@ body {
 
 		input[type="checkbox"] {
 
-			// stylelint-disable-next-line selector-pseudo-element-colon-notation
-			&:before {
+			&::before {
 				content: none;
 			}
 
-			// stylelint-disable-next-line selector-pseudo-element-colon-notation
-			&:checked:before {
+			&:checked::before {
 				content: none;
 			}
 		}


### PR DESCRIPTION
Minor fix after #1860

If you don't need to support legacy browsers (Internet Explorer 8), you should not ignore `selector-pseudo-element-colon-notation` lint rule.

Modern CSS requires **double colons** for `pseudo-elements` (e.g., `::before`, `::after`) and **single colons** for `pseudo-classes` (e.g., `:hover`).

----

Furthermore, if you want to ignore this rule, you should not do that from SCSS files. Instead, change the global setting in `.stylelintrc`/`.stylelintrc.json` configuration file:

```
"rules": {
    "selector-pseudo-element-colon-notation": "single"
}
```

But again, in this case, single colon should not be used.

----

## Test plan

- [x] `npm run lint:css` passes with 0 errors

----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated pseudo-element styling to use modern `::before` and `::after` syntax.
  * Preserved existing visual behavior for checkboxes, icons, notifications, and accessibility-related elements.
  * Removed obsolete style-lint suppression comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->