### PR TITLE
Don't fail the build when a fork PR can't get a comment posted

### DIFF
--- a/.github/workflows/build-plugin-with-ref.yml
+++ b/.github/workflows/build-plugin-with-ref.yml
@@ -296,6 +296,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           post-comment: ${{ github.event_name == 'pull_request' }}
           pr-number: ${{ github.event.pull_request.number }}
+          # Fork PRs (e.g. first-time contributors) always get a read-only
+          # GITHUB_TOKEN under the pull_request trigger, so post-comment can
+          # never succeed there no matter what permissions: grants above -
+          # that's what failed run #1871 (PR #1871, mjoslyn/accessibility-checker).
+          # Warn instead of failing the whole build in that case; the
+          # Playground link still lands in the job summary either way.
+          skip-comment-on-missing-permission: 'true'
           comment-template: |
             ✅ Accessibility Checker build
 


### PR DESCRIPTION
## Summary

- The "Build Accessibility Checker Plugin with Ref Param" workflow failed on [run #31399438416](https://github.com/equalizedigital/accessibility-checker/actions/runs/31399438416?pr=1871) (PR #1871, a first-time fork contribution) with an unhandled `HttpError: Resource not accessible by integration` (403) while trying to post the Playground-link PR comment.
- Root cause: GitHub always gives `pull_request`-triggered workflows a **read-only** `GITHUB_TOKEN` when the PR is from a fork, regardless of the `permissions:` block declared in this workflow. `post-comment` can never succeed there — it's a platform restriction, not something fixable from this repo's side.
- `pattonwebz/wordpress-playground-action@v0` now supports a `skip-comment-on-missing-permission` input (added in [v0.3.0](https://github.com/pattonwebz/wordpress-playground-action/releases/tag/v0.3.0)/[v0.3.1](https://github.com/pattonwebz/wordpress-playground-action/releases/tag/v0.3.1)): a 403 while posting the comment becomes a `::warning::` instead of failing the whole step. The Playground link still lands in the run's job summary either way, so it isn't lost — it just can't be posted as a PR comment for a fork contributor under this trigger.
- This PR sets that flag to `true` so future fork-PR builds (like #1871) go green with a warning instead of failing outright.

## Test plan

- [ ] Confirm the workflow still runs and posts a comment normally on a non-fork PR with the `gha-build` label.
- [ ] Confirm a fork PR build with the label now succeeds (warning in the log, link visible in the run's Summary tab) instead of failing at the "Playground link" step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fork pull-request builds now continue successfully when comment permissions are unavailable.
  * Playground links remain available in the job summary even when posting a comment is not permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->