### PR TITLE
Fix front-end highlighter theme style leakage (#1880, #1881)

### DIFF
--- a/src/frontendHighlighterApp/sass/app.scss
+++ b/src/frontendHighlighterApp/sass/app.scss
@@ -201,9 +201,10 @@ body {
 		}
 
 		&-toggle {
+			all: unset !important;
 			width: 50px !important;
 			height: 50px !important;
-			display: block;
+			display: block !important;
 			background: transparent url(../images/edac-emblem.png) center center no-repeat !important;
 			background-size: contain !important;
 			box-shadow: 0 0 5px rgba(variables.$color-black, 0.5) !important;
@@ -719,7 +720,7 @@ body {
 				gap: 8px !important;
 
 				button {
-					all: unset;
+					all: unset !important;
 					text-decoration: none !important;
 					color: variables.$color-blue !important;
 					background-color: transparent !important;


### PR DESCRIPTION
Make the panel-toggle and controls-buttons resets use `all: unset !important;`,
matching the pattern already used by other resets in this stylesheet, so
theme `!important` button styles (font, padding, border) can no longer
override the highlighter's own styling.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014ummPaBvhFzE52KkJwsQpg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the highlighter panel toggle and footer buttons so their controls display and behave consistently despite broader panel styling resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->