### PR TITLE
Add WooCommerce HPOS compatibility declaration and version headers

### DIFF
--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -12,6 +12,8 @@
  * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
  * Version:           1.47.0
  * Requires PHP:      7.4
+ * WC requires at least: 7.1
+ * WC tested up to:   11.0
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+
@@ -86,6 +88,24 @@ define( 'EDAC_SVG_IGNORE_ICON', file_get_contents( __DIR__ . '/assets/images/ign
  */
 register_activation_hook( __FILE__, 'edac_activation' );
 register_deactivation_hook( __FILE__, 'edac_deactivation' );
+
+/**
+ * Declare compatibility with WooCommerce's High-Performance Order Storage.
+ *
+ * This plugin does not read or write order data, so it is compatible
+ * regardless of whether HPOS is enabled. No-op when WooCommerce is not
+ * active, since this hook is only fired by WooCommerce itself.
+ *
+ * @since 1.xx.x
+ */
+add_action(
+	'before_woocommerce_init',
+	function () {
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
+		}
+	}
+);
 
 /* ***************************** CLASS AUTOLOADING *************************** */
 if ( file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -7,19 +7,19 @@
  * @since   1.0.0
  *
  * @wordpress-plugin
- * Plugin Name:       Accessibility Checker
- * Plugin URI:        https://equalizedigital.com/accessibility-checker
- * Description:       Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
- * Version:           1.47.0
- * Requires PHP:      7.4
+ * Plugin Name:          Accessibility Checker
+ * Plugin URI:           https://equalizedigital.com/accessibility-checker
+ * Description:          Audit and check your website for accessibility before you hit publish. In-post accessibility scanner and guidance.
+ * Version:              1.47.0
+ * Requires PHP:         7.4
  * WC requires at least: 7.1
- * WC tested up to: 11.0
- * Author:            Equalize Digital
- * Author URI:        https://equalizedigital.com
- * License:           GPL-2.0+
- * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:       accessibility-checker
- * Domain Path:       /languages
+ * WC tested up to:      11.0
+ * Author:               Equalize Digital
+ * Author URI:           https://equalizedigital.com
+ * License:              GPL-2.0+
+ * License URI:          http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:          accessibility-checker
+ * Domain Path:          /languages
  */
 
 use EDAC\Inc\Plugin;

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -13,7 +13,7 @@
  * Version:           1.47.0
  * Requires PHP:      7.4
  * WC requires at least: 7.1
- * WC tested up to:   11.0
+ * WC tested up to: 11.0
  * Author:            Equalize Digital
  * Author URI:        https://equalizedigital.com
  * License:           GPL-2.0+

--- a/accessibility-checker.php
+++ b/accessibility-checker.php
@@ -96,7 +96,7 @@ register_deactivation_hook( __FILE__, 'edac_deactivation' );
  * regardless of whether HPOS is enabled. No-op when WooCommerce is not
  * active, since this hook is only fired by WooCommerce itself.
  *
- * @since 1.xx.x
+ * @since 1.48.0
  */
 add_action(
 	'before_woocommerce_init',


### PR DESCRIPTION
## Summary
- Adds `WC requires at least` / `WC tested up to` plugin headers so the WooCommerce Marketplace validation check has the metadata it expects.
- Declares HPOS (`custom_order_tables`) compatibility via `FeaturesUtil::declare_compatibility()`, guarded behind `class_exists()` and the `before_woocommerce_init` hook so it's a complete no-op on any site without an active, HPOS-capable WooCommerce.

## Why
The Marketplace validation report was flagging this plugin (errors on `WC requires at least`, `WC tested up to`, and HPOS) which is blocking the "Excellence verified" quality badge. This plugin never touches order data at all, so declaring HPOS compatibility is trivially true — there's nothing to reconcile with either storage mode. Deliberately not adding `Requires Plugins: woocommerce`, since that header would turn WooCommerce into a hard WordPress-core-enforced dependency, which is wrong for a plugin that works standalone.

## Test plan
- [x] `php -l accessibility-checker.php`
- [x] `./vendor/bin/phpcs accessibility-checker.php`
- [ ] Confirm the next Marketplace validation run clears the `WC requires at least` / `WC tested up to` / HPOS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Added support for WooCommerce versions 7.1 through 11.0.
  * Added compatibility with WooCommerce High-Performance Order Storage when available.
  * Improved reliability across supported WooCommerce configurations, helping stores continue using accessibility checks with newer WooCommerce versions.
  * Existing WooCommerce integrations remain supported without changes to their configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->