### PR TITLE
Fix: exclude Query Monitor's fallback output from scans

### DIFF
--- a/src/pageScanner/config/exclusions.js
+++ b/src/pageScanner/config/exclusions.js
@@ -1,8 +1,16 @@
-
 // Define the list of exclusions for accessibility scans.
 export const exclusionsArray = [
 	'#wpadminbar',
 	'#edac-highlight-panel',
+	// Query Monitor. It renders debug output on the front end for logged in
+	// users only, and the markup varies by version: older releases use
+	// #query-monitor-main, newer ones mount the panel into
+	// #query-monitor-container and print server-rendered fallback panels into
+	// #query-monitor-fallbacks. The .qm-panel-container class catches the
+	// individual fallback panels since their IDs differ between versions.
 	'#query-monitor-main',
+	'#query-monitor-container',
+	'#query-monitor-fallbacks',
+	'.qm-panel-container',
 	'#qm-icon-container',
 ];

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -45,6 +45,12 @@ describe( 'Scanner Context Exclusions', ( ) => {
 					<button id="query-monitor-fallback-button"></button>
 				</div>
 			</div>
+
+			<!-- A panel container on its own, covering the class selector
+			     independently of the wrapper it usually sits inside -->
+			<div class="qm-panel-container" id="qm-db_queries-container">
+				<button id="query-monitor-panel-button"></button>
+			</div>
 		`;
 
 		// Define context with exclude list matching src/pageScanner/index.js
@@ -71,6 +77,7 @@ describe( 'Scanner Context Exclusions', ( ) => {
 		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-button"' ) ) ).toBe( false );
 		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-container-button"' ) ) ).toBe( false );
 		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-fallback-button"' ) ) ).toBe( false );
+		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-panel-button"' ) ) ).toBe( false );
 		expect( violationHTML.some( ( html ) => html.includes( 'id="edac-panel-button"' ) ) ).toBe( false );
 	} );
 } );

--- a/tests/jest/pageScanner/context.test.js
+++ b/tests/jest/pageScanner/context.test.js
@@ -3,8 +3,8 @@
  * Test for scanner context exclusions
  *
  * This test verifies that elements with the selectors in the exclude array
- * are properly excluded from accessibility scans, including the newly added
- * #qm-icon-container selector.
+ * are properly excluded from accessibility scans, including Query Monitor's
+ * fallback output.
  */
 import axe from 'axe-core';
 import { exclusionsArray } from '../../../src/pageScanner/config/exclusions';
@@ -32,8 +32,18 @@ describe( 'Scanner Context Exclusions', ( ) => {
 			<div id="query-monitor-main">
 				<button id="query-monitor-button"></button>
 			</div>
+			<div id="query-monitor-container">
+				<button id="query-monitor-container-button"></button>
+			</div>
 			<div id="edac-highlight-panel">
 				<button id="edac-panel-button"></button>
+			</div>
+
+			<!-- Query Monitor fallback output, as rendered on WP VIP -->
+			<div id="query-monitor-fallbacks">
+				<div class="qm-panel-container" id="qm-alloptions">
+					<button id="query-monitor-fallback-button"></button>
+				</div>
 			</div>
 		`;
 
@@ -59,6 +69,8 @@ describe( 'Scanner Context Exclusions', ( ) => {
 		expect( violationHTML.some( ( html ) => html.includes( 'id="qm-icon-button"' ) ) ).toBe( false );
 		expect( violationHTML.some( ( html ) => html.includes( 'id="wpadminbar-button"' ) ) ).toBe( false );
 		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-button"' ) ) ).toBe( false );
+		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-container-button"' ) ) ).toBe( false );
+		expect( violationHTML.some( ( html ) => html.includes( 'id="query-monitor-fallback-button"' ) ) ).toBe( false );
 		expect( violationHTML.some( ( html ) => html.includes( 'id="edac-panel-button"' ) ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Fixes #1893

## The problem

On Hamilton County Schools (WP VIP), logged-in users get a wall of unstyled Query Monitor debug output at the bottom of every page, and Accessibility Checker scans it — reporting things like "Ambiguous Anchor Text" on VIP's *Read more* link and "Link Opens New Window or Tab" on the Jetpack Search colophon. The offending container measured 1186 × 29973px.

Query Monitor isn't installed as a regular plugin on those sites. VIP ships it as an mu-plugin, which is why this looked like a VIP quirk.

## The cause

We already exclude Query Monitor from scans, but only via `#query-monitor-main` — that's the older markup. Current Query Monitor ([`dispatchers/Html.php`](https://github.com/johnbillion/query-monitor/blob/develop/dispatchers/Html.php)) does this instead:

```php
// Output server-side rendered panels outside the React container.
echo '<div id="query-monitor-fallbacks">';
foreach ( $this->outputters as $id => $output ) {
    printf( '<div class="qm-panel-container" id="qm-%1$s-container">', esc_html( $id ) );
    ...
}
echo '</div>';

// Output the empty container for React to mount into (shadow DOM host)
printf( '<div id="query-monitor-container" data-css-url="%s"></div>', esc_url( $this->panel_css_url ) );
```

Neither container was in our exclusion list, so all of it got scanned. It renders unstyled because QM's own CSS/UI isn't loading on those sites — which is exactly why it's visible to axe as ordinary page content.

## The fix

Added `#query-monitor-container`, `#query-monitor-fallbacks`, and `.qm-panel-container` to `exclusionsArray`. `#query-monitor-main` stays for older QM versions.

`.qm-panel-container` is deliberate rather than redundant: the panel IDs differ between QM versions (VIP's build emits `id="qm-alloptions"` where upstream emits `id="qm-alloptions-container"`), so matching the class is what makes this version-proof.

The same array drives `getPageDensity()`, so this also stops the debug output from inflating density counts.

## Testing

`tests/jest/pageScanner/context.test.js` now includes the VIP fallback markup and asserts nothing inside it is reported. Verified the new assertions fail against the old exclusion list and pass with the fix.

- `npm run test:jest` — 986 tests, 54 suites, all passing
- `wp-scripts lint-js` clean

To verify manually: activate Query Monitor on a site, view a page on the front end while logged in, and scan. Before this change the QM output appears in the results; after, it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qipx5izJvACbtD9u8rhwu2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility scanning by excluding Query Monitor panels and WP VIP fallback output containers from false-positive violations.
  * Preserved existing scanner exclusions while supporting newer panel layouts.

* **Tests**
  * Expanded automated coverage for Query Monitor and fallback output containers, including buttons within those areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->