### PR TITLE
Add adjacent duplicate link check (warning)

### DIFF
--- a/includes/classes/Rules/Rule/LinkDuplicateAdjacentRule.php
+++ b/includes/classes/Rules/Rule/LinkDuplicateAdjacentRule.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * LinkDuplicateAdjacent Rule.
+ *
+ * @package EqualizeDigital\AccessibilityChecker
+ */
+
+namespace EqualizeDigital\AccessibilityChecker\Rules\Rule;
+
+use EqualizeDigital\AccessibilityChecker\Rules\RuleInterface;
+use EqualizeDigital\AccessibilityChecker\Rules\AffectedDisabilities;
+
+/**
+ * LinkDuplicateAdjacent Rule class.
+ */
+class LinkDuplicateAdjacentRule implements RuleInterface {
+	/**
+	 * Get the rule definition.
+	 *
+	 * @return array The rule definition array.
+	 */
+	public static function get_rule(): array {
+		return [
+			'title'                 => esc_html__( 'Adjacent Duplicate Links', 'accessibility-checker' ),
+			'info_url'              => 'https://a11ychecker.com/help1990',
+			'slug'                  => 'link_duplicate_adjacent',
+			'rule_type'             => 'warning',
+			'summary'               => esc_html__( 'This link sits directly next to another link that points to the same destination.', 'accessibility-checker' ),
+			'summary_plural'        => esc_html__( 'These links sit directly next to other links that point to the same destination.', 'accessibility-checker' ),
+			'why_it_matters'        => esc_html__( 'When two adjacent links point to the same destination, screen reader and keyboard users encounter the same stop twice in a row with no added benefit. This commonly happens by accident when a thumbnail image and its title are wrapped in separate links instead of being combined, which adds unnecessary navigation overhead and can be confusing.', 'accessibility-checker' ),
+			'how_to_fix'            => sprintf(
+			// translators: %1$s is <code>aria-hidden="true"</code>, %2$s is <code>tabindex="-1"</code>.
+				esc_html__( 'Combine the adjacent links into a single link that wraps both the image and the text. If they must remain separate, make one of them (typically the thumbnail image link) presentational by adding %1$s and %2$s so it is skipped by assistive technology and keyboard navigation, leaving only one stop for that destination.', 'accessibility-checker' ),
+				'<code>aria-hidden="true"</code>',
+				'<code>tabindex="-1"</code>'
+			),
+			'references'            => [
+				[
+					'text' => __( 'W3C Technique H2: Combining adjacent image and text links for the same resource', 'accessibility-checker' ),
+					'url'  => 'https://www.w3.org/WAI/WCAG21/Techniques/html/H2',
+				],
+				[
+					'text' => __( 'Understanding WCAG SC 2.4.4: Link Purpose (In Context)', 'accessibility-checker' ),
+					'url'  => 'https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html',
+				],
+			],
+			'ruleset'               => 'js',
+			'wcag'                  => '2.4.4',
+			'severity'              => 3, // Medium.
+			'affected_disabilities' => [
+				AffectedDisabilities::BLIND,
+				AffectedDisabilities::LOW_VISION,
+				AffectedDisabilities::MOBILITY,
+				AffectedDisabilities::COGNITIVE,
+			],
+		];
+	}
+}

--- a/includes/classes/Rules/RuleRegistry.php
+++ b/includes/classes/Rules/RuleRegistry.php
@@ -44,6 +44,7 @@ class RuleRegistry {
 			'IncorrectHeadingOrderRule',
 			'LinkAmbiguousTextRule',
 			'LinkBlankRule',
+			'LinkDuplicateAdjacentRule',
 			'LinkImproperRule',
 			'LinkMsOfficeFileRule',
 			'LinkTextIsUrlRule',

--- a/src/pageScanner/checks/link-has-adjacent-duplicate.js
+++ b/src/pageScanner/checks/link-has-adjacent-duplicate.js
@@ -1,0 +1,58 @@
+/**
+ * Check whether a link sits directly next to another link (only whitespace text between them)
+ * that points to the same destination. This commonly happens by accident when a thumbnail
+ * image and its title are wrapped in separate links instead of being combined.
+ */
+
+const isWhitespaceTextNode = ( node ) => node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '';
+
+/**
+ * Walk past whitespace-only text nodes to find the next element sibling in a direction.
+ * Returns null if a non-whitespace text node or non-element node is encountered first,
+ * since that means the links are not directly adjacent.
+ *
+ * @param {HTMLElement} node      The node to start from.
+ * @param {string}      direction Either 'next' or 'previous'.
+ * @return {HTMLElement|null} The adjacent element, or null if none is directly adjacent.
+ */
+const getAdjacentLinkElement = ( node, direction ) => {
+	let sibling = direction === 'next' ? node.nextSibling : node.previousSibling;
+
+	while ( sibling ) {
+		if ( isWhitespaceTextNode( sibling ) ) {
+			sibling = direction === 'next' ? sibling.nextSibling : sibling.previousSibling;
+			continue;
+		}
+
+		return sibling.nodeType === Node.ELEMENT_NODE ? sibling : null;
+	}
+
+	return null;
+};
+
+const hasUsableHref = ( element ) => {
+	const href = element.getAttribute( 'href' );
+	return !! href && href.trim() !== '' && href.trim() !== '#';
+};
+
+const isMatchingLink = ( candidate, node ) => {
+	if ( ! candidate || candidate.tagName?.toLowerCase() !== 'a' || ! hasUsableHref( candidate ) ) {
+		return false;
+	}
+
+	return candidate.href === node.href;
+};
+
+export default {
+	id: 'link_has_adjacent_duplicate',
+	evaluate: ( node ) => {
+		if ( node.tagName.toLowerCase() !== 'a' || ! hasUsableHref( node ) ) {
+			return false;
+		}
+
+		const nextLink = getAdjacentLinkElement( node, 'next' );
+		const previousLink = getAdjacentLinkElement( node, 'previous' );
+
+		return isMatchingLink( nextLink, node ) || isMatchingLink( previousLink, node );
+	},
+};

--- a/src/pageScanner/config/rules.js
+++ b/src/pageScanner/config/rules.js
@@ -68,6 +68,8 @@ import imageAnimated from '../rules/img-animated';
 import imageAnimatedCheck from '../checks/img-animated-check';
 import linkTextIsUrl from '../rules/link-text-is-url';
 import linkTextIsUrlCheck from '../checks/link-text-is-url';
+import linkDuplicateAdjacent from '../rules/link-duplicate-adjacent';
+import linkHasAdjacentDuplicate from '../checks/link-has-adjacent-duplicate';
 import alwaysFail from '../checks/always-fail';
 
 // Define all the custom rules to be used.
@@ -107,6 +109,7 @@ export const rulesArray = [
 	ariaHiddenValidation,
 	ariaBrokenReference,
 	linkTextIsUrl,
+	linkDuplicateAdjacent,
 ];
 
 // Define all the custom checks to be used.
@@ -152,6 +155,7 @@ export const checksArray = [
 	ariaDescribedByNotFoundCheck,
 	ariaOwnsNotFoundCheck,
 	linkTextIsUrlCheck,
+	linkHasAdjacentDuplicate,
 ];
 
 // Define the standard axe core rules to be used.

--- a/src/pageScanner/rules/link-duplicate-adjacent.js
+++ b/src/pageScanner/rules/link-duplicate-adjacent.js
@@ -1,0 +1,22 @@
+/**
+ * Check for two links placed immediately next to each other that point to the same destination.
+ */
+
+export default {
+	id: 'link_duplicate_adjacent',
+	selector: 'a[href]',
+	excludeHidden: false,
+	tags: [
+		'cat.text',
+		'wcag2a',
+		'wcag244',
+		'best-practice',
+	],
+	metadata: {
+		description: 'Detects links placed directly next to another link that shares the same destination.',
+		help: 'Adjacent links that point to the same destination should be combined into a single link.',
+	},
+	all: [],
+	any: [],
+	none: [ 'link_has_adjacent_duplicate' ],
+};

--- a/tests/jest/rules/linkDuplicateAdjacent.test.js
+++ b/tests/jest/rules/linkDuplicateAdjacent.test.js
@@ -1,0 +1,85 @@
+import axe from 'axe-core';
+
+beforeAll( async () => {
+	const ruleModule = await import( '../../../src/pageScanner/rules/link-duplicate-adjacent.js' );
+	const checkModule = await import( '../../../src/pageScanner/checks/link-has-adjacent-duplicate.js' );
+
+	axe.configure( {
+		rules: [ ruleModule.default ],
+		checks: [ checkModule.default ],
+	} );
+} );
+
+beforeEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'Link Duplicate Adjacent Rule', () => {
+	test.each( [
+		// ❌ Failing cases - adjacent links to the same destination
+		{
+			name: 'Fails when an image link is immediately followed by a text link to the same page',
+			html: '<a href="/post-1"><img src="thumb.jpg" alt="Post one" /></a><a href="/post-1">Read the full story</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Fails when links are separated only by whitespace',
+			html: '<a href="/post-1">Photo</a>\n\t<a href="/post-1">Read more</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'Fails when hrefs resolve to the same absolute URL (relative vs absolute)',
+			html: `<a href="/post-1">Photo</a><a href="${ window.location.origin }/post-1">Read more</a>`,
+			shouldPass: false,
+		},
+		{
+			name: 'Fails for the middle link in three identical adjacent links',
+			html: '<a href="/post-1">A</a><a href="/post-1">B</a><a href="/post-1">C</a>',
+			shouldPass: false,
+		},
+
+		// ✅ Passing cases
+		{
+			name: 'Passes when adjacent links point to different destinations',
+			html: '<a href="/post-1">Photo</a><a href="/post-2">Read more</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes when a non-whitespace element separates the links',
+			html: '<a href="/post-1">Photo</a><span> | </span><a href="/post-1">Read more</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes for a single link with no adjacent sibling link',
+			html: '<a href="/post-1">Read more</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes when the duplicate link is not adjacent (separated by another element)',
+			html: '<a href="/post-1">Photo</a><p>Some text</p><a href="/post-1">Read more</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes when links have empty or placeholder hrefs',
+			html: '<a href="#">A</a><a href="#">B</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'Passes when one of the adjacent elements is not a link',
+			html: '<a href="/post-1">Photo</a><button>Read more</button>',
+			shouldPass: true,
+		},
+	] )( '$name', async ( { html, shouldPass } ) => {
+		document.body.innerHTML = html;
+
+		const results = await axe.run( document.body, {
+			runOnly: [ 'link_duplicate_adjacent' ],
+		} );
+
+		if ( shouldPass ) {
+			expect( results.violations.length ).toBe( 0 );
+		} else {
+			expect( results.violations.length ).toBeGreaterThan( 0 );
+		}
+	} );
+} );


### PR DESCRIPTION
## Summary

Adds a new accessibility check: `link_duplicate_adjacent` — flags two `<a>` elements sitting immediately next to each other (only whitespace between them) that resolve to the same `href`. This is a common accidental pattern on client sites (e.g. a thumbnail image link followed by a separate title/text link to the same destination), which creates a redundant stop for screen reader and keyboard users navigating by link/tab.

Registered as a **warning (needs review)** rather than an error, since some adjacent same-destination links may be intentional or otherwise benign.

- `src/pageScanner/rules/link-duplicate-adjacent.js` — axe-core custom rule (`selector: 'a[href]'`)
- `src/pageScanner/checks/link-has-adjacent-duplicate.js` — walks `previousSibling`/`nextSibling`, skipping only whitespace text nodes, and compares resolved `.href` values (handles relative vs. absolute URLs to the same page); ignores empty/`#` hrefs
- `includes/classes/Rules/Rule/LinkDuplicateAdjacentRule.php` — rule metadata (title, summary, why it matters, how to fix, WCAG 2.4.4 / W3C Technique H2, `rule_type: warning`, severity 3/Medium)
- Registered in `src/pageScanner/config/rules.js` and `includes/classes/Rules/RuleRegistry.php`

**Note:** `info_url` in the PHP rule uses a placeholder (`https://a11ychecker.com/help1990`) — needs to be swapped for the real help-article URL once one is published.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes

## Test plan

- Added `tests/jest/rules/linkDuplicateAdjacent.test.js` with 10 cases (adjacent duplicate image+text links, whitespace-only gap, relative-vs-absolute href match, 3-in-a-row, different destinations, non-whitespace separator, non-adjacent duplicate, empty/`#` href, non-link sibling).
- Full jest rule suite passes: 39 suites / 818 tests.
- `php -l` clean on both modified/new PHP files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessibility check that detects adjacent links leading to the same destination.
  * Added guidance mapped to WCAG 2.4.4 to help improve link clarity and navigation.

* **Bug Fixes**
  * Identifies duplicate links even when separated only by whitespace, while excluding placeholders, fragments, and unrelated elements.

* **Tests**
  * Added coverage for matching, equivalent, separated, distinct, and non-link scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->