### PR TITLE
Add local context for issue dismiss in metabox area and resetting focus

### DIFF
--- a/src/admin/details/dismiss-issue-focus.js
+++ b/src/admin/details/dismiss-issue-focus.js
@@ -23,7 +23,7 @@ const findRuleDisplayBtn = ( root, panelId ) => {
 	}
 
 	const rulePanelDisplayButtons = Array.from( root.querySelectorAll( RULE_BUTTON_SELECTOR ) );
-	const rulePanelDisplayButton = rulePanelDisplayButtons .find( ( button ) => button.getAttribute( 'aria-controls' ) === panelId ) || null;
+	const rulePanelDisplayButton = rulePanelDisplayButtons.find( ( button ) => button.getAttribute( 'aria-controls' ) === panelId ) || null;
 
 	return rulePanelDisplayButton;
 };
@@ -92,7 +92,7 @@ export const restoreDismissIssueFocus = ( context, root = document ) => {
 		rulePanelIgnore.style.display = 'block';
 	}
 
-	const focusTarget = findIssueDismissBtn( root, context.issueId )
+	const focusTarget = findIssueDismissBtn( root, context.issueId );
 
 	focusTarget?.focus();
 

--- a/src/admin/details/dismiss-issue-focus.js
+++ b/src/admin/details/dismiss-issue-focus.js
@@ -1,0 +1,100 @@
+/**
+ * Focus helpers for a dismissed issue in the server-rendered details panel.
+ */
+
+const RULE_PANEL_SELECTOR = '.edac-details-rule-records';
+const RULE_BUTTON_SELECTOR = '.edac-details-rule-title-arrow';
+const RULE_TITLE_SELECTOR = '.edac-details-rule-title';
+const ISSUE_RECORD_SELECTOR = '.edac-details-rule-records-record';
+const ISSUE_RECORD_ID_PREFIX = 'edac-details-rule-records-record-';
+const ISSUE_RECORD_IGNORE_PREFIX = 'edac-details-rule-records-record-ignore-';
+const ISSUE_RECORD_DISMISS_BUTTON = '.edac-details-rule-records-record-ignore-submit';
+
+/**
+ * Find the rule button that controls a panel.
+ *
+ * @param {Document|Element} root    The root to search.
+ * @param {string}           panelId The controlled panel ID.
+ * @return {HTMLElement|null} The matching rule display button.
+ */
+const findRuleDisplayBtn = ( root, panelId ) => {
+	if ( ! panelId ) {
+		return null;
+	}
+
+	const rulePanelDisplayButtons = Array.from( root.querySelectorAll( RULE_BUTTON_SELECTOR ) );
+	const rulePanelDisplayButton = rulePanelDisplayButtons .find( ( button ) => button.getAttribute( 'aria-controls' ) === panelId ) || null;
+
+	return rulePanelDisplayButton;
+};
+
+/**
+ * Capture stable focus context for the issue being dismissed or reopened.
+ *
+ * @param {HTMLElement} submitButton The dismiss or reopen submit button.
+ * @return {Object|null} The dismissal focus context.
+ */
+export const captureDismissIssueFocusContext = ( submitButton ) => {
+	const issueRecord = submitButton?.closest( ISSUE_RECORD_SELECTOR );
+	const rulePanel = issueRecord?.closest( RULE_PANEL_SELECTOR );
+	const issueId = submitButton?.dataset?.id;
+
+	if ( ! issueRecord || ! rulePanel || ! issueId ) {
+		return null;
+	}
+
+	return {
+		issueId: String( issueId ),
+		rulePanelId: rulePanel.id,
+	};
+};
+
+/**
+ * Find an issue's dismiss button by its issue ID.
+ *
+ * @param {Document}    root    The document containing the metabox.
+ * @param {string|null} issueId The issue ID.
+ * @return {HTMLElement|null} The issue button.
+ */
+const findIssueDismissBtn = ( root, issueId ) => {
+	const issue = root.getElementById( ISSUE_RECORD_ID_PREFIX + issueId );
+
+	const dismissBtn = issue?.querySelector( ISSUE_RECORD_DISMISS_BUTTON ) || null;
+
+	return dismissBtn;
+};
+
+/**
+ * Expand the acted rule and restore focus after its markup is replaced.
+ *
+ * @param {Object|null} context The dismissal focus context.
+ * @param {Document}    root    The document containing the metabox.
+ * @return {HTMLElement|null} The focused element, or null.
+ */
+export const restoreDismissIssueFocus = ( context, root = document ) => {
+	if ( ! context ) {
+		return null;
+	}
+
+	const rulePanel = root.getElementById( context.rulePanelId );
+	const ruleDisplayBtn = findRuleDisplayBtn( root, context.rulePanelId );
+	const rulePanelIgnore = root.getElementById( ISSUE_RECORD_IGNORE_PREFIX + context.issueId );
+
+	if ( rulePanel ) {
+		rulePanel.style.display = 'block';
+
+		// Add active class to title and update aria on button
+		ruleDisplayBtn?.closest( RULE_TITLE_SELECTOR )?.classList.add( 'active' );
+		ruleDisplayBtn?.setAttribute( 'aria-expanded', 'true' );
+	}
+
+	if ( rulePanelIgnore ) {
+		rulePanelIgnore.style.display = 'block';
+	}
+
+	const focusTarget = findIssueDismissBtn( root, context.issueId )
+
+	focusTarget?.focus();
+
+	return focusTarget;
+};

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -9,6 +9,10 @@ import {
 import { initFixesInputStateHandler } from './fixes-page/conditional-disable-settings';
 import { initRequiredSetup } from './fixes-page/conditional-required-settings';
 import { inlineSettingsProUpsell } from '../common/settings-pro-callout';
+import {
+	captureDismissIssueFocusContext,
+	restoreDismissIssueFocus,
+} from './details/dismiss-issue-focus';
 
 // eslint-disable-next-line camelcase
 const edacScriptVars = edac_script_vars;
@@ -77,10 +81,11 @@ const edacScriptVars = edac_script_vars;
 
 		// Listen for ignore updates from the Gutenberg sidebar modal
 		window.addEventListener( 'edac-ignore-updated', function( event ) {
+			const refreshContext = event.detail?.refreshContext || null;
 			// Small delay to ensure the database update is complete
 			window.setTimeout( function() {
 				refreshSummaryAndReadability();
-				edacDetailsAjax();
+				edacDetailsAjax( refreshContext );
 			}, 300 );
 		} );
 
@@ -159,8 +164,9 @@ const edacScriptVars = edac_script_vars;
 
 		/**
 		 * Ajax Details
+		 * @param {Object|null} dismissFocusContext Context for a metabox dismiss action.
 		 */
-		function edacDetailsAjax() {
+		function edacDetailsAjax( dismissFocusContext = null ) {
 			if ( ! edacScriptVars.showMetaboxInBlockEditor ) {
 				return;
 			}
@@ -232,6 +238,10 @@ const edacScriptVars = edac_script_vars;
 
 					// handle fix button click events.
 					initFixButtonEventHandlers();
+
+					if ( dismissFocusContext ) {
+						restoreDismissIssueFocus( dismissFocusContext );
+					}
 				} else {
 					// eslint-disable-next-line no-console
 					console.log( response );
@@ -336,6 +346,8 @@ const edacScriptVars = edac_script_vars;
 
 					// Map legacy actions to REST endpoint actions.
 					const restAction = ignoreAction === 'enable' ? 'dismiss' : 'undismiss';
+
+					const refreshContext = captureDismissIssueFocusContext( this );
 
 					jQuery.ajax( {
 						url: edacScriptVars.edacApiUrl + '/dismiss-issue/' + issueId,
@@ -475,6 +487,7 @@ const edacScriptVars = edac_script_vars;
 									postId: parseInt( jQuery( '#post_ID' ).val() ),
 									action: data.action,
 									ruleId: data.rule_id,
+									refreshContext,
 								},
 							} );
 							window.dispatchEvent( event );


### PR DESCRIPTION
## Summary

Fixes #1771 

When an issue was dismissed or reopened from the Accessibility Checker meta box, the details markup was rebuilt after the AJAX refresh. Because the focused element was removed from the DOM, keyboard users lost their focus position and context.

## Fix

This update captures the issue and rule-panel context before the action is submitted. After the details markup is refreshed it:

- Reopens the affected rule panel and issue controls.
- Restores the appropriate expanded state and ARIA attribute.
- Finds the replacement dismiss/reopen button and returns focus to it.

This keeps keyboard users in the same issue and panel after either action.

## Notes / follow-up considerations

- The button label changes slightly after the initial action.
- The current fix restores the panel associated with the most recent action. It does not preserve the complete expanded state of every open panel.
- If multiple panels are open and the user navigates elsewhere before opening another panel, restoring the acted-on panel can produce a layout shift. We may want to follow up by either preserving all expanded-panel state or collapsing unrelated panels during the refresh.

## Test plan

- Confirm linting and automated tests pass.
- Open an issue in the Accessibility Checker meta box using keyboard navigation.
- Place focus on the dismiss button and activate it.
- Confirm the affected rule and issue controls remain open after the refresh.
- Confirm focus returns to the corresponding reopen button.
- Repeat with multiple rule panels open and confirm the correct panel and button are restored.
- Verify the behavior with both keyboard navigation and mouse interaction.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard focus handling when issues are dismissed or reopened in the accessibility checker.
  * Preserved the relevant rule panel’s expanded state after updates.
  * Restored focus to the affected issue’s dismiss control after the panel refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->