### PR TITLE
Add dialog semantics to email opt-in Thickbox modal

### DIFF
--- a/src/emailOptIn/modal.js
+++ b/src/emailOptIn/modal.js
@@ -57,6 +57,13 @@ const bindFocusTrap = () => {
 
 	closeIcon.setAttribute( 'aria-hidden', 'true' );
 
+	// Core Thickbox does not expose #TB_window as a dialog, so add the
+	// semantics here once it exists. The accessible name comes from the
+	// Thickbox title element that core renders.
+	modal.setAttribute( 'role', 'dialog' );
+	modal.setAttribute( 'aria-modal', 'true' );
+	modal.setAttribute( 'aria-labelledby', 'TB_ajaxWindowTitle' );
+
 	const focusTrap = createFocusTrap( modal );
 	focusTrap.activate();
 

--- a/tests/jest/emailOptIn/modal.test.js
+++ b/tests/jest/emailOptIn/modal.test.js
@@ -3,6 +3,7 @@
  */
 
 import { initOptInModal } from '../../../src/emailOptIn/modal';
+import { createFocusTrap } from 'focus-trap';
 
 jest.mock(
 	'focus-trap',
@@ -42,5 +43,43 @@ describe( 'email opt-in modal init', () => {
 
 		expect( addEventListenerSpy ).toHaveBeenCalledWith( 'mousemove', expect.any( Function ), { once: true } );
 		expect( addEventListenerSpy ).toHaveBeenCalledWith( 'scroll', expect.any( Function ), { once: true } );
+	} );
+
+	test( 'adds dialog semantics to the Thickbox window once it opens', () => {
+		jest.useFakeTimers();
+
+		// Stand-ins for the globals core Thickbox and WP admin provide.
+		window.tb_show = jest.fn();
+		window.tb_remove = jest.fn();
+		window.jQuery = jest.fn( () => ( { one: jest.fn() } ) );
+		createFocusTrap.mockReturnValue( { activate: jest.fn(), deactivate: jest.fn() } );
+
+		// Minimal version of the markup tb_show() builds.
+		document.body.innerHTML = `
+			<div id="TB_window">
+				<div id="TB_title">
+					<div id="TB_ajaxWindowTitle">Accessibility Checker</div>
+					<button type="button" id="TB_closeWindowButton"><span class="tb-close-icon"></span></button>
+				</div>
+				<div id="TB_ajaxContent"></div>
+			</div>`;
+
+		const addEventListenerSpy = jest.spyOn( window, 'addEventListener' );
+		initOptInModal();
+		addEventListenerSpy.mock.calls.find( ( call ) => call[ 0 ] === 'load' )[ 1 ]();
+		addEventListenerSpy.mock.calls.find( ( call ) => call[ 0 ] === 'mousemove' )[ 1 ]();
+
+		expect( window.tb_show ).toHaveBeenCalled();
+
+		// bindFocusTrap() polls every 250ms for the Thickbox window.
+		jest.advanceTimersByTime( 250 );
+
+		const modal = document.getElementById( 'TB_window' );
+		expect( modal.getAttribute( 'role' ) ).toBe( 'dialog' );
+		expect( modal.getAttribute( 'aria-modal' ) ).toBe( 'true' );
+		expect( modal.getAttribute( 'aria-labelledby' ) ).toBe( 'TB_ajaxWindowTitle' );
+		expect( createFocusTrap ).toHaveBeenCalledWith( modal );
+
+		jest.useRealTimers();
 	} );
 } );


### PR DESCRIPTION
The email opt-in modal on the welcome page uses core Thickbox, which renders `#TB_window` without any dialog semantics, so screen reader users are not informed that a modal has opened (WCAG 4.1.2, Name/Role/Value).

Since core Thickbox markup can't be edited directly, this adds the attributes from the plugin side in `bindFocusTrap()`, which already runs once the Thickbox window exists and before the focus trap activates — so when focus moves into the modal it is announced as "Accessibility Checker, dialog":

- `role="dialog"` — `dialog` rather than `alertdialog`, as this is a non-urgent form
- `aria-modal="true"`
- `aria-labelledby="TB_ajaxWindowTitle"` — the visible Thickbox title, so the accessible name stays in sync if the title ever changes

Out of scope, left as-is deliberately: focus trapping/restoration is covered separately by #1778; the other issues on this modal (#1776–#1780) are untouched.

Added a Jest test covering the new attributes using a minimal Thickbox fixture; it verifies the plugin's attribute handling, not core's markup — also verified manually in WP admin.

Fixes #1775

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced the email opt-in modal with dialog semantics for assistive technologies.
  * Added focus trapping to keep keyboard navigation within the modal while it is open.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->