### PR TITLE
Keep flagging ambiguous link text when behavioral suffixes are appended

### DIFF
--- a/src/pageScanner/checks/has-ambiguous-text.js
+++ b/src/pageScanner/checks/has-ambiguous-text.js
@@ -23,12 +23,59 @@ const ambiguousPhrases = [
 	__( 'opens a new window', 'accessibility-checker' ),
 ];
 
+// Phrases that describe how a link opens rather than where it goes.
+// Appended to accessible names by the "Add Label To Links That Open A
+// New Tab/Window" fix and by similar theme/plugin features. They add no
+// information about the link's purpose, so they are ignored when
+// deciding whether a name is ambiguous.
+const behavioralPhrases = [
+	__( 'opens a new window', 'accessibility-checker' ),
+	__( 'opens in a new window', 'accessibility-checker' ),
+	__( 'opens a new tab', 'accessibility-checker' ),
+	__( 'opens in a new tab', 'accessibility-checker' ),
+	__( 'opens new window', 'accessibility-checker' ),
+	__( 'opens new tab', 'accessibility-checker' ),
+];
+
+// The exact string the plugin's own new-window fix appends is injected
+// into the page it runs on; read it from the same source the fix reads
+// so the rule always matches what was actually appended — including
+// translations and strings customized via edac_filter_frontend_fixes_data.
+const getInjectedPhrases = () => [
+	window.edac_frontend_fixes?.new_window_warning?.localizedString,
+	window.anww_localized?.localizedString,
+].filter( Boolean );
+
+const normalizeText = ( text ) =>
+	text.toLowerCase().replace( /[^a-z]+/g, ' ' ).trim();
+
+const stripBehavioralSuffixes = ( text ) => {
+	const suffixes = [ ...behavioralPhrases, ...getInjectedPhrases() ].map( normalizeText );
+	let stripped = text;
+	let changed = true;
+	while ( changed ) {
+		changed = false;
+		for ( const suffix of suffixes ) {
+			if ( stripped !== suffix && stripped.endsWith( ' ' + suffix ) ) {
+				stripped = stripped.slice( 0, -( suffix.length + 1 ) ).trim();
+				changed = true;
+			}
+		}
+	}
+	return stripped;
+};
+
 const checkAmbiguousPhrase = ( text ) => {
 	if ( ! text ) {
 		return false;
 	}
-	text = text.toLowerCase().replace( /[^a-z]+/g, ' ' ).trim();
-	return ambiguousPhrases.includes( text );
+	text = normalizeText( text );
+	if ( ambiguousPhrases.includes( text ) ) {
+		return true;
+	}
+	// A name like "read more, opens a new window" is still ambiguous: the
+	// appended text describes behavior, not the link's destination.
+	return ambiguousPhrases.includes( stripBehavioralSuffixes( text ) );
 };
 
 export default {

--- a/tests/jest/rules/linkAmbiguousText.test.js
+++ b/tests/jest/rules/linkAmbiguousText.test.js
@@ -119,6 +119,44 @@ describe( 'Link Ambiguous Text Rule', () => {
 			html: '<a href="/page">More...</a>',
 			shouldPass: false,
 		},
+
+		// Behavioral suffixes — text describing how a link opens does not
+		// make an ambiguous name descriptive (see #1891).
+		{
+			name: 'should fail for ambiguous aria-label with appended new-window text',
+			html: '<a href="/page" target="_blank" aria-label="Read more, opens a new window">Read more</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for ambiguous aria-label with appended new-tab text',
+			html: '<a href="/page" target="_blank" aria-label="learn more, opens in a new tab">learn more</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for ambiguous aria-label with stacked behavioral suffixes',
+			html: '<a href="/page" aria-label="read more, opens a new window, opens in a new tab">read more</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for ambiguous aria-labelledby with appended new-window text',
+			html: '<span id="nw-lbl">click here, opens a new window</span><a href="/page" aria-labelledby="nw-lbl">Visit page</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for image link with ambiguous alt plus new-window text',
+			html: '<a href="/page"><img src="icon.png" alt="here, opens a new window" /></a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should pass for descriptive aria-label with appended new-window text',
+			html: '<a href="/pricing" target="_blank" aria-label="Read more about pricing, opens a new window">Read more</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should fail for exact "opens a new window" as the whole label',
+			html: '<a href="/page" aria-label="opens a new window">Visit page</a>',
+			shouldPass: false,
+		},
 	];
 
 	testCases.forEach( ( testCase ) => {
@@ -135,6 +173,30 @@ describe( 'Link Ambiguous Text Rule', () => {
 				expect( results.violations.length ).toBeGreaterThan( 0 );
 				expect( results.violations[ 0 ].id ).toBe( 'link_ambiguous_text' );
 			}
+		} );
+	} );
+
+	describe( 'customized new-window fix string', () => {
+		afterEach( () => {
+			delete window.edac_frontend_fixes;
+		} );
+
+		test( 'should fail when the suffix matches the string injected for the new-window fix', async () => {
+			// The new-window fix appends the string it reads from this same
+			// global, so a site-customized string must also be recognized.
+			window.edac_frontend_fixes = {
+				new_window_warning: {
+					localizedString: 'link opens in a popup',
+				},
+			};
+			document.body.innerHTML = '<a href="/page" target="_blank" aria-label="Read more, link opens in a popup">Read more</a>';
+
+			const results = await axe.run( document.body, {
+				runOnly: [ 'link_ambiguous_text' ],
+			} );
+
+			expect( results.violations.length ).toBeGreaterThan( 0 );
+			expect( results.violations[ 0 ].id ).toBe( 'link_ambiguous_text' );
 		} );
 	} );
 } );


### PR DESCRIPTION
A link with ambiguous text ("read more") is correctly flagged by the
Ambiguous Anchor Text rule, but the flag wrongly cleared once anything was
appended to its accessible name, including pure behavioral boilerplate such
as the ", opens a new window" suffix added by the "Add Label To Links That
Open A New Tab/Window" fix. The link's purpose is no clearer, so the flag
should remain (WCAG 2.4.4).

**Approach.** The check normalized the accessible name and required an exact
match against the ambiguous-phrases list, so any appended text defeated it.
This PR keeps the existing name-source precedence (aria-label →
aria-labelledby → text content → image alt) untouched and adds a
normalization step: known behavioral suffixes, phrases describing how a
link opens rather than where it goes, are stripped from the end of the
name, and the result is re-checked against the same list.

- "read more" → flagged (unchanged)
- "Read more, opens a new window" → stripped to "read more" → **still flagged** (the reported bug)
- "Read more about pricing, opens a new window" → stripped to "read more about pricing" → not flagged (no new false positives)
- a name that is exactly "opens a new window" → flagged via the existing list entry (unchanged)

**Matching what the fix actually appends.** The new-window fix reads its
appended string from `window.edac_frontend_fixes.new_window_warning.localizedString`
(filterable via `edac_filter_frontend_fixes_data`, translated via the
`opens a new window` string). The check reads the same globals at evaluation
time, so the rule always recognizes the exact string the fix appended —
translations and site customizations included. A static list of common
variants ("opens in a new tab", etc., translatable via `__()`) covers
themes, other plugins, and hand-written labels, per the issue.

**Relationship to #1864.** This is the second, independent attempt #1891
calls for. It avoids removing the aria-label/aria-labelledby handling
(the concern raised there): all name sources and existing tests are kept,
and the rule continues to evaluate the name assistive technology actually
announces.

Added Jest coverage: the reported case via aria-label, the new-tab variant,
stacked suffixes, the aria-labelledby and image-alt paths, the descriptive-
name guardrail, and a test pinning the injected-string contract with a
customized `localizedString`.

Fixes #1891

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of ambiguous link text when names include new-window or new-tab warnings.
  * Added support for translated and customized warning messages.
  * Improved handling across accessible labels and image alternative text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->