### PR TITLE
Fix: textdomain loaded too early notice on plugins_loaded

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -493,13 +493,17 @@ function edac_ignore_capability(): SyncCapability {
 	return $capability;
 }
 // Assemble after all plugins have loaded so add-ons can contribute to the
-// bundle via the filter regardless of plugin load order.
-add_action( 'plugins_loaded', 'edac_ignore_capability', 20 );
+// bundle via the filter regardless of plugin load order. Hooked to init
+// (rather than plugins_loaded) because edac_capability_metadata() calls
+// translation functions, and add-ons register their edac_capabilities filter
+// callbacks via add_filter() at plugin load time, so they're already in
+// place well before init fires either way.
+add_action( 'init', 'edac_ignore_capability', 20 );
 
 // Register the Permissions page request handler (admin-post save) on every
 // request. The tab UI itself is wired later on admin_menu.
 add_action(
-	'plugins_loaded',
+	'init',
 	function () {
 		$settings_capability = apply_filters( 'edac_filter_settings_capability', 'manage_options' );
 		( new PermissionsPage( $settings_capability ) )->register_request_handlers();

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -441,7 +441,7 @@ function edac_sync_capability_roles(): void {
 }
 
 /**
- * The SyncCapability instance managing the bundle. Assembled on plugins_loaded
+ * The SyncCapability instance managing the bundle. Assembled on init
  * (see below) so every active add-on has contributed to edac_capability_bundle
  * first; also usable directly (e.g. in tests) as a lazy singleton.
  *
@@ -452,7 +452,7 @@ function edac_ignore_capability(): SyncCapability {
 
 	if ( null === $capability ) {
 		// Precompute each capability's floor once (all active add-ons have
-		// contributed metadata by the time this runs on plugins_loaded), so the
+		// contributed metadata by the time this runs on init), so the
 		// floor policy passed to the engine is a cheap array lookup rather than a
 		// metadata rebuild per role/capability during sync.
 		$floors = [];


### PR DESCRIPTION
## Summary
- A customer reported the "Translation loading for the accessibility-checker domain was triggered too early" notice from the Accessibility Checker (via a WordPress 6.7+ core check).
- `edac_ignore_capability()` was hooked to `plugins_loaded` and calls `edac_capability_metadata()`, which builds an array containing `__()` translation calls — this runs before `init`, before translations are loaded, triggering the core notice.
- Moved that hook, and the sibling `PermissionsPage::register_request_handlers()` registration (same file, same pattern), from `plugins_loaded` to `init`.
- Confirmed add-on plugins (Pro, Export, Audit History) register their `edac_capabilities` filter callbacks via `add_filter()` at plugin load time, so moving assembly to `init` doesn't change contribution order.

## Test plan
- [ ] `php -l includes/options-page.php`
- [ ] Confirm the "textdomain loaded too early" notice no longer appears with `WP_DEBUG`/`WP_DEBUG_LOG` enabled on a fresh page load
- [ ] Verify the Permissions settings tab still loads and saves correctly
- [ ] Verify add-on capabilities (Pro / Export / Audit History) still appear in the Permissions UI when those plugins are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz3KmgPopKSZYaPKTZFVRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization timing for capabilities and permission handling.
  * Preserved the correct order of capability setup before permission processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->