### PR TITLE
docs: add WordPress.org plugin badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 [![Security](https://github.com/equalizedigital/accessibility-checker/actions/workflows/security.yml/badge.svg)](https://github.com/equalizedigital/accessibility-checker/actions/workflows/security.yml)
 [![Test](https://github.com/equalizedigital/accessibility-checker/actions/workflows/phpunit.yml/badge.svg)](https://github.com/equalizedigital/accessibility-checker/actions/workflows/phpunit.yml)
 [![Coverage Status](https://coveralls.io/repos/github/equalizedigital/accessibility-checker/badge.svg?branch=develop)](https://coveralls.io/github/equalizedigital/accessibility-checker?branch=develop)
+[![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/accessibility-checker.svg)](https://wordpress.org/plugins/accessibility-checker/)
+![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/accessibility-checker.svg)
+[![WordPress Plugin Active Installs](https://img.shields.io/wordpress/plugin/installs/accessibility-checker.svg)](https://wordpress.org/plugins/accessibility-checker/advanced/)
+[![WordPress Plugin Downloads](https://img.shields.io/wordpress/plugin/dt/accessibility-checker.svg)](https://wordpress.org/plugins/accessibility-checker/advanced/)
+[![WordPress Plugin Rating](https://img.shields.io/wordpress/plugin/stars/accessibility-checker.svg)](https://wordpress.org/support/plugin/accessibility-checker/reviews/)
+[![GitHub](https://img.shields.io/github/license/equalizedigital/accessibility-checker.svg)](https://github.com/equalizedigital/accessibility-checker/blob/develop/LICENSE.txt)
 
 # Equalize Digital Accessibility Checker
 


### PR DESCRIPTION
## Summary
- Adds WordPress.org plugin badges (version, tested up to, active installs, downloads, rating) and a GitHub license badge to the top of the README, matching the badge style used by other WP plugin READMEs.
- Badges point at the `accessibility-checker` WordPress.org slug and this GitHub repo/license file.
- Same change as #1906, targeted at `develop`.

## Test plan
- [x] Visually confirmed badge markdown renders correctly in preview
- [ ] Confirm badges resolve correctly once merged (shields.io + wordpress.org endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WordPress plugin metadata badges to the README, including version, compatibility, active installations, downloads, rating, and license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->