### PR TITLE
docs: separate WordPress.org badges onto their own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Security](https://github.com/equalizedigital/accessibility-checker/actions/workflows/security.yml/badge.svg)](https://github.com/equalizedigital/accessibility-checker/actions/workflows/security.yml)
 [![Test](https://github.com/equalizedigital/accessibility-checker/actions/workflows/phpunit.yml/badge.svg)](https://github.com/equalizedigital/accessibility-checker/actions/workflows/phpunit.yml)
 [![Coverage Status](https://coveralls.io/repos/github/equalizedigital/accessibility-checker/badge.svg?branch=develop)](https://coveralls.io/github/equalizedigital/accessibility-checker?branch=develop)
+
 [![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/accessibility-checker.svg)](https://wordpress.org/plugins/accessibility-checker/)
 ![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/accessibility-checker.svg)
 [![WordPress Plugin Active Installs](https://img.shields.io/wordpress/plugin/installs/accessibility-checker.svg)](https://wordpress.org/plugins/accessibility-checker/advanced/)


### PR DESCRIPTION
## Summary
- PR #1909 merged the WordPress.org plugin badges into `develop` but landed before the follow-up formatting fix, so they're currently on the same line as the CI/coverage badges.
- Adds a blank line so the WordPress.org badges render as their own paragraph, separate from the CI/coverage badges.

## Test plan
- [x] Visually confirmed badge markdown renders on a separate line in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README formatting by adding spacing between the coverage badge and WordPress plugin badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->