### PR TITLE
Fix: contrast error count ignores rule filtering

### DIFF
--- a/includes/classes/class-summary-generator.php
+++ b/includes/classes/class-summary-generator.php
@@ -75,7 +75,7 @@ class Summary_Generator {
 		$summary['errors']             = $this->count_errors();
 		$summary['warnings']           = $this->count_warnings();
 		$summary['ignored']            = $this->count_ignored();
-		$summary['contrast_errors']    = $this->count_contrast_errors();
+		$summary['contrast_errors']    = $this->count_contrast_errors( $rules );
 		$summary['errors']            -= $summary['contrast_errors'];
 		$summary['content_grade']      = $this->calculate_content_grade();
 		$summary['readability']        = $this->get_readability( $summary );
@@ -216,11 +216,20 @@ class Summary_Generator {
 	 * Counts the number of contrast errors for the current post.
 	 * This method queries the database to count the number of accessibility issues specifically related to color contrast failures.
 	 *
+	 * Returns 0 without querying if the color contrast rule is not among the currently active
+	 * rules (e.g. it has been filtered out via `edac_filter_register_rules`), since any existing
+	 * violations for a filtered rule should not affect the error count.
+	 *
+	 * @param array $rules The currently active rules, as returned by edac_register_rules().
 	 * @return int The count of contrast errors.
 	 *
 	 * @since 1.9.0
 	 */
-	private function count_contrast_errors() {
+	private function count_contrast_errors( $rules = [] ) {
+		if ( ! in_array( 'color_contrast_failure', wp_list_pluck( $rules, 'slug' ), true ) ) {
+			return 0;
+		}
+
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Using direct query for interacting with custom database, safe variable used for table name, caching not required for one time operation.

--- a/tests/phpunit/includes/classes/SummaryGeneratorTest.php
+++ b/tests/phpunit/includes/classes/SummaryGeneratorTest.php
@@ -55,4 +55,76 @@ class SummaryGeneratorTest extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $method->invoke( $summary_generator ) );
 	}
+
+	/**
+	 * Ensures count_contrast_errors() does not query the database, and returns 0,
+	 * when the color contrast rule is not among the currently active rules (e.g. it
+	 * has been filtered out), even if contrast violations still exist in the database.
+	 *
+	 * @throws ReflectionException If the method does not exist this is thrown.
+	 */
+	public function test_count_contrast_errors_returns_zero_when_rule_is_filtered_out() {
+		global $wpdb;
+
+		$post_id = self::factory()->post->create();
+
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery -- this is just one-time use data for testing.
+			$wpdb->prefix . 'accessibility_checker',
+			[
+				'siteid'   => get_current_blog_id(),
+				'postid'   => $post_id,
+				'rule'     => 'color_contrast_failure',
+				'ruletype' => 'error',
+				'ignre'    => 0,
+			]
+		);
+
+		$summary_generator = new Summary_Generator( $post_id );
+
+		$method = ( new ReflectionClass( get_class( $summary_generator ) ) )
+			->getMethod( 'count_contrast_errors' );
+		$method->setAccessible( true );
+
+		// Color contrast rule is not present in the active rules list, simulating it being filtered out.
+		$active_rules = [
+			[ 'slug' => 'some_other_rule' ],
+		];
+
+		$this->assertSame( 0, $method->invoke( $summary_generator, $active_rules ) );
+	}
+
+	/**
+	 * Ensures count_contrast_errors() still counts violations when the color contrast
+	 * rule is present among the currently active rules.
+	 *
+	 * @throws ReflectionException If the method does not exist this is thrown.
+	 */
+	public function test_count_contrast_errors_counts_when_rule_is_active() {
+		global $wpdb;
+
+		$post_id = self::factory()->post->create();
+
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery -- this is just one-time use data for testing.
+			$wpdb->prefix . 'accessibility_checker',
+			[
+				'siteid'   => get_current_blog_id(),
+				'postid'   => $post_id,
+				'rule'     => 'color_contrast_failure',
+				'ruletype' => 'error',
+				'ignre'    => 0,
+			]
+		);
+
+		$summary_generator = new Summary_Generator( $post_id );
+
+		$method = ( new ReflectionClass( get_class( $summary_generator ) ) )
+			->getMethod( 'count_contrast_errors' );
+		$method->setAccessible( true );
+
+		$active_rules = [
+			[ 'slug' => 'color_contrast_failure' ],
+		];
+
+		$this->assertSame( 1, $method->invoke( $summary_generator, $active_rules ) );
+	}
 }


### PR DESCRIPTION
## Summary

- `Summary_Generator::count_contrast_errors()` always queried the DB for `color_contrast_failure` violations and unconditionally subtracted the count from `errors` in `generate_summary()`, even when the color contrast rule has been filtered out via `edac_filter_register_rules`.
- Now takes the currently active `$rules` list and returns `0` (skipping the query and the subtraction) when `color_contrast_failure` isn't among them, so the error count stays correct while the rule is filtered and stale violations still exist in the DB.

## Why

Discovered during the rule-filtering investigation in equalizedigital/accessibility-checker#504. Unlike the general count-inflation behavior noted there (which self-resolves after a rescan), this was a logic bug in the query itself — filed and tracked separately as equalizedigital/accessibility-checker#1911.

## Test plan

- [x] Added two PHPUnit tests covering both branches (rule filtered → returns 0 without touching the DB result; rule active → counts violations as before)
- [x] Full suite run via `npm run test:php` / `test:php:run` — 968 tests pass
- [x] `./vendor/bin/phpcs` clean on changed files

Fixes equalizedigital/accessibility-checker#1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contrast violation totals are now calculated only when the color-contrast rule is enabled.
  * Reports correctly show zero contrast errors when that rule is excluded.

* **Tests**
  * Added coverage for enabled and disabled color-contrast rule scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->