### PR TITLE
fix: rescan the front-end highlighter after an Elementor save

### DIFF
--- a/src/frontendHighlighterApp/index.js
+++ b/src/frontendHighlighterApp/index.js
@@ -8,6 +8,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { saveFixSettings } from '../common/saveFixSettingsRest';
 import { fillFixesModal, fixSettingsModalInit, openFixesModal } from './fixesModal';
 import { getLandmarkType as getLandmarkTypeUtil } from './getLandmarkType';
+import { setupElementorSaveListener } from './setupElementorSaveListener';
 
 class AccessibilityCheckerHighlight {
 	/**
@@ -2054,10 +2055,11 @@ class AccessibilityCheckerHighlight {
 let highlighterInitialized = false;
 const initHighlighter = () => {
 	if ( ! highlighterInitialized ) {
-		new AccessibilityCheckerHighlight();
+		const highlighter = new AccessibilityCheckerHighlight();
 		if ( window.edacFrontendHighlighterApp?.userCanFix ) {
 			fixSettingsModalInit();
 		}
+		setupElementorSaveListener( highlighter );
 		highlighterInitialized = true;
 	}
 };

--- a/src/frontendHighlighterApp/setupElementorSaveListener.js
+++ b/src/frontendHighlighterApp/setupElementorSaveListener.js
@@ -1,0 +1,53 @@
+/**
+ * Elementor saves a post through its own Backbone app and never touches `wp.data`
+ * (which is what the Gutenberg save-detection relies on), so the front-end highlighter
+ * has no way to learn a save happened and keeps showing stale results until the page
+ * is manually reloaded.
+ *
+ * This script runs inside Elementor's live-preview iframe, while the `elementor`
+ * global and its `saver` save events live in the parent (editor) window. Reach into
+ * the parent to listen for a completed save and trigger a rescan.
+ *
+ * @param {Object}   highlighter              The AccessibilityCheckerHighlight instance to rescan with.
+ * @param {Function} highlighter.rescanPage   Triggers a rescan of the current page.
+ * @param {Object}   [options]                Optional overrides, primarily for tests.
+ * @param {number}   [options.pollIntervalMs] Milliseconds between readiness checks. Default 500.
+ * @param {number}   [options.maxAttempts]    Maximum number of readiness checks before giving up. Default 20.
+ */
+export function setupElementorSaveListener( highlighter, options = {} ) {
+	const { pollIntervalMs = 500, maxAttempts = 20 } = options;
+
+	// Not inside an iframe, so this can't be an Elementor preview.
+	if ( window === window.parent ) {
+		return;
+	}
+
+	const attach = ( parentElementor ) => {
+		parentElementor.saver.on( 'after:save', () => {
+			highlighter.rescanPage();
+		} );
+	};
+
+	// Elementor's editor may still be initializing when the preview iframe first
+	// loads, so poll briefly for it to become available. A cross-origin parent
+	// throws immediately on access, in which case there's nothing we can do.
+	let attempts = 0;
+	const interval = setInterval( () => {
+		attempts++;
+
+		let candidate;
+		try {
+			candidate = window.parent.elementor;
+		} catch ( e ) {
+			clearInterval( interval );
+			return;
+		}
+
+		if ( candidate?.saver?.on ) {
+			clearInterval( interval );
+			attach( candidate );
+		} else if ( attempts >= maxAttempts ) {
+			clearInterval( interval );
+		}
+	}, pollIntervalMs );
+}

--- a/src/frontendHighlighterApp/setupElementorSaveListener.js
+++ b/src/frontendHighlighterApp/setupElementorSaveListener.js
@@ -23,9 +23,29 @@ export function setupElementorSaveListener( highlighter, options = {} ) {
 	}
 
 	const attach = ( parentElementor ) => {
-		parentElementor.saver.on( 'after:save', () => {
+		const onAfterSave = ( saveOptions ) => {
+			// Elementor autosaves periodically in the background; it isn't a
+			// deliberate save and its content isn't published. Rescanning (and
+			// persisting) on it would overwrite the post's saved issues with
+			// in-progress draft state — the same problem the Gutenberg
+			// save-detection in src/editorApp/checkPage.js already guards
+			// against by ignoring wp.data's isAutosavingPost().
+			if ( saveOptions?.status === 'autosave' ) {
+				return;
+			}
 			highlighter.rescanPage();
-		} );
+		};
+
+		parentElementor.saver.on( 'after:save', onAfterSave );
+
+		// The preview iframe can be reloaded independently of the parent editor
+		// (e.g. switching preview devices). Backbone's `.on()` stores the callback
+		// on the parent's long-lived saver object, so without this the closure
+		// above — and the highlighter/DOM it references — would be kept alive
+		// and would still fire rescans after this iframe is gone.
+		window.addEventListener( 'pagehide', () => {
+			parentElementor.saver.off( 'after:save', onAfterSave );
+		}, { once: true } );
 	};
 
 	// Elementor's editor may still be initializing when the preview iframe first

--- a/tests/jest/frontendHighlighterApp/setupElementorSaveListener.test.js
+++ b/tests/jest/frontendHighlighterApp/setupElementorSaveListener.test.js
@@ -48,7 +48,8 @@ describe( 'setupElementorSaveListener', () => {
 
 	test( 'attaches to elementor.saver and rescans on after:save when elementor is ready immediately', () => {
 		const on = jest.fn();
-		mockWindowParent( { elementor: { saver: { on } } } );
+		const off = jest.fn();
+		mockWindowParent( { elementor: { saver: { on, off } } } );
 		const highlighter = { rescanPage: jest.fn() };
 
 		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );
@@ -66,10 +67,46 @@ describe( 'setupElementorSaveListener', () => {
 		expect( jest.getTimerCount() ).toBe( 0 );
 	} );
 
+	test( 'does not rescan when the save was an autosave', () => {
+		const on = jest.fn();
+		const off = jest.fn();
+		mockWindowParent( { elementor: { saver: { on, off } } } );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );
+		jest.advanceTimersByTime( 500 );
+
+		const afterSaveHandler = on.mock.calls[ 0 ][ 1 ];
+		afterSaveHandler( { status: 'autosave' } );
+
+		expect( highlighter.rescanPage ).not.toHaveBeenCalled();
+
+		// A real save afterwards should still rescan.
+		afterSaveHandler( { status: 'publish' } );
+		expect( highlighter.rescanPage ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'detaches the after:save listener on pagehide so a stale highlighter is never rescanned', () => {
+		const on = jest.fn();
+		const off = jest.fn();
+		mockWindowParent( { elementor: { saver: { on, off } } } );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );
+		jest.advanceTimersByTime( 500 );
+
+		const afterSaveHandler = on.mock.calls[ 0 ][ 1 ];
+
+		window.dispatchEvent( new Event( 'pagehide' ) );
+
+		expect( off ).toHaveBeenCalledWith( 'after:save', afterSaveHandler );
+	} );
+
 	test( 'keeps polling until elementor becomes available, then attaches', () => {
 		const on = jest.fn();
+		const off = jest.fn();
 		let ready = false;
-		mockWindowParent( () => ( ready ? { elementor: { saver: { on } } } : {} ) );
+		mockWindowParent( () => ( ready ? { elementor: { saver: { on, off } } } : {} ) );
 		const highlighter = { rescanPage: jest.fn() };
 
 		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );

--- a/tests/jest/frontendHighlighterApp/setupElementorSaveListener.test.js
+++ b/tests/jest/frontendHighlighterApp/setupElementorSaveListener.test.js
@@ -1,0 +1,119 @@
+/**
+ * Tests for setupElementorSaveListener.
+ *
+ * Regression coverage for https://github.com/equalizedigital/accessibility-checker/issues/1359 -
+ * the front-end highlighter not refreshing after a save made inside the Elementor editor,
+ * because Elementor saves bypass `wp.data` entirely.
+ */
+
+import { setupElementorSaveListener } from '../../../src/frontendHighlighterApp/setupElementorSaveListener';
+
+/**
+ * Replace `window.parent` with a stand-in for the duration of a test.
+ *
+ * @param {Object|Function} parent An object to use as window.parent, or a function
+ *                                 returning one lazily (useful for throwing getters).
+ */
+function mockWindowParent( parent ) {
+	Object.defineProperty( window, 'parent', {
+		configurable: true,
+		get: typeof parent === 'function' ? parent : () => parent,
+	} );
+}
+
+describe( 'setupElementorSaveListener', () => {
+	const originalParent = window.parent;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		Object.defineProperty( window, 'parent', {
+			configurable: true,
+			value: originalParent,
+		} );
+	} );
+
+	test( 'does nothing when not inside an iframe', () => {
+		mockWindowParent( window );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter );
+		jest.advanceTimersByTime( 10000 );
+
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+
+	test( 'attaches to elementor.saver and rescans on after:save when elementor is ready immediately', () => {
+		const on = jest.fn();
+		mockWindowParent( { elementor: { saver: { on } } } );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );
+		jest.advanceTimersByTime( 500 );
+
+		expect( on ).toHaveBeenCalledWith( 'after:save', expect.any( Function ) );
+
+		// Simulate Elementor firing the save event.
+		const afterSaveHandler = on.mock.calls[ 0 ][ 1 ];
+		afterSaveHandler();
+
+		expect( highlighter.rescanPage ).toHaveBeenCalledTimes( 1 );
+
+		// Polling should have stopped once attached.
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+
+	test( 'keeps polling until elementor becomes available, then attaches', () => {
+		const on = jest.fn();
+		let ready = false;
+		mockWindowParent( () => ( ready ? { elementor: { saver: { on } } } : {} ) );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );
+
+		jest.advanceTimersByTime( 1500 );
+		expect( on ).not.toHaveBeenCalled();
+
+		ready = true;
+		jest.advanceTimersByTime( 500 );
+
+		expect( on ).toHaveBeenCalledWith( 'after:save', expect.any( Function ) );
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+
+	test( 'stops polling after maxAttempts if elementor never becomes available', () => {
+		mockWindowParent( {} );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 3 } );
+		jest.advanceTimersByTime( 500 * 3 );
+
+		expect( jest.getTimerCount() ).toBe( 0 );
+
+		// Nothing further happens even if more time passes.
+		jest.advanceTimersByTime( 500 * 10 );
+		expect( highlighter.rescanPage ).not.toHaveBeenCalled();
+	} );
+
+	test( 'stops polling without attaching when the parent is cross-origin', () => {
+		// A cross-origin parent window reference is itself readable; only reading
+		// properties off of it (like `.elementor`) throws a SecurityError.
+		const crossOriginParent = {};
+		Object.defineProperty( crossOriginParent, 'elementor', {
+			get() {
+				throw new Error( 'cross-origin access denied' );
+			},
+		} );
+		mockWindowParent( crossOriginParent );
+		const highlighter = { rescanPage: jest.fn() };
+
+		setupElementorSaveListener( highlighter, { pollIntervalMs: 500, maxAttempts: 20 } );
+		jest.advanceTimersByTime( 500 );
+
+		expect( jest.getTimerCount() ).toBe( 0 );
+		expect( highlighter.rescanPage ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes #1359

The front-end highlighter detects saves via `wp.data` (Gutenberg's data store), but Elementor saves a post through its own Backbone app and never touches `wp.data`. As a result the highlighter kept showing stale issues after an Elementor save until the page was manually reloaded.

## Changes

- Added `setupElementorSaveListener()` (`src/frontendHighlighterApp/setupElementorSaveListener.js`), called once the highlighter initializes.
  - The highlighter runs inside Elementor's live-preview iframe, while the `elementor` global (with its `saver` save events) lives in the parent editor window.
  - Detects the iframe context, polls briefly (up to ~10s) for `window.parent.elementor.saver` to become available since Elementor's editor may still be initializing when the preview iframe first loads, then attaches an `after:save` listener that calls `highlighter.rescanPage()`.
  - Ignores autosaves (`status === 'autosave'`) so in-progress draft edits don't get persisted against the published post, mirroring the Gutenberg autosave guard in `src/editorApp/checkPage.js`.
  - Detaches the listener on `pagehide` so a stale highlighter from a previous preview-iframe load can't be rescanned after the iframe reloads.
  - A cross-origin parent is handled gracefully (stops polling, no-op).
- `src/frontendHighlighterApp/index.js` now retains the `AccessibilityCheckerHighlight` instance so it can be passed to the new listener.

## Checklist

- [x] PR is linked to the main issue in the repo
- [x] Tests are added that cover changes

Added `tests/jest/frontendHighlighterApp/setupElementorSaveListener.test.js` covering: no-op outside an iframe, immediate attachment, autosave skipping, listener detachment on pagehide, delayed availability via polling, giving up after max attempts, and cross-origin failure.

## Test plan

- `npm run lint:js` — passes
- `npm run test:jest` — full suite passes (57 suites / 1008 tests)
- `npm run build` — compiles cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Highlighter results automatically refresh after completed Elementor saves in preview mode.
  * Supports delayed Elementor availability and ignores autosave events.
  * Automatically stops monitoring when the preview is no longer visible.

* **Bug Fixes**
  * Safely handles unsupported contexts, polling limits, and cross-origin access failures.

* **Tests**
  * Added coverage for save detection, autosave filtering, rescanning, delayed initialization, cleanup, timeouts, and iframe access failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->